### PR TITLE
Add tissue-specific drug penetration simulation

### DIFF
--- a/simulations/Cargo.toml
+++ b/simulations/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "sim-icd",
     "sim-combo",
     "sim-invivo",
+    "sim-tissue-pk",
 ]
 resolver = "2"
 

--- a/simulations/ferroptosis-core/src/drug_transport.rs
+++ b/simulations/ferroptosis-core/src/drug_transport.rs
@@ -141,12 +141,19 @@ pub fn rsl3_like() -> DrugParams {
     }
 }
 
-/// Doxorubicin — calibration drug with well-characterized penetration.
+/// Doxorubicin-like transport profile (penetration calibration reference).
 ///
-/// MW ~540 Da. Known penetration depth ~40-80μm in solid tumors
-/// (Minchinton & Tannock 2006). Higher uptake than RSL3 due to DNA
-/// intercalation trapping.
-pub fn doxorubicin() -> DrugParams {
+/// Uses doxorubicin's well-characterized transport parameters
+/// (MW ~540 Da, D ≈ 3×10⁻⁷ cm²/s, high uptake from DNA trapping)
+/// to validate that the exponential model produces a penetration
+/// length in the published 40-80μm range (Minchinton & Tannock 2006).
+///
+/// **Important:** This is a transport-only reference. The cell-level
+/// pharmacology still uses the RSL3/GPX4-inhibition pathway, not
+/// doxorubicin's actual mechanism (DNA intercalation, topoisomerase II).
+/// Comparative kill rates between this and `rsl3_like()` reflect only
+/// differences in tissue penetration depth, not drug mechanism.
+pub fn doxorubicin_transport_reference() -> DrugParams {
     DrugParams {
         // Doxorubicin D ≈ 3 × 10⁻⁷ cm²/s in tissue
         // Ref: El-Kareh & Secomb 2000
@@ -157,7 +164,7 @@ pub fn doxorubicin() -> DrugParams {
         metabolism_rate: 0.002,
         // Freely permeable
         vessel_wall_conc: 1.0,
-        name: "Doxorubicin",
+        name: "Doxorubicin-transport",
     }
 }
 
@@ -253,13 +260,13 @@ mod tests {
     }
 
     #[test]
-    fn doxorubicin_penetration_matches_literature() {
+    fn doxorubicin_transport_penetration_matches_literature() {
         // Minchinton & Tannock 2006: doxorubicin penetrates ~40-80μm
-        let drug = doxorubicin();
+        let drug = doxorubicin_transport_reference();
         let lambda = penetration_length_um(&drug);
         assert!(
             lambda > 30.0 && lambda < 120.0,
-            "Doxorubicin λ should be ~50-80μm, got {lambda:.1}μm"
+            "Doxorubicin transport λ should be ~50-80μm, got {lambda:.1}μm"
         );
     }
 

--- a/simulations/ferroptosis-core/src/drug_transport.rs
+++ b/simulations/ferroptosis-core/src/drug_transport.rs
@@ -1,0 +1,299 @@
+//! Drug penetration modeling for tissue-specific pharmacokinetics.
+//!
+//! Models how drug concentration drops with distance from the nearest
+//! blood vessel using an exponential decay approximation of the Krogh
+//! cylinder steady-state solution.
+//!
+//! The key equation: `C(r) = C₀ × exp(-r / λ)` where `λ = √(D/k)` is
+//! the penetration length, `D` is the effective diffusion coefficient,
+//! and `k` is the total clearance rate (cellular uptake + metabolism).
+//!
+//! # References
+//!
+//! - Minchinton AI, Tannock IF. "Drug penetration in solid tumours."
+//!   Nature Reviews Cancer 6:583-592, 2006.
+//! - Thurber GM, et al. "Antibody tumor penetration." Advanced Drug
+//!   Delivery Reviews 60:1421-1434, 2008.
+//! - El-Kareh AW, Secomb TW. "A mathematical model for comparison of
+//!   bolus injection, continuous infusion, and liposomal delivery of
+//!   doxorubicin." Neoplasia 2:325-338, 2000.
+
+use serde::{Deserialize, Serialize};
+
+/// Drug physicochemical and pharmacokinetic parameters.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DrugParams {
+    /// Effective diffusion coefficient in tissue (cm²/s).
+    /// Depends on drug molecular weight, charge, and tissue density.
+    /// Small molecules (~500 Da): 1-10 × 10⁻⁷ cm²/s.
+    /// Antibodies (~150 kDa): 0.1-1 × 10⁻⁷ cm²/s.
+    pub diffusion_coeff_cm2_s: f64,
+
+    /// Cellular uptake rate (1/s). How fast cells internalize the drug.
+    pub uptake_rate: f64,
+
+    /// Extracellular metabolism/degradation rate (1/s).
+    pub metabolism_rate: f64,
+
+    /// Concentration at the vessel wall (normalized, 0-1).
+    /// Represents the fraction of plasma concentration that crosses the
+    /// endothelium. Equals 1.0 for freely permeable drugs.
+    pub vessel_wall_conc: f64,
+
+    /// Human-readable name for output.
+    pub name: &'static str,
+}
+
+/// Tissue-specific transport parameters affecting drug penetration.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TissueParams {
+    /// Mean inter-vessel distance (μm). Determines how far a drug must
+    /// diffuse to reach the most remote cells. Inversely related to
+    /// vascular density. Typical: 100-300μm in solid tumors.
+    pub inter_vessel_distance_um: f64,
+
+    /// Vascular permeability factor (0-1). Fraction of vessel-wall
+    /// concentration that reaches the interstitium. Reduced by tight
+    /// junctions (BBB), elevated interstitial fluid pressure, etc.
+    pub vascular_permeability: f64,
+
+    /// Human-readable name for output.
+    pub name: &'static str,
+}
+
+/// Characteristic penetration length (μm).
+///
+/// This is the distance at which drug concentration drops to 1/e (~37%)
+/// of its vessel-wall value. Determined by the balance between diffusion
+/// (spreading the drug) and clearance (cells consuming it).
+///
+/// `λ = √(D / k_total)` where `k_total = uptake_rate + metabolism_rate`.
+pub fn penetration_length_um(drug: &DrugParams) -> f64 {
+    let k_total = drug.uptake_rate + drug.metabolism_rate;
+    if k_total <= 0.0 {
+        return f64::INFINITY;
+    }
+    // Convert D from cm²/s to μm²/s (1 cm = 10⁴ μm, so 1 cm² = 10⁸ μm²)
+    let d_um2_s = drug.diffusion_coeff_cm2_s * 1e8;
+    (d_um2_s / k_total).sqrt()
+}
+
+/// Drug concentration at radial distance `r_um` (μm) from the nearest vessel.
+///
+/// Returns normalized concentration in [0, 1]. Uses the exponential decay
+/// approximation of the Krogh cylinder steady-state solution, which is valid
+/// when the vessel radius is much smaller than the tissue radius (typically
+/// R_vessel ≈ 5-10μm vs R_tissue ≈ 50-150μm).
+///
+/// `C(r) = C_vessel × permeability × exp(-r / λ)`
+pub fn concentration_at_distance(r_um: f64, drug: &DrugParams, tissue: &TissueParams) -> f64 {
+    let lambda = penetration_length_um(drug);
+    let c0 = drug.vessel_wall_conc * tissue.vascular_permeability;
+    (c0 * (-r_um / lambda).exp()).min(1.0)
+}
+
+/// Maximum distance from a vessel (half the inter-vessel distance).
+pub fn max_distance_um(tissue: &TissueParams) -> f64 {
+    tissue.inter_vessel_distance_um / 2.0
+}
+
+/// Compute the concentration profile across the full radial range.
+///
+/// Returns `n_bins` evenly spaced `(distance_um, concentration)` pairs
+/// from 0 to `max_distance_um`.
+pub fn concentration_profile(
+    drug: &DrugParams,
+    tissue: &TissueParams,
+    n_bins: usize,
+) -> Vec<(f64, f64)> {
+    let r_max = max_distance_um(tissue);
+    (0..n_bins)
+        .map(|i| {
+            let r = r_max * i as f64 / (n_bins - 1).max(1) as f64;
+            (r, concentration_at_distance(r, drug, tissue))
+        })
+        .collect()
+}
+
+// ============================================================
+// Drug Presets
+// ============================================================
+
+/// RSL3-like small molecule GPX4 inhibitor.
+///
+/// MW ~500 Da. Moderate diffusion, moderate cellular uptake.
+/// Penetration length ~100-120μm in well-vascularized tissue.
+pub fn rsl3_like() -> DrugParams {
+    DrugParams {
+        // Small molecule in tissue: D ≈ 5 × 10⁻⁷ cm²/s
+        // Ref: El-Kareh & Secomb 2000 (doxorubicin range 1-8 × 10⁻⁷)
+        diffusion_coeff_cm2_s: 5.0e-7,
+        // Moderate uptake: cells internalize but don't trap heavily
+        uptake_rate: 0.004,
+        // Low extracellular metabolism for a stable small molecule
+        metabolism_rate: 0.001,
+        // Freely permeable small molecule
+        vessel_wall_conc: 1.0,
+        name: "RSL3-like",
+    }
+}
+
+/// Doxorubicin — calibration drug with well-characterized penetration.
+///
+/// MW ~540 Da. Known penetration depth ~40-80μm in solid tumors
+/// (Minchinton & Tannock 2006). Higher uptake than RSL3 due to DNA
+/// intercalation trapping.
+pub fn doxorubicin() -> DrugParams {
+    DrugParams {
+        // Doxorubicin D ≈ 3 × 10⁻⁷ cm²/s in tissue
+        // Ref: El-Kareh & Secomb 2000
+        diffusion_coeff_cm2_s: 3.0e-7,
+        // High uptake due to DNA binding/trapping
+        uptake_rate: 0.01,
+        // Moderate metabolism
+        metabolism_rate: 0.002,
+        // Freely permeable
+        vessel_wall_conc: 1.0,
+        name: "Doxorubicin",
+    }
+}
+
+// ============================================================
+// Tissue Presets
+// ============================================================
+
+/// Well-vascularized epithelial tissue (breast, lung, colorectal).
+///
+/// Dense capillary network, moderate permeability.
+/// Inter-vessel distance ~100-150μm.
+pub fn epithelial_well_vascularized() -> TissueParams {
+    TissueParams {
+        inter_vessel_distance_um: 120.0,
+        vascular_permeability: 0.8,
+        name: "Epithelial (well-vascularized)",
+    }
+}
+
+/// Poorly vascularized epithelial tissue (pancreatic, some liver).
+///
+/// Sparse vasculature, high interstitial fluid pressure, low permeability.
+/// Inter-vessel distance ~200-300μm.
+/// Ref: Olive et al., Science 2009 (pancreatic desmoplasia)
+pub fn epithelial_poorly_vascularized() -> TissueParams {
+    TissueParams {
+        inter_vessel_distance_um: 250.0,
+        vascular_permeability: 0.4,
+        name: "Epithelial (poorly-vascularized)",
+    }
+}
+
+/// CNS/neuroectodermal tissue (glioblastoma).
+///
+/// Blood-brain barrier severely restricts drug entry. Even disrupted BBB
+/// in tumor core has much lower permeability than systemic vasculature.
+/// Inter-vessel distance moderate but permeability very low.
+/// Ref: Sarkaria et al., Neuro-Oncology 2018 (BBB and drug delivery)
+pub fn neuroectodermal_cns() -> TissueParams {
+    TissueParams {
+        inter_vessel_distance_um: 150.0,
+        vascular_permeability: 0.15,
+        name: "Neuroectodermal (CNS/BBB)",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn concentration_at_vessel_wall_is_c0() {
+        let drug = rsl3_like();
+        let tissue = epithelial_well_vascularized();
+        let c = concentration_at_distance(0.0, &drug, &tissue);
+        let expected = drug.vessel_wall_conc * tissue.vascular_permeability;
+        assert!((c - expected).abs() < 1e-10, "At r=0: expected {expected}, got {c}");
+    }
+
+    #[test]
+    fn concentration_decays_with_distance() {
+        let drug = rsl3_like();
+        let tissue = epithelial_well_vascularized();
+        let c_near = concentration_at_distance(10.0, &drug, &tissue);
+        let c_far = concentration_at_distance(100.0, &drug, &tissue);
+        assert!(c_far < c_near, "Concentration should decrease with distance");
+    }
+
+    #[test]
+    fn concentration_near_zero_at_large_distance() {
+        let drug = rsl3_like();
+        let tissue = epithelial_well_vascularized();
+        let c = concentration_at_distance(1000.0, &drug, &tissue);
+        assert!(c < 0.01, "Concentration at 1mm should be negligible, got {c}");
+    }
+
+    #[test]
+    fn penetration_length_scales_with_sqrt_d_over_k() {
+        let drug1 = DrugParams {
+            diffusion_coeff_cm2_s: 4.0e-7,
+            uptake_rate: 0.004,
+            metabolism_rate: 0.0,
+            vessel_wall_conc: 1.0,
+            name: "test1",
+        };
+        // 4× diffusion should give 2× penetration length (sqrt scaling)
+        let drug2 = DrugParams {
+            diffusion_coeff_cm2_s: 16.0e-7,
+            ..drug1.clone()
+        };
+        let ratio = penetration_length_um(&drug2) / penetration_length_um(&drug1);
+        assert!((ratio - 2.0).abs() < 0.01, "λ should scale as √D: ratio={ratio}");
+    }
+
+    #[test]
+    fn doxorubicin_penetration_matches_literature() {
+        // Minchinton & Tannock 2006: doxorubicin penetrates ~40-80μm
+        let drug = doxorubicin();
+        let lambda = penetration_length_um(&drug);
+        assert!(
+            lambda > 30.0 && lambda < 120.0,
+            "Doxorubicin λ should be ~50-80μm, got {lambda:.1}μm"
+        );
+    }
+
+    #[test]
+    fn bbb_reduces_effective_concentration() {
+        let drug = rsl3_like();
+        let normal = epithelial_well_vascularized();
+        let cns = neuroectodermal_cns();
+        let c_normal = concentration_at_distance(50.0, &drug, &normal);
+        let c_cns = concentration_at_distance(50.0, &drug, &cns);
+        assert!(
+            c_cns < c_normal * 0.5,
+            "BBB should substantially reduce concentration: normal={c_normal:.3}, cns={c_cns:.3}"
+        );
+    }
+
+    #[test]
+    fn profile_has_correct_length() {
+        let drug = rsl3_like();
+        let tissue = epithelial_well_vascularized();
+        let profile = concentration_profile(&drug, &tissue, 50);
+        assert_eq!(profile.len(), 50);
+        assert!((profile[0].0 - 0.0).abs() < 1e-10, "First point should be at r=0");
+        let r_max = max_distance_um(&tissue);
+        assert!((profile[49].0 - r_max).abs() < 1e-10, "Last point should be at r_max");
+    }
+
+    #[test]
+    fn zero_clearance_gives_infinite_penetration() {
+        let drug = DrugParams {
+            diffusion_coeff_cm2_s: 5.0e-7,
+            uptake_rate: 0.0,
+            metabolism_rate: 0.0,
+            vessel_wall_conc: 1.0,
+            name: "no-clearance",
+        };
+        let lambda = penetration_length_um(&drug);
+        assert!(lambda.is_infinite(), "Zero clearance should give infinite penetration");
+    }
+}

--- a/simulations/ferroptosis-core/src/drug_transport.rs
+++ b/simulations/ferroptosis-core/src/drug_transport.rs
@@ -35,9 +35,12 @@ pub struct DrugParams {
     /// Extracellular metabolism/degradation rate (1/s).
     pub metabolism_rate: f64,
 
-    /// Concentration at the vessel wall (normalized, 0-1).
-    /// Represents the fraction of plasma concentration that crosses the
-    /// endothelium. Equals 1.0 for freely permeable drugs.
+    /// Drug-intrinsic bioavailability at the vessel wall (normalized, 0-1).
+    /// Accounts for plasma protein binding and endothelial exclusion
+    /// specific to the drug molecule. Set to 1.0 for freely permeable
+    /// small molecules. This is multiplied by the tissue's vascular
+    /// permeability to get the interstitial concentration, so do NOT
+    /// duplicate the tissue permeability factor here.
     pub vessel_wall_conc: f64,
 
     /// Human-readable name for output.

--- a/simulations/ferroptosis-core/src/lib.rs
+++ b/simulations/ferroptosis-core/src/lib.rs
@@ -26,6 +26,7 @@
 //! | [`grid`] | 2D tumor grid with heterogeneous architecture |
 //! | [`immune`] | ICD/DAMP immune cascade model |
 //! | [`io`] | JSON and CSV output helpers |
+//! | [`drug_transport`] | Tissue-specific drug penetration (Krogh cylinder approximation) |
 
 pub mod cell;
 pub mod params;
@@ -35,3 +36,4 @@ pub mod physics;
 pub mod grid;
 pub mod immune;
 pub mod io;
+pub mod drug_transport;

--- a/simulations/sim-tissue-pk/Cargo.toml
+++ b/simulations/sim-tissue-pk/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "sim-tissue-pk"
+version = "0.1.0"
+edition = "2021"
+description = "Tissue-specific drug penetration and ferroptosis efficacy simulation"
+
+[dependencies]
+ferroptosis-core = { workspace = true }
+rand = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+csv = { workspace = true }

--- a/simulations/sim-tissue-pk/src/main.rs
+++ b/simulations/sim-tissue-pk/src/main.rs
@@ -129,12 +129,14 @@ fn main() {
     eprintln!("=== Tissue-Specific Drug Penetration Simulation ===");
     eprintln!("Cells per radial bin: {N_CELLS_PER_BIN}");
     eprintln!("Radial bins: {N_RADIAL_BINS}");
-    eprintln!("Phenotype: Persister (FSP1-low)\n");
+    eprintln!("Phenotype: Persister (FSP1-low)");
+    eprintln!("NOTE: All drugs use the RSL3/GPX4-inhibition pathway. Differences");
+    eprintln!("      reflect transport profiles only, not distinct pharmacology.\n");
 
     let base_params = Params::default();
     let seed: u64 = 42;
 
-    let drugs: Vec<DrugParams> = vec![drug_transport::rsl3_like(), drug_transport::doxorubicin()];
+    let drugs: Vec<DrugParams> = vec![drug_transport::rsl3_like(), drug_transport::doxorubicin_transport_reference()];
 
     let tissues: Vec<TissueParams> = vec![
         drug_transport::epithelial_well_vascularized(),
@@ -207,16 +209,14 @@ fn main() {
         );
     }
 
-    // Calibration check
-    let dox_lambda = penetration_length_um(&drug_transport::doxorubicin());
-    eprintln!("\n=== Calibration Check ===");
+    // Transport parameter consistency check (not independent calibration —
+    // the parameters were chosen to produce a λ in the published range)
+    let dox_lambda = penetration_length_um(&drug_transport::doxorubicin_transport_reference());
+    eprintln!("\n=== Transport Consistency Check ===");
     eprintln!(
-        "Doxorubicin penetration length: {:.1} μm (literature: 40-80 μm, Minchinton 2006)",
+        "Doxorubicin-transport λ: {:.1} μm (published range: 40-80 μm, Minchinton 2006)",
         dox_lambda
     );
-    if dox_lambda >= 30.0 && dox_lambda <= 120.0 {
-        eprintln!("  PASS — within calibration range");
-    } else {
-        eprintln!("  WARNING — outside expected range");
-    }
+    eprintln!("  Note: this is a self-consistency check on chosen transport parameters,");
+    eprintln!("  not independent calibration against experimental outcome data.");
 }

--- a/simulations/sim-tissue-pk/src/main.rs
+++ b/simulations/sim-tissue-pk/src/main.rs
@@ -1,0 +1,222 @@
+//! Tissue-specific drug penetration simulation.
+//!
+//! Computes drug concentration profiles and ferroptosis kill rates as a
+//! function of distance from the nearest blood vessel, across different
+//! tissue types.
+//!
+//! Usage: `cargo run --release --bin sim-tissue-pk`
+
+use std::fs;
+use std::path::Path;
+
+use rand::prelude::*;
+use serde::Serialize;
+
+use ferroptosis_core::biochem::sim_cell;
+use ferroptosis_core::cell::{gen_cell, Phenotype, Treatment};
+use ferroptosis_core::drug_transport::{
+    self, concentration_profile, max_distance_um,
+    penetration_length_um, DrugParams, TissueParams,
+};
+use ferroptosis_core::params::Params;
+use ferroptosis_core::stats::wilson_ci;
+
+const N_RADIAL_BINS: usize = 50;
+const N_CELLS_PER_BIN: usize = 1000;
+
+#[derive(Serialize)]
+struct BinResult {
+    distance_um: f64,
+    concentration: f64,
+    death_rate: f64,
+    ci_low: f64,
+    ci_high: f64,
+    n_cells: usize,
+    n_dead: usize,
+    tissue: String,
+    drug: String,
+}
+
+#[derive(Serialize)]
+struct Summary {
+    tissue: String,
+    drug: String,
+    penetration_length_um: f64,
+    max_distance_um: f64,
+    vessel_wall_concentration: f64,
+    vessel_wall_death_rate: f64,
+    effective_kill_depth_um: f64,
+    overall_kill_fraction: f64,
+}
+
+fn run_tissue_drug(
+    drug: &DrugParams,
+    tissue: &TissueParams,
+    base_params: &Params,
+    phenotype: Phenotype,
+    seed: u64,
+) -> (Vec<BinResult>, Summary) {
+    let r_max = max_distance_um(tissue);
+    let lambda = penetration_length_um(drug);
+    let profile = concentration_profile(drug, tissue, N_RADIAL_BINS);
+
+    let mut results = Vec::with_capacity(N_RADIAL_BINS);
+    let mut total_dead = 0usize;
+    let mut total_cells = 0usize;
+
+    for (bin_idx, &(r_um, conc)) in profile.iter().enumerate() {
+        // Scale GPX4 inhibition by local drug concentration
+        let mut params = base_params.clone();
+        params.rsl3_gpx4_inhib *= conc;
+
+        let mut n_dead = 0usize;
+        for i in 0..N_CELLS_PER_BIN {
+            let cell_seed = seed + (bin_idx as u64) * (N_CELLS_PER_BIN as u64) * 2 + (i as u64) * 2;
+            let mut rng = StdRng::seed_from_u64(cell_seed);
+            let cell = gen_cell(phenotype, &mut rng);
+            let mut sim_rng = StdRng::seed_from_u64(cell_seed + 1);
+            let (dead, _, _, _) = sim_cell(&cell, Treatment::RSL3, &params, &mut sim_rng);
+            if dead {
+                n_dead += 1;
+            }
+        }
+
+        let death_rate = n_dead as f64 / N_CELLS_PER_BIN as f64;
+        let (ci_low, ci_high) = wilson_ci(N_CELLS_PER_BIN, n_dead);
+
+        total_dead += n_dead;
+        total_cells += N_CELLS_PER_BIN;
+
+        results.push(BinResult {
+            distance_um: r_um,
+            concentration: conc,
+            death_rate,
+            ci_low,
+            ci_high,
+            n_cells: N_CELLS_PER_BIN,
+            n_dead,
+            tissue: tissue.name.to_string(),
+            drug: drug.name.to_string(),
+        });
+    }
+
+    // Find effective kill depth: distance where death rate drops below 10%
+    let kill_depth = results
+        .iter()
+        .rev()
+        .find(|r| r.death_rate >= 0.10)
+        .map(|r| r.distance_um)
+        .unwrap_or(0.0);
+
+    let vessel_wall_dr = results.first().map(|r| r.death_rate).unwrap_or(0.0);
+    let vessel_wall_conc = results.first().map(|r| r.concentration).unwrap_or(0.0);
+
+    let summary = Summary {
+        tissue: tissue.name.to_string(),
+        drug: drug.name.to_string(),
+        penetration_length_um: lambda,
+        max_distance_um: r_max,
+        vessel_wall_concentration: vessel_wall_conc,
+        vessel_wall_death_rate: vessel_wall_dr,
+        effective_kill_depth_um: kill_depth,
+        overall_kill_fraction: total_dead as f64 / total_cells as f64,
+    };
+
+    (results, summary)
+}
+
+fn main() {
+    eprintln!("=== Tissue-Specific Drug Penetration Simulation ===");
+    eprintln!("Cells per radial bin: {N_CELLS_PER_BIN}");
+    eprintln!("Radial bins: {N_RADIAL_BINS}");
+    eprintln!("Phenotype: Persister (FSP1-low)\n");
+
+    let base_params = Params::default();
+    let seed: u64 = 42;
+
+    let drugs: Vec<DrugParams> = vec![drug_transport::rsl3_like(), drug_transport::doxorubicin()];
+
+    let tissues: Vec<TissueParams> = vec![
+        drug_transport::epithelial_well_vascularized(),
+        drug_transport::epithelial_poorly_vascularized(),
+        drug_transport::neuroectodermal_cns(),
+    ];
+
+    let output_dir = Path::new("output/tissue-pk");
+    fs::create_dir_all(output_dir).expect("Failed to create output directory");
+
+    let mut all_results: Vec<BinResult> = Vec::new();
+    let mut all_summaries: Vec<Summary> = Vec::new();
+
+    for drug in &drugs {
+        eprintln!("Drug: {} (λ = {:.1} μm)", drug.name, penetration_length_um(drug));
+        for tissue in &tissues {
+            let (results, summary) = run_tissue_drug(
+                drug,
+                tissue,
+                &base_params,
+                Phenotype::Persister,
+                seed,
+            );
+
+            eprintln!(
+                "  {}: kill depth = {:.0} μm, vessel-wall death = {:.1}%, overall = {:.1}%",
+                tissue.name,
+                summary.effective_kill_depth_um,
+                summary.vessel_wall_death_rate * 100.0,
+                summary.overall_kill_fraction * 100.0,
+            );
+
+            all_summaries.push(summary);
+            all_results.extend(results);
+        }
+        eprintln!();
+    }
+
+    // Write CSV
+    let csv_path = output_dir.join("tissue_pk_results.csv");
+    let mut wtr = csv::Writer::from_path(&csv_path).expect("Failed to create CSV");
+    for r in &all_results {
+        wtr.serialize(r).expect("Failed to write CSV row");
+    }
+    wtr.flush().expect("Failed to flush CSV");
+    eprintln!("Written: {}", csv_path.display());
+
+    // Write JSON summary
+    let json_path = output_dir.join("tissue_pk_summary.json");
+    let json = serde_json::to_string_pretty(&all_summaries).expect("Failed to serialize JSON");
+    fs::write(&json_path, json).expect("Failed to write JSON");
+    eprintln!("Written: {}", json_path.display());
+
+    // Print comparison table
+    eprintln!("\n=== Summary ===\n");
+    eprintln!(
+        "{:<15} {:<35} {:<12} {:<12} {:<12} {:<12}",
+        "Drug", "Tissue", "λ (μm)", "Kill depth", "Vessel DR", "Overall"
+    );
+    eprintln!("{}", "-".repeat(98));
+    for s in &all_summaries {
+        eprintln!(
+            "{:<15} {:<35} {:<12.1} {:<12.0} {:>10.1}% {:>10.1}%",
+            s.drug,
+            s.tissue,
+            s.penetration_length_um,
+            s.effective_kill_depth_um,
+            s.vessel_wall_death_rate * 100.0,
+            s.overall_kill_fraction * 100.0,
+        );
+    }
+
+    // Calibration check
+    let dox_lambda = penetration_length_um(&drug_transport::doxorubicin());
+    eprintln!("\n=== Calibration Check ===");
+    eprintln!(
+        "Doxorubicin penetration length: {:.1} μm (literature: 40-80 μm, Minchinton 2006)",
+        dox_lambda
+    );
+    if dox_lambda >= 30.0 && dox_lambda <= 120.0 {
+        eprintln!("  PASS — within calibration range");
+    } else {
+        eprintln!("  WARNING — outside expected range");
+    }
+}


### PR DESCRIPTION
Closes #45

## Summary
Adds a drug transport module modeling how drug concentration drops with distance from blood vessels, and a binary that computes tissue-specific penetration profiles coupled to the existing ferroptosis biochemistry.

## Approach
Exponential decay approximation of the Krogh cylinder steady-state: `C(r) = C₀ × exp(-r / λ)` where `λ = √(D/k)`. The Bessel function solution for cylindrical geometry gives <5% different results in the physiological range, and the exponential form is what Minchinton & Tannock 2006 use.

**Important:** All drugs use the RSL3/GPX4-inhibition pathway for cell-level pharmacology. Differences between drug profiles reflect transport properties only (diffusion coefficient, uptake rate), not distinct mechanisms of action.

## What changed (5 files, zero blast radius)

| File | Change |
|------|--------|
| `ferroptosis-core/src/drug_transport.rs` | **New** — DrugParams, TissueParams, concentration model, 2 transport presets, 3 tissue presets, 8 unit tests |
| `ferroptosis-core/src/lib.rs` | Add `pub mod drug_transport` (1 line) |
| `sim-tissue-pk/Cargo.toml` | **New** binary |
| `sim-tissue-pk/src/main.rs` | **New** — runs transport → ferroptosis at 50 radial bins × 1000 cells |
| `simulations/Cargo.toml` | Add workspace member (1 line) |

## Transport presets

- **RSL3-like** (small molecule, λ=100μm): moderate diffusion, moderate uptake
- **Doxorubicin-transport** (calibration reference, λ=50μm): lower diffusion, higher uptake from DNA trapping. Transport parameters only — not a pharmacological doxorubicin model.

## Tissue presets

- Epithelial well-vascularized (breast/lung): 120μm inter-vessel, 80% permeability
- Epithelial poorly-vascularized (pancreatic): 250μm inter-vessel, 40% permeability
- Neuroectodermal CNS/BBB (glioblastoma): 150μm inter-vessel, 15% permeability

## Results

| Drug | Tissue | λ (μm) | Vessel-wall DR | Overall |
|------|--------|--------|---------------|---------|
| RSL3-like | Epithelial (well-vasc) | 100 | 12.1% | 6.6% |
| RSL3-like | Epithelial (poor-vasc) | 100 | 2.6% | 2.1% |
| RSL3-like | CNS/BBB | 100 | 1.8% | 1.5% |

Doxorubicin-transport λ=50μm is a self-consistency check on chosen transport parameters (published range: 40-80μm), not independent calibration.

## Verification
```bash
cargo test -p ferroptosis-core         # 19/19 pass
cargo run --release --bin sim-tissue-pk # generates output/tissue-pk/
cargo run --release --bin sim-original  # regression: bitwise identical
```

Generated with [Claude Code](https://claude.com/claude-code)