### PR TITLE
Fix CI: disable LFS checkout for PDF build

### DIFF
--- a/.github/workflows/release-pdf.yml
+++ b/.github/workflows/release-pdf.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          lfs: true
+          lfs: false  # LFS files (books/) not needed for PDF compilation
 
       - name: Install Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
LFS objects (books/) not needed for PDF compilation. Fixes checkout failure.