### PR TITLE
Prepare ferroptosis-core for independent use

### DIFF
--- a/simulations/ferroptosis-core/Cargo.toml
+++ b/simulations/ferroptosis-core/Cargo.toml
@@ -2,7 +2,12 @@
 name = "ferroptosis-core"
 version = "0.2.0"
 edition = "2021"
-description = "Shared ferroptosis biochemistry engine for the simulation suite"
+description = "Embeddable ferroptosis biochemistry engine for cancer simulation"
+license = "MIT"
+repository = "https://github.com/ELares/cancer_research"
+keywords = ["ferroptosis", "cancer", "simulation", "biochemistry", "pharmacology"]
+categories = ["science", "simulation"]
+readme = "README.md"
 
 [dependencies]
 rand = { workspace = true }

--- a/simulations/ferroptosis-core/LICENSE
+++ b/simulations/ferroptosis-core/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ezequiel Lares
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/simulations/ferroptosis-core/README.md
+++ b/simulations/ferroptosis-core/README.md
@@ -2,7 +2,7 @@
 
 Embeddable ferroptosis biochemistry engine for cancer simulation.
 
-This library provides a mechanistic model of the ferroptosis cell death pathway — from ROS generation through GSH depletion, GPX4 inactivation, lipid peroxidation, and cell death — with parameters informed by published experimental data. It is designed to be embedded in multi-scale cancer simulators (PhysiCell, CompuCell3D, custom frameworks) or used standalone for parameter exploration.
+This library provides a mechanistic model of the ferroptosis cell death pathway — from ROS generation through GSH depletion, GPX4 inactivation, lipid peroxidation, and cell death. Some parameters are grounded in published measurements; others are estimated from literature ranges or assumed as mechanistic placeholders (see parameter provenance below). It is designed to be embedded in multi-scale cancer simulators (PhysiCell, CompuCell3D, custom frameworks) or used standalone for parameter exploration.
 
 ## Quick start
 
@@ -59,7 +59,7 @@ gen_cell(phenotype, rng) -> Cell
 
 ## Parameters
 
-All ~30 simulation parameters are documented with literature sources and sensitivity ratings in [`calibration/parameter_provenance.md`](../calibration/parameter_provenance.md).
+All ~30 simulation parameters are documented with literature sources and sensitivity ratings in [`parameter_provenance.md`](https://github.com/ELares/cancer_research/blob/main/simulations/calibration/parameter_provenance.md) (in the parent repository's `simulations/calibration/` directory).
 
 ## License
 

--- a/simulations/ferroptosis-core/README.md
+++ b/simulations/ferroptosis-core/README.md
@@ -2,7 +2,7 @@
 
 Embeddable ferroptosis biochemistry engine for cancer simulation.
 
-This library provides a mechanistic model of the ferroptosis cell death pathway — from ROS generation through GSH depletion, GPX4 inactivation, lipid peroxidation, and cell death — calibrated against published experimental data. It is designed to be embedded in multi-scale cancer simulators (PhysiCell, CompuCell3D, custom frameworks) or used standalone for parameter exploration.
+This library provides a mechanistic model of the ferroptosis cell death pathway — from ROS generation through GSH depletion, GPX4 inactivation, lipid peroxidation, and cell death — with parameters informed by published experimental data. It is designed to be embedded in multi-scale cancer simulators (PhysiCell, CompuCell3D, custom frameworks) or used standalone for parameter exploration.
 
 ## Quick start
 

--- a/simulations/ferroptosis-core/README.md
+++ b/simulations/ferroptosis-core/README.md
@@ -1,0 +1,66 @@
+# ferroptosis-core
+
+Embeddable ferroptosis biochemistry engine for cancer simulation.
+
+This library provides a mechanistic model of the ferroptosis cell death pathway — from ROS generation through GSH depletion, GPX4 inactivation, lipid peroxidation, and cell death — calibrated against published experimental data. It is designed to be embedded in multi-scale cancer simulators (PhysiCell, CompuCell3D, custom frameworks) or used standalone for parameter exploration.
+
+## Quick start
+
+```rust
+use rand::prelude::*;
+use ferroptosis_core::biochem::sim_cell;
+use ferroptosis_core::cell::{gen_cell, Phenotype, Treatment};
+use ferroptosis_core::params::Params;
+
+let params = Params::default();
+let mut rng = StdRng::seed_from_u64(42);
+let cell = gen_cell(Phenotype::Persister, &mut rng);
+let mut sim_rng = StdRng::seed_from_u64(43);
+
+let (dead, lp, gsh, gpx4) = sim_cell(&cell, Treatment::SDT, &params, &mut sim_rng);
+println!("Dead: {dead}, LP: {lp:.2}, GSH: {gsh:.2}, GPX4: {gpx4:.2}");
+```
+
+Run the included example: `cargo run -p ferroptosis-core --example basic_usage`
+
+## Modules
+
+| Module | Purpose |
+|--------|---------|
+| `cell` | Cell types, phenotypes (Glycolytic, OXPHOS, Persister, PersisterNrf2, Stromal), treatments, stochastic cell generation |
+| `params` | All rate constants: `Params` (biochemistry), `SpatialParams` (physics), `ImmuneParams` (immune cascade), `RecoveryRates` |
+| `biochem` | Core simulation engine: `sim_cell` (full 180-step loop), `sim_cell_step` (single timestep for spatial interleaving) |
+| `stats` | Wilson confidence intervals, parallel Monte Carlo execution via rayon |
+| `physics` | Depth-dependent energy deposition: Beer-Lambert (PDT), acoustic attenuation (SDT), uniform (RSL3) |
+| `grid` | 2D tumor grid with heterogeneous architecture, neighbor iteration, iron diffusion |
+| `immune` | ICD/DAMP immune cascade: ferroptotic death quality drives dendritic cell activation and T cell priming |
+| `io` | JSON and CSV output helpers |
+
+## Key API
+
+**Single-cell simulation (full loop):**
+```rust
+sim_cell(cell, treatment, params, rng) -> (dead, lp, gsh, gpx4)
+```
+
+**Single timestep (for embedding in spatial/multi-scale models):**
+```rust
+sim_cell_step(state, cell, params, step, extra_iron, rng) -> dead
+```
+
+**Cell generation:**
+```rust
+gen_cell(phenotype, rng) -> Cell
+```
+
+**Parameter contexts:**
+- `Params::default()` — 2D culture baseline
+- `Params::invivo()` — 3D/in-vivo with SCD1-driven MUFA lipid remodeling (M_ss = 0.40)
+
+## Parameters
+
+All ~30 simulation parameters are documented with literature sources and sensitivity ratings in [`calibration/parameter_provenance.md`](../calibration/parameter_provenance.md).
+
+## License
+
+MIT

--- a/simulations/ferroptosis-core/examples/basic_usage.rs
+++ b/simulations/ferroptosis-core/examples/basic_usage.rs
@@ -44,16 +44,22 @@ fn main() {
         }
     }
 
-    // Demonstrate in-vivo parameters (MUFA protection)
+    // Demonstrate in-vivo parameters (MUFA protection) with a small population
     println!("\n--- In-vivo context (SCD1-driven MUFA protection) ---\n");
     let invivo_params = Params::invivo();
     println!("MUFA steady-state protection: {:.2}", invivo_params.initial_mufa_protection);
-    let mut rng = StdRng::seed_from_u64(seed);
-    let cell = gen_cell(Phenotype::Persister, &mut rng);
-    let mut sim_rng = StdRng::seed_from_u64(seed + 1);
-    let (dead_2d, _, _, _) = sim_cell(&cell, Treatment::RSL3, &params, &mut sim_rng);
-    let mut sim_rng = StdRng::seed_from_u64(seed + 1);
-    let (dead_vivo, _, _, _) = sim_cell(&cell, Treatment::RSL3, &invivo_params, &mut sim_rng);
-    println!("Persister + RSL3 (2D):     dead = {}", dead_2d);
-    println!("Persister + RSL3 (in-vivo): dead = {}", dead_vivo);
+    let n = 500;
+    let mut deaths_2d = 0;
+    let mut deaths_vivo = 0;
+    for i in 0..n {
+        let mut rng = StdRng::seed_from_u64(i * 2);
+        let cell = gen_cell(Phenotype::Persister, &mut rng);
+        let mut sr = StdRng::seed_from_u64(i * 2 + 1);
+        if sim_cell(&cell, Treatment::RSL3, &params, &mut sr).0 { deaths_2d += 1; }
+        let mut sr = StdRng::seed_from_u64(i * 2 + 1);
+        if sim_cell(&cell, Treatment::RSL3, &invivo_params, &mut sr).0 { deaths_vivo += 1; }
+    }
+    println!("Persister + RSL3 (2D):     {deaths_2d}/{n} dead ({:.0}%)", deaths_2d as f64 / n as f64 * 100.0);
+    println!("Persister + RSL3 (in-vivo): {deaths_vivo}/{n} dead ({:.0}%)", deaths_vivo as f64 / n as f64 * 100.0);
+    println!("MUFA protection factor: {:.1}x", deaths_2d as f64 / deaths_vivo.max(1) as f64);
 }

--- a/simulations/ferroptosis-core/examples/basic_usage.rs
+++ b/simulations/ferroptosis-core/examples/basic_usage.rs
@@ -1,0 +1,59 @@
+//! Basic usage of the ferroptosis-core library.
+//!
+//! Generates a persister cell and simulates ferroptosis under different
+//! treatments, printing the outcome for each.
+//!
+//! Run with: `cargo run -p ferroptosis-core --example basic_usage`
+
+use rand::prelude::*;
+
+use ferroptosis_core::biochem::sim_cell;
+use ferroptosis_core::cell::{gen_cell, Phenotype, Treatment};
+use ferroptosis_core::params::Params;
+
+fn main() {
+    let params = Params::default();
+    let seed: u64 = 42;
+
+    let phenotypes = [
+        (Phenotype::Glycolytic, "Glycolytic"),
+        (Phenotype::Persister, "Persister (FSP1-low)"),
+        (Phenotype::PersisterNrf2, "Persister + NRF2"),
+    ];
+    let treatments = [
+        (Treatment::Control, "Control"),
+        (Treatment::RSL3, "RSL3"),
+        (Treatment::SDT, "SDT"),
+    ];
+
+    println!("ferroptosis-core v{}", env!("CARGO_PKG_VERSION"));
+    println!("Parameters: default (2D culture)\n");
+    println!("{:<25} {:<10} {:<8} {:<10} {:<10} {:<10}", "Phenotype", "Treatment", "Dead?", "LP", "GSH", "GPX4");
+    println!("{}", "-".repeat(73));
+
+    for (pheno, pname) in &phenotypes {
+        for (tx, tname) in &treatments {
+            let mut rng = StdRng::seed_from_u64(seed);
+            let cell = gen_cell(*pheno, &mut rng);
+            let mut sim_rng = StdRng::seed_from_u64(seed + 1);
+            let (dead, lp, gsh, gpx4) = sim_cell(&cell, *tx, &params, &mut sim_rng);
+            println!(
+                "{:<25} {:<10} {:<8} {:<10.3} {:<10.3} {:<10.3}",
+                pname, tname, if dead { "YES" } else { "no" }, lp, gsh, gpx4
+            );
+        }
+    }
+
+    // Demonstrate in-vivo parameters (MUFA protection)
+    println!("\n--- In-vivo context (SCD1-driven MUFA protection) ---\n");
+    let invivo_params = Params::invivo();
+    println!("MUFA steady-state protection: {:.2}", invivo_params.initial_mufa_protection);
+    let mut rng = StdRng::seed_from_u64(seed);
+    let cell = gen_cell(Phenotype::Persister, &mut rng);
+    let mut sim_rng = StdRng::seed_from_u64(seed + 1);
+    let (dead_2d, _, _, _) = sim_cell(&cell, Treatment::RSL3, &params, &mut sim_rng);
+    let mut sim_rng = StdRng::seed_from_u64(seed + 1);
+    let (dead_vivo, _, _, _) = sim_cell(&cell, Treatment::RSL3, &invivo_params, &mut sim_rng);
+    println!("Persister + RSL3 (2D):     dead = {}", dead_2d);
+    println!("Persister + RSL3 (in-vivo): dead = {}", dead_vivo);
+}

--- a/simulations/ferroptosis-core/src/biochem.rs
+++ b/simulations/ferroptosis-core/src/biochem.rs
@@ -250,3 +250,73 @@ pub fn sim_cell(
 
     (lp > params.death_threshold, lp, gsh, gpx4)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cell::{gen_cell, Phenotype};
+    use rand::SeedableRng;
+
+    #[test]
+    fn control_does_not_kill_glycolytic() {
+        let params = Params::default();
+        let mut rng = StdRng::seed_from_u64(0);
+        let cell = gen_cell(Phenotype::Glycolytic, &mut rng);
+        let mut sim_rng = StdRng::seed_from_u64(1);
+        let (dead, lp, _, _) = sim_cell(&cell, Treatment::Control, &params, &mut sim_rng);
+        assert!(!dead, "Glycolytic cell should survive Control");
+        assert!(lp < params.death_threshold, "LP should stay below threshold");
+    }
+
+    #[test]
+    fn sdt_kills_persister() {
+        let params = Params::default();
+        let mut rng = StdRng::seed_from_u64(0);
+        let cell = gen_cell(Phenotype::Persister, &mut rng);
+        let mut sim_rng = StdRng::seed_from_u64(1);
+        let (dead, _, _, _) = sim_cell(&cell, Treatment::SDT, &params, &mut sim_rng);
+        assert!(dead, "Persister cell should die under SDT");
+    }
+
+    #[test]
+    fn rsl3_inhibits_gpx4() {
+        let params = Params::default();
+        let mut rng = StdRng::seed_from_u64(0);
+        let cell = gen_cell(Phenotype::Glycolytic, &mut rng);
+        let mut sim_rng = StdRng::seed_from_u64(1);
+        let state = CellState::from_cell(&cell, Treatment::RSL3, &params, &mut sim_rng);
+        let expected = cell.gpx4 * (1.0 - params.rsl3_gpx4_inhib);
+        assert!((state.gpx4 - expected).abs() < 1e-10, "RSL3 should reduce GPX4 by {}%", params.rsl3_gpx4_inhib * 100.0);
+    }
+
+    #[test]
+    fn mufa_protection_reduces_death_rate() {
+        // In-vivo MUFA should protect persisters from RSL3 relative to 2D
+        let params_2d = Params::default();
+        let params_vivo = Params::invivo();
+        let n = 1000;
+        let mut deaths_2d = 0;
+        let mut deaths_vivo = 0;
+        for i in 0..n {
+            let mut rng = StdRng::seed_from_u64(i * 2);
+            let cell = gen_cell(Phenotype::Persister, &mut rng);
+            let mut sr = StdRng::seed_from_u64(i * 2 + 1);
+            if sim_cell(&cell, Treatment::RSL3, &params_2d, &mut sr).0 { deaths_2d += 1; }
+            let mut sr = StdRng::seed_from_u64(i * 2 + 1);
+            if sim_cell(&cell, Treatment::RSL3, &params_vivo, &mut sr).0 { deaths_vivo += 1; }
+        }
+        assert!(deaths_vivo < deaths_2d, "In-vivo MUFA should reduce RSL3 deaths: 2D={deaths_2d}, vivo={deaths_vivo}");
+    }
+
+    #[test]
+    fn single_step_does_not_kill_healthy_cell() {
+        let params = Params::default();
+        let mut rng = StdRng::seed_from_u64(0);
+        let cell = gen_cell(Phenotype::Glycolytic, &mut rng);
+        let mut sim_rng = StdRng::seed_from_u64(1);
+        let mut state = CellState::from_cell(&cell, Treatment::Control, &params, &mut sim_rng);
+        let dead = sim_cell_step(&mut state, &cell, &params, 0, 0.0, &mut sim_rng);
+        assert!(!dead, "One step should not kill a healthy glycolytic cell");
+        assert!(state.lp < 1.0, "LP should be near zero after one step");
+    }
+}

--- a/simulations/ferroptosis-core/src/lib.rs
+++ b/simulations/ferroptosis-core/src/lib.rs
@@ -1,7 +1,31 @@
-//! Ferroptosis Simulation Suite — shared library.
+//! # ferroptosis-core
 //!
-//! Provides the core biochemistry engine, cell types, physics models,
-//! spatial grid, immune cascade, and I/O utilities used by all simulation binaries.
+//! Embeddable ferroptosis biochemistry engine for cancer simulation.
+//!
+//! This library models the ferroptosis cell death pathway at single-cell resolution:
+//! ROS generation, GSH depletion, GPX4/FSP1 repair, lipid peroxidation, and
+//! death threshold crossing. It supports both full single-cell simulations and
+//! single-timestep updates for embedding in spatial or multi-scale frameworks.
+//!
+//! ## Key entry points
+//!
+//! - [`biochem::sim_cell`] — full 180-step ferroptosis simulation for one cell
+//! - [`biochem::sim_cell_step`] — single timestep (for spatial model interleaving)
+//! - [`cell::gen_cell`] — generate a cell with stochastic phenotype-specific parameters
+//! - [`params::Params`] — all biochemistry rate constants (`default()` for 2D, `invivo()` for 3D)
+//!
+//! ## Modules
+//!
+//! | Module | Purpose |
+//! |--------|---------|
+//! | [`cell`] | Phenotypes, treatments, stochastic cell generation |
+//! | [`params`] | Rate constants for biochemistry, physics, immune cascade |
+//! | [`biochem`] | Core simulation engine |
+//! | [`stats`] | Wilson CIs, parallel Monte Carlo execution |
+//! | [`physics`] | Depth-dependent energy deposition (Beer-Lambert, acoustic) |
+//! | [`grid`] | 2D tumor grid with heterogeneous architecture |
+//! | [`immune`] | ICD/DAMP immune cascade model |
+//! | [`io`] | JSON and CSV output helpers |
 
 pub mod cell;
 pub mod params;


### PR DESCRIPTION
Closes #49 (first pass)

## Summary
Prepares the ferroptosis-core library for independent consumption by adding licensing, documentation, tests, and an example. No library code changed — existing binaries produce bitwise-identical output.

## What changed

| File | Change |
|------|--------|
| `ferroptosis-core/Cargo.toml` | Added MIT license, repository, keywords, categories, readme |
| `ferroptosis-core/LICENSE` | MIT license file |
| `ferroptosis-core/README.md` | Crate README: quick start, module overview, key API, parameter link |
| `ferroptosis-core/src/lib.rs` | Expanded crate-level docs with module guide and entry points |
| `ferroptosis-core/src/biochem.rs` | 5 unit tests for core biochemistry |
| `ferroptosis-core/examples/basic_usage.rs` | Self-contained example: generate cell, simulate RSL3/SDT, print results |

## What was NOT changed (deferred)
- No C FFI bindings (requires repr(C), cbindgen — separate issue)
- No Python bindings via PyO3 (requires maturin, CI for wheels — separate issue)
- No crates.io publish (API should be reviewed first)
- No library code changes — zero blast radius on simulation outputs

## Verification
```
cargo test -p ferroptosis-core              # 11 pass (6 physics + 5 biochem)
cargo run -p ferroptosis-core --example basic_usage  # runs, prints results
cargo doc -p ferroptosis-core --no-deps     # clean, no warnings
cargo package -p ferroptosis-core --list    # includes LICENSE, README, example
cargo run --release --bin sim-original      # bitwise identical to ground truth
```

## Test plan
- [ ] `cargo test -p ferroptosis-core` — 11/11 pass
- [ ] `cargo run -p ferroptosis-core --example basic_usage` — produces output
- [ ] `cargo package -p ferroptosis-core --list` — includes LICENSE and README
- [ ] sim-original output matches `simulation_results_v1_ground_truth.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)