### PR TITLE
Fix requirements.txt: add missing Python dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,7 @@ python-dotenv>=1.0.0
 pyyaml>=6.0
 lxml>=5.0.0
 tqdm>=4.66.0
+PyMuPDF>=1.24.0
+matplotlib>=3.8.0
+numpy>=1.26.0
+scipy>=1.12.0


### PR DESCRIPTION
## Summary

Add 4 missing third-party packages to `requirements.txt`:

- `PyMuPDF>=1.24.0` — imported as `fitz` in `fetch_articles.py`, `recover_fulltext.py`, `search_books.py`
- `matplotlib>=3.8.0` — used by `generate_figures.py`
- `numpy>=1.26.0` — used by `generate_figures.py`
- `scipy>=1.12.0` — used by `generate_figures.py`

Without these, `pip install -r requirements.txt` produces an environment that fails on import for both the corpus pipeline and figure generation.

## Verification

`pip install --dry-run -r requirements.txt` resolves all dependencies.

Closes #32