### PR TITLE
Integrate simulation results into manuscript and add Python smoke tests

### DIFF
--- a/article/drafts/v1.md
+++ b/article/drafts/v1.md
@@ -337,7 +337,7 @@ To test whether the proposed persister ferroptosis vulnerability is biochemicall
 
 [FIGURE 7: Monte Carlo simulation results. (a) Ferroptosis death rate by cell phenotype and treatment (n=1M cells/condition, 95% CI). (b) Sensitivity analysis tornado plot showing result robustness.]
 
-**Model limitations**: This is a qualitative model testing directional predictions, not a quantitative predictor of clinical death rates. The absolute percentages (87%, 42%, etc.) depend on model-specific rate constants and should not be interpreted as clinical predictions. Its value is in demonstrating that the proposed biochemical chain produces the expected differential sensitivity under biologically plausible parameters.
+**Model limitations**: This is a qualitative model testing directional predictions, not a quantitative predictor of clinical death rates. The absolute percentages (87%, 42%, etc.) depend on model-specific rate constants and should not be interpreted as clinical predictions. Its value is in demonstrating that the proposed biochemical chain produces the expected differential sensitivity under biologically plausible parameters. All ~30 simulation parameters are documented with literature sources and confidence ratings. A calibration layer evaluates 5 targets against existing simulation outputs: 3 are independent calibration targets (persister RSL3 death rate, RSL3 window closure timing, MUFA protection factor) and 2 are self-consistency checks on physics parameters (PDT attenuation, SDT penetration).
 
 #### 4.3.1 Spatial Tumor Simulation: Depth-Dependent Energy Deposition
 
@@ -373,6 +373,8 @@ Dead cells release labile iron to their Moore neighborhood (8-neighbors), modeli
 
 [FIGURE 8: Spatial tumor simulation. (a) Depth-kill curves for PDT, SDT, RSL3, and Control across 1 cm tissue. (b) 2D death heatmaps showing spatial kill patterns. PDT kills superficial cells only; SDT penetrates throughout; RSL3 selectively kills persister pockets regardless of depth.]
 
+The spatial model treats RSL3 as uniformly distributed, but real drug concentration drops with distance from the nearest blood vessel. A tissue-specific drug penetration module using the exponential Krogh cylinder approximation (C(r) = C₀ × exp(-r/λ), where λ = √(D/k) is the penetration length) shows that even at the vessel wall (the highest-concentration position), tissue-specific vascular permeability reduces effective drug exposure — yielding vessel-wall persister kill rates of 12.1% in well-vascularized epithelial tissue, 2.6% in poorly-vascularized tissue (pancreatic), and 1.8% behind the blood-brain barrier (glioblastoma), with overall tumor kill rates even lower (6.6%, 2.1%, 1.5% respectively). These are substantially lower than the 40% kill rate observed in 2D culture, reinforcing the in-vitro-to-in-vivo translation gap. All transport parameters are estimated, not calibrated — the comparison across tissue types is directionally informative, not quantitatively precise.
+
 #### 4.3.2 Vulnerability Window: How Long Does the Ferroptosis-Sensitive Window Stay Open?
 
 A critical question for clinical translation is timing: how long after chemotherapy withdrawal do persister cells remain ferroptosis-sensitive? We modeled the recovery of defense pathways (FSP1, GPX4, NRF2, GSH) using exponential kinetics with literature-estimated half-times (FSP1: 7 days, GPX4: 3 days, NRF2: 5 days, GSH: 1 day) and simulated 100,000 cells per condition at each timepoint.
@@ -388,6 +390,12 @@ A critical question for clinical translation is timing: how long after chemother
 | 4 weeks | 0.00% | 99.5% |
 
 **The RSL3 vulnerability window closes within 3 days** as GPX4 is re-expressed. By one week, RSL3 is completely ineffective (0.01%). **The SDT window remains open for at least 4 weeks** (99.5% kill at day 28), because the exogenous ROS burst overwhelms even partially recovered antioxidant defenses. This differential has direct clinical implications: pharmacologic ferroptosis inducers require intervention within days of chemotherapy, while physical modalities offer a much wider scheduling window. To our knowledge, this is the first computational estimate of the persister ferroptosis vulnerability window duration.
+
+#### 4.3.3 Mechanistic Combination Modeling: Why Drug Pairs Synergize
+
+The ferroptosis pathway has two parallel repair arms: GPX4 (GSH-dependent) and FSP1 (CoQ10-dependent). These feed into a shared antioxidant quench term that suppresses autocatalytic lipid peroxidation propagation. Depleting both arms simultaneously should produce mechanistic synergy — the simulation lets us test this prediction quantitatively.
+
+Running pairwise combinations of four interventions (RSL3/GPX4 inhibitor, SDT/exogenous ROS, FSP1 inhibitor, HDAC inhibitor/basal ROS upregulation) on 1,000 persister cells per condition and comparing against Bliss-independent predictions reveals three synergistic pairs. RSL3 + FSP1i is the strongest (Bliss synergy score 1.99): single-agent RSL3 kills 40% and FSP1i kills 3.7%, but the combination kills 84.1% — nearly double the 42.2% Bliss prediction. The pathway traces show why: with both GPX4 and FSP1 depleted, mean lipid peroxidation reaches 8.7 (near the 10.0 death threshold), whereas RSL3 alone only drives LP to 4.5 because intact FSP1 partially compensates. RSL3 + HDACi (1.25x) and FSP1i + HDACi (1.21x) are also synergistic. SDT combinations are merely additive because SDT alone already kills 100% of persisters (ceiling effect). Drug potency parameters (FSP1i 85% inhibition, HDACi 2x ROS) are estimates — exact synergy scores depend on these assumptions, but the directional finding (dual-pathway depletion > single-pathway) is robust to parameter variation.
 
 ### 4.4 Other Directions The Repo Was Underweighting
 

--- a/article/drafts/v1.tex
+++ b/article/drafts/v1.tex
@@ -407,7 +407,7 @@ Persister + NRF2 & 0.00\% & 0.05\% & 99.5\% & 99.5\% \\
 \label{fig:fig7_monte_carlo_simulation}
 \end{figure}
 
-\textbf{Model limitations}: This is a qualitative model testing directional predictions, not a quantitative predictor of clinical death rates. The absolute percentages (87\%, 42\%, etc.) depend on model-specific rate constants and should not be interpreted as clinical predictions. Its value is in demonstrating that the proposed biochemical chain produces the expected differential sensitivity under biologically plausible parameters.
+\textbf{Model limitations}: This is a qualitative model testing directional predictions, not a quantitative predictor of clinical death rates. The absolute percentages (87\%, 42\%, etc.) depend on model-specific rate constants and should not be interpreted as clinical predictions. Its value is in demonstrating that the proposed biochemical chain produces the expected differential sensitivity under biologically plausible parameters. All $\sim$30 simulation parameters are documented with literature sources and confidence ratings. A calibration layer evaluates 5 targets against existing simulation outputs: 3 are independent calibration targets (persister RSL3 death rate, RSL3 window closure timing, MUFA protection factor) and 2 are self-consistency checks on physics parameters (PDT attenuation, SDT penetration).
 
 \subsubsection{Spatial Tumor Simulation: Depth-Dependent Energy Deposition}
 
@@ -448,6 +448,8 @@ Dead cells release labile iron to their Moore neighborhood (8-neighbors), modeli
 \label{fig:fig8_simulation_by_treatment}
 \end{figure}
 
+The spatial model treats RSL3 as uniformly distributed, but real drug concentration drops with distance from the nearest blood vessel. A tissue-specific drug penetration module using the exponential Krogh cylinder approximation (C(r) = C$_0$ $\times$ exp(-r/λ), where λ = √(D/k) is the penetration length) shows that even at the vessel wall (the highest-concentration position), tissue-specific vascular permeability reduces effective drug exposure --- yielding vessel-wall persister kill rates of 12.1\% in well-vascularized epithelial tissue, 2.6\% in poorly-vascularized tissue (pancreatic), and 1.8\% behind the blood-brain barrier (glioblastoma), with overall tumor kill rates even lower (6.6\%, 2.1\%, 1.5\% respectively). These are substantially lower than the 40\% kill rate observed in 2D culture, reinforcing the in-vitro-to-in-vivo translation gap. All transport parameters are estimated, not calibrated --- the comparison across tissue types is directionally informative, not quantitatively precise.
+
 \subsubsection{Vulnerability Window: How Long Does the Ferroptosis-Sensitive Window Stay Open?}
 
 A critical question for clinical translation is timing: how long after chemotherapy withdrawal do persister cells remain ferroptosis-sensitive? We modeled the recovery of defense pathways (FSP1, GPX4, NRF2, GSH) using exponential kinetics with literature-estimated half-times (FSP1: 7 days, GPX4: 3 days, NRF2: 5 days, GSH: 1 day) and simulated 100,000 cells per condition at each timepoint.
@@ -463,6 +465,12 @@ A critical question for clinical translation is timing: how long after chemother
 
 
 \textbf{The RSL3 vulnerability window closes within 3 days} as GPX4 is re-expressed. By one week, RSL3 is completely ineffective (0.01\%). \textbf{The SDT window remains open for at least 4 weeks} (99.5\% kill at day 28), because the exogenous ROS burst overwhelms even partially recovered antioxidant defenses. This differential has direct clinical implications: pharmacologic ferroptosis inducers require intervention within days of chemotherapy, while physical modalities offer a much wider scheduling window. To our knowledge, this is the first computational estimate of the persister ferroptosis vulnerability window duration.
+
+\subsubsection{Mechanistic Combination Modeling: Why Drug Pairs Synergize}
+
+The ferroptosis pathway has two parallel repair arms: GPX4 (GSH-dependent) and FSP1 (CoQ10-dependent). These feed into a shared antioxidant quench term that suppresses autocatalytic lipid peroxidation propagation. Depleting both arms simultaneously should produce mechanistic synergy --- the simulation lets us test this prediction quantitatively.
+
+Running pairwise combinations of four interventions (RSL3/GPX4 inhibitor, SDT/exogenous ROS, FSP1 inhibitor, HDAC inhibitor/basal ROS upregulation) on 1,000 persister cells per condition and comparing against Bliss-independent predictions reveals three synergistic pairs. RSL3 + FSP1i is the strongest (Bliss synergy score 1.99): single-agent RSL3 kills 40\% and FSP1i kills 3.7\%, but the combination kills 84.1\% --- nearly double the 42.2\% Bliss prediction. The pathway traces show why: with both GPX4 and FSP1 depleted, mean lipid peroxidation reaches 8.7 (near the 10.0 death threshold), whereas RSL3 alone only drives LP to 4.5 because intact FSP1 partially compensates. RSL3 + HDACi (1.25x) and FSP1i + HDACi (1.21x) are also synergistic. SDT combinations are merely additive because SDT alone already kills 100\% of persisters (ceiling effect). Drug potency parameters (FSP1i 85\% inhibition, HDACi 2x ROS) are estimates --- exact synergy scores depend on these assumptions, but the directional finding (dual-pathway depletion > single-pathway) is robust to parameter variation.
 
 \subsection{Other Directions The Repo Was Underweighting}
 

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -157,17 +157,17 @@ class TestAnalysisOutputs:
     @pytest.mark.parametrize("filename", EXPECTED_OUTPUTS)
     def test_analysis_output_exists_and_nonempty(self, filename):
         path = ANALYSIS_DIR / filename
-        if not path.exists():
-            pytest.skip(f"{filename} not found")
+        assert path.exists(), f"Analysis output missing: {filename}"
         content = path.read_text()
         assert len(content) > 100, f"{filename} is too small ({len(content)} chars)"
 
-    def test_evidence_gold_eval_exists(self):
+    def test_evidence_gold_eval_has_expected_structure(self):
         path = ANALYSIS_DIR / "evidence-gold-eval.md"
-        if not path.exists():
-            pytest.skip("evidence-gold-eval.md not found")
+        assert path.exists(), "evidence-gold-eval.md missing"
         content = path.read_text()
-        assert "46/100" in content or "46.0%" in content, "Gold-set eval should report 46% accuracy"
+        assert "## Overall Metrics" in content, "Gold-set eval should have Overall Metrics section"
+        assert "Exact-label accuracy:" in content, "Gold-set eval should report exact-label accuracy"
+        assert "## Per-Label Metrics" in content, "Gold-set eval should have Per-Label Metrics section"
 
 
 # ============================================================

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -1,0 +1,202 @@
+"""
+Smoke tests for the Python corpus pipeline.
+
+These verify that core scripts import cleanly and produce expected outputs
+without running the full pipeline (which takes minutes). Each test is
+designed to catch obvious breakage: missing imports, broken function
+signatures, and empty outputs.
+
+Run: pytest tests/test_pipeline_smoke.py -v
+"""
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add scripts/ to path so we can import pipeline modules
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+CORPUS_INDEX = REPO_ROOT / "corpus" / "INDEX.jsonl"
+ANALYSIS_DIR = REPO_ROOT / "analysis"
+
+
+# ============================================================
+# Import tests: verify modules load without error
+# ============================================================
+
+class TestImports:
+    def test_config_imports(self):
+        config = importlib.import_module("config")
+        assert hasattr(config, "MECHANISM_KEYWORDS")
+        assert hasattr(config, "CANCER_TYPE_KEYWORDS")
+        assert hasattr(config, "DIAGNOSTIC_THERAPY_KEYWORDS")
+        assert hasattr(config, "TISSUE_CATEGORY_ORDER")
+        assert len(config.MECHANISM_KEYWORDS) > 0
+
+    def test_tag_articles_imports(self):
+        mod = importlib.import_module("tag_articles")
+        assert hasattr(mod, "match_keywords")
+        assert hasattr(mod, "match_diagnostic_therapy_links")
+        assert hasattr(mod, "match_evidence_level")
+
+    def test_evidence_utils_imports(self):
+        mod = importlib.import_module("evidence_utils")
+        assert hasattr(mod, "normalize_text")
+        assert hasattr(mod, "is_review_like")
+
+    def test_analyze_corpus_imports(self):
+        mod = importlib.import_module("analyze_corpus")
+        assert hasattr(mod, "build_mechanism_matrix")
+        assert hasattr(mod, "build_diagnostic_therapy_audit")
+
+    def test_generate_figures_imports(self):
+        # This imports matplotlib which sets Agg backend
+        mod = importlib.import_module("generate_figures")
+        assert hasattr(mod, "load_corpus")
+        assert hasattr(mod, "load_index")
+
+    def test_generate_latex_imports(self):
+        # generate_latex is a script, not a module with functions,
+        # but we can verify it parses without SyntaxError
+        path = SCRIPTS_DIR / "generate_latex.py"
+        assert path.exists()
+        compile(path.read_text(), str(path), "exec")
+
+
+# ============================================================
+# Keyword/config consistency tests
+# ============================================================
+
+class TestConfigConsistency:
+    def test_diagnostic_therapy_order_matches_keywords(self):
+        from config import DIAGNOSTIC_THERAPY_ORDER, DIAGNOSTIC_THERAPY_KEYWORDS
+        assert set(DIAGNOSTIC_THERAPY_ORDER) == set(DIAGNOSTIC_THERAPY_KEYWORDS.keys())
+
+    def test_tissue_order_matches_mapping(self):
+        from config import TISSUE_CATEGORY_ORDER, CANCER_TYPE_TO_TISSUE
+        tissue_values = set(CANCER_TYPE_TO_TISSUE.values())
+        assert tissue_values.issubset(set(TISSUE_CATEGORY_ORDER))
+
+    def test_cancer_subtype_order_matches_keywords(self):
+        from config import CANCER_SUBTYPE_ORDER, CANCER_SUBTYPE_KEYWORDS
+        assert set(CANCER_SUBTYPE_ORDER) == set(CANCER_SUBTYPE_KEYWORDS.keys())
+
+    def test_all_mechanisms_have_keywords(self):
+        from config import MECHANISM_KEYWORDS
+        for mech, keywords in MECHANISM_KEYWORDS.items():
+            assert len(keywords) > 0, f"Mechanism {mech} has no keywords"
+
+    def test_diagnostic_therapy_chains_have_all_fields(self):
+        from config import DIAGNOSTIC_THERAPY_KEYWORDS
+        for chain_id, chain in DIAGNOSTIC_THERAPY_KEYWORDS.items():
+            assert "diagnostic" in chain, f"{chain_id} missing 'diagnostic'"
+            assert "feature" in chain, f"{chain_id} missing 'feature'"
+            assert "intervention" in chain, f"{chain_id} missing 'intervention'"
+
+
+# ============================================================
+# Corpus index tests
+# ============================================================
+
+class TestCorpusIndex:
+    @pytest.fixture
+    def index_entries(self):
+        if not CORPUS_INDEX.exists():
+            pytest.skip("INDEX.jsonl not found")
+        entries = []
+        with open(CORPUS_INDEX) as f:
+            for line in f:
+                entries.append(json.loads(line))
+        return entries
+
+    def test_index_is_nonempty(self, index_entries):
+        assert len(index_entries) > 4000, f"Expected 4000+ entries, got {len(index_entries)}"
+
+    def test_index_has_required_fields(self, index_entries):
+        required = {"pmid", "title", "mechanisms", "cancer_types", "evidence_level"}
+        sample = index_entries[0]
+        for field in required:
+            assert field in sample, f"Missing field: {field}"
+
+    def test_index_has_diagnostic_therapy_field(self, index_entries):
+        # At least some entries should have the new field
+        with_links = [e for e in index_entries if e.get("diagnostic_therapy_links")]
+        assert len(with_links) > 50, f"Expected 50+ entries with diagnostic_therapy_links, got {len(with_links)}"
+
+    def test_index_has_tissue_categories(self, index_entries):
+        with_tissue = [e for e in index_entries if e.get("tissue_categories")]
+        assert len(with_tissue) > 2000, f"Expected 2000+ entries with tissue_categories, got {len(with_tissue)}"
+
+
+# ============================================================
+# Analysis output tests
+# ============================================================
+
+class TestAnalysisOutputs:
+    EXPECTED_OUTPUTS = [
+        "mechanism-matrix.md",
+        "convergence-map.md",
+        "evidence-tiers.md",
+        "gap-analysis.md",
+        "evidence-coverage-audit.md",
+        "tissue-mechanism-summary.md",
+        "tissue-evidence-summary.md",
+        "weighted-evidence-summary.md",
+        "diagnostic-therapy-audit.md",
+        "sarcoma-subtype-audit.md",
+        "pathway-target-audit.md",
+        "radioligand-audit.md",
+        "designed-combinations.md",
+    ]
+
+    @pytest.mark.parametrize("filename", EXPECTED_OUTPUTS)
+    def test_analysis_output_exists_and_nonempty(self, filename):
+        path = ANALYSIS_DIR / filename
+        if not path.exists():
+            pytest.skip(f"{filename} not found")
+        content = path.read_text()
+        assert len(content) > 100, f"{filename} is too small ({len(content)} chars)"
+
+    def test_evidence_gold_eval_exists(self):
+        path = ANALYSIS_DIR / "evidence-gold-eval.md"
+        if not path.exists():
+            pytest.skip("evidence-gold-eval.md not found")
+        content = path.read_text()
+        assert "46/100" in content or "46.0%" in content, "Gold-set eval should report 46% accuracy"
+
+
+# ============================================================
+# Matching function tests
+# ============================================================
+
+class TestMatchingFunctions:
+    def test_match_keywords_basic(self):
+        from tag_articles import match_keywords
+        from config import MECHANISM_KEYWORDS
+        text = "this paper describes immunotherapy with checkpoint inhibitors for breast cancer treatment"
+        matches = match_keywords(text, MECHANISM_KEYWORDS)
+        assert "immunotherapy" in matches
+
+    def test_match_diagnostic_therapy_requires_intervention(self):
+        from tag_articles import match_diagnostic_therapy_links
+        # Only diagnostic language, no intervention — should NOT match
+        text = "pd-l1 immunohistochemistry showed high pd-l1 expression in the tumor"
+        matches = match_diagnostic_therapy_links(text)
+        assert len(matches) == 0, "Should not match without intervention keyword"
+
+    def test_match_diagnostic_therapy_with_intervention(self):
+        from tag_articles import match_diagnostic_therapy_links
+        # Diagnostic + intervention — should match
+        text = "pd-l1 ihc showed high expression and the patient received pembrolizumab"
+        matches = match_diagnostic_therapy_links(text)
+        assert "pdl1-ihc-to-checkpoint" in matches
+
+    def test_normalize_text(self):
+        from evidence_utils import normalize_text
+        result = normalize_text("  Hello   World  ")
+        assert result == "hello world"


### PR DESCRIPTION
Closes #64
Closes #65

## Summary
Integrates three simulation result sets into the manuscript and adds Python pipeline smoke tests.

## Manuscript changes (v1.md + v1.tex)

Three insertions in the simulation Discussion (Section 4.3), reflected in both Markdown and LaTeX:

**1. Calibration reference** (model limitations paragraph): Notes that all ~30 parameters are documented with sources, and 5 calibration targets are evaluated (3 independent, 2 self-consistency).

**2. Drug penetration** (after spatial simulation): RSL3-like drug kill drops from 40% in 2D culture to vessel-wall rates of 12.1% (well-vascularized), 2.6% (poorly-vascularized), 1.8% (CNS/BBB), with overall tumor kill even lower (6.6%, 2.1%, 1.5%). Explicit caveat that transport parameters are estimated.

**3. Combination synergy** (new Section 4.3.3): RSL3 + FSP1i = 1.99x Bliss synergy from dual-pathway depletion. Pathway traces: LP reaches 8.7 in combo vs 4.5 for RSL3 alone. Drug potency caveats included.

## Python smoke tests (33 tests)

| Category | Tests | What they catch |
|----------|-------|----------------|
| Import tests | 6 | Missing imports, syntax errors in all pipeline modules |
| Config consistency | 5 | Order lists vs keyword dicts, chains missing fields |
| Corpus index | 4 | Missing INDEX.jsonl fields, empty diagnostic-therapy/tissue tags (skips if INDEX.jsonl absent) |
| Analysis outputs | 14 | Missing or empty analysis markdown files (fails on missing, not skips) |
| Matching functions | 4 | Broken keyword matching, diagnostic-therapy intervention requirement |

## Verification
```bash
python -m pytest tests/test_pipeline_smoke.py -v   # 33/33 pass
python scripts/generate_latex.py                     # v1.tex regenerated
```

Generated with [Claude Code](https://claude.com/claude-code)