### PR TITLE
Add Python bindings for ferroptosis-core

### DIFF
--- a/simulations/Cargo.toml
+++ b/simulations/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "sim-invivo",
     "sim-tissue-pk",
     "sim-combo-mech",
+    "ferroptosis-python",
 ]
 resolver = "2"
 

--- a/simulations/ferroptosis-python/Cargo.toml
+++ b/simulations/ferroptosis-python/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "ferroptosis-python"
+version = "0.1.0"
+edition = "2021"
+description = "Python bindings for the ferroptosis-core biochemistry engine"
+license = "MIT"
+
+[lib]
+name = "ferroptosis_core"
+crate-type = ["cdylib"]
+
+[dependencies]
+ferroptosis-core = { path = "../ferroptosis-core" }
+pyo3 = { version = "0.23", features = ["extension-module"] }
+rand = "0.8"
+rayon = "1.10"

--- a/simulations/ferroptosis-python/src/lib.rs
+++ b/simulations/ferroptosis-python/src/lib.rs
@@ -1,0 +1,252 @@
+//! Python bindings for ferroptosis-core.
+//!
+//! Exposes a functional, dict-based API designed for Python researchers.
+//! No classes to learn — just functions that take strings and keyword
+//! arguments, returning dicts.
+//!
+//! ```python
+//! import ferroptosis_core as fc
+//!
+//! stats = fc.sim_batch("Persister", "RSL3", n=1000, seed=42)
+//! print(f"Death rate: {stats['death_rate']:.1%}")
+//! ```
+
+use std::collections::HashMap;
+
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+use rand::prelude::*;
+use rayon::prelude::*;
+
+use ::ferroptosis_core::biochem::sim_cell as rust_sim_cell;
+use ::ferroptosis_core::cell::{gen_cell, Phenotype, Treatment};
+use ::ferroptosis_core::params::Params;
+use ::ferroptosis_core::stats::wilson_ci;
+
+// ============================================================
+// Enum parsing
+// ============================================================
+
+fn parse_phenotype(s: &str) -> PyResult<Phenotype> {
+    match s {
+        "Glycolytic" => Ok(Phenotype::Glycolytic),
+        "OXPHOS" => Ok(Phenotype::OXPHOS),
+        "Persister" => Ok(Phenotype::Persister),
+        "PersisterNrf2" | "Persister+NRF2" => Ok(Phenotype::PersisterNrf2),
+        "Stromal" => Ok(Phenotype::Stromal),
+        _ => Err(PyValueError::new_err(format!(
+            "Unknown phenotype '{}'. Valid: Glycolytic, OXPHOS, Persister, PersisterNrf2, Stromal",
+            s
+        ))),
+    }
+}
+
+fn parse_treatment(s: &str) -> PyResult<Treatment> {
+    match s {
+        "Control" => Ok(Treatment::Control),
+        "RSL3" => Ok(Treatment::RSL3),
+        "SDT" => Ok(Treatment::SDT),
+        "PDT" => Ok(Treatment::PDT),
+        _ => Err(PyValueError::new_err(format!(
+            "Unknown treatment '{}'. Valid: Control, RSL3, SDT, PDT",
+            s
+        ))),
+    }
+}
+
+// ============================================================
+// Params helpers
+// ============================================================
+
+fn params_to_dict(py: Python<'_>, params: &Params) -> PyResult<Py<PyDict>> {
+    let dict = PyDict::new(py);
+    dict.set_item("fenton_rate", params.fenton_rate)?;
+    dict.set_item("gsh_scav_efficiency", params.gsh_scav_efficiency)?;
+    dict.set_item("gsh_km", params.gsh_km)?;
+    dict.set_item("nrf2_gsh_rate", params.nrf2_gsh_rate)?;
+    dict.set_item("lp_rate", params.lp_rate)?;
+    dict.set_item("lp_propagation", params.lp_propagation)?;
+    dict.set_item("gpx4_rate", params.gpx4_rate)?;
+    dict.set_item("fsp1_rate", params.fsp1_rate)?;
+    dict.set_item("scd_mufa_rate", params.scd_mufa_rate)?;
+    dict.set_item("scd_mufa_max", params.scd_mufa_max)?;
+    dict.set_item("initial_mufa_protection", params.initial_mufa_protection)?;
+    dict.set_item("scd_mufa_decay", params.scd_mufa_decay)?;
+    dict.set_item("gpx4_degradation_by_ros", params.gpx4_degradation_by_ros)?;
+    dict.set_item("gpx4_nrf2_upregulation", params.gpx4_nrf2_upregulation)?;
+    dict.set_item("sdt_ros", params.sdt_ros)?;
+    dict.set_item("pdt_ros", params.pdt_ros)?;
+    dict.set_item("rsl3_gpx4_inhib", params.rsl3_gpx4_inhib)?;
+    dict.set_item("gsh_max", params.gsh_max)?;
+    dict.set_item("gpx4_nrf2_target_multiplier", params.gpx4_nrf2_target_multiplier)?;
+    dict.set_item("death_threshold", params.death_threshold)?;
+    Ok(dict.into())
+}
+
+fn apply_overrides(params: &mut Params, overrides: &HashMap<String, f64>) -> PyResult<()> {
+    for (key, val) in overrides {
+        match key.as_str() {
+            "fenton_rate" => params.fenton_rate = *val,
+            "gsh_scav_efficiency" => params.gsh_scav_efficiency = *val,
+            "gsh_km" => params.gsh_km = *val,
+            "nrf2_gsh_rate" => params.nrf2_gsh_rate = *val,
+            "lp_rate" => params.lp_rate = *val,
+            "lp_propagation" => params.lp_propagation = *val,
+            "gpx4_rate" => params.gpx4_rate = *val,
+            "fsp1_rate" => params.fsp1_rate = *val,
+            "scd_mufa_rate" => params.scd_mufa_rate = *val,
+            "scd_mufa_max" => params.scd_mufa_max = *val,
+            "initial_mufa_protection" => params.initial_mufa_protection = *val,
+            "scd_mufa_decay" => params.scd_mufa_decay = *val,
+            "gpx4_degradation_by_ros" => params.gpx4_degradation_by_ros = *val,
+            "gpx4_nrf2_upregulation" => params.gpx4_nrf2_upregulation = *val,
+            "sdt_ros" => params.sdt_ros = *val,
+            "pdt_ros" => params.pdt_ros = *val,
+            "rsl3_gpx4_inhib" => params.rsl3_gpx4_inhib = *val,
+            "gsh_max" => params.gsh_max = *val,
+            "gpx4_nrf2_target_multiplier" => params.gpx4_nrf2_target_multiplier = *val,
+            "death_threshold" => params.death_threshold = *val,
+            _ => {
+                return Err(PyValueError::new_err(format!(
+                    "Unknown parameter '{}'. Use default_params() to see valid names.",
+                    key
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+// ============================================================
+// Python API
+// ============================================================
+
+/// Return default parameter values as a dict.
+#[pyfunction]
+fn default_params(py: Python<'_>) -> PyResult<Py<PyDict>> {
+    params_to_dict(py, &Params::default())
+}
+
+/// Return in-vivo parameter values (with SCD1/MUFA protection) as a dict.
+#[pyfunction]
+fn invivo_params(py: Python<'_>) -> PyResult<Py<PyDict>> {
+    params_to_dict(py, &Params::invivo())
+}
+
+/// Simulate a single cell and return the outcome as a dict.
+///
+/// Args:
+///     phenotype: "Glycolytic", "OXPHOS", "Persister", "PersisterNrf2", or "Stromal"
+///     treatment: "Control", "RSL3", "SDT", or "PDT"
+///     seed: RNG seed for reproducibility
+///     **kwargs: parameter overrides (e.g., rsl3_gpx4_inhib=0.5)
+///
+/// Returns:
+///     dict with keys: dead (bool), lp, gsh, gpx4 (floats)
+#[pyfunction]
+#[pyo3(signature = (phenotype, treatment, seed, **kwargs))]
+fn sim_cell(
+    py: Python<'_>,
+    phenotype: &str,
+    treatment: &str,
+    seed: u64,
+    kwargs: Option<HashMap<String, f64>>,
+) -> PyResult<Py<PyDict>> {
+    let pheno = parse_phenotype(phenotype)?;
+    let tx = parse_treatment(treatment)?;
+    let mut params = Params::default();
+    if let Some(overrides) = &kwargs {
+        apply_overrides(&mut params, overrides)?;
+    }
+
+    let mut cell_rng = StdRng::seed_from_u64(seed);
+    let cell = gen_cell(pheno, &mut cell_rng);
+    let mut sim_rng = StdRng::seed_from_u64(seed.wrapping_add(1));
+    let (dead, lp, gsh, gpx4) = rust_sim_cell(&cell, tx, &params, &mut sim_rng);
+
+    let dict = PyDict::new(py);
+    dict.set_item("dead", dead)?;
+    dict.set_item("lp", lp)?;
+    dict.set_item("gsh", gsh)?;
+    dict.set_item("gpx4", gpx4)?;
+    Ok(dict.into())
+}
+
+/// Simulate a population of cells and return aggregate statistics.
+///
+/// Runs n cells in parallel (via rayon) and returns death rate with
+/// Wilson confidence intervals and mean final pathway states.
+///
+/// Args:
+///     phenotype: "Glycolytic", "OXPHOS", "Persister", "PersisterNrf2", or "Stromal"
+///     treatment: "Control", "RSL3", "SDT", or "PDT"
+///     n: number of cells to simulate
+///     seed: RNG seed for reproducibility
+///     **kwargs: parameter overrides (e.g., rsl3_gpx4_inhib=0.5)
+///
+/// Returns:
+///     dict with keys: death_rate, ci_low, ci_high, n_dead, n_cells,
+///                     mean_lp, mean_gsh, mean_gpx4
+#[pyfunction]
+#[pyo3(signature = (phenotype, treatment, n, seed, **kwargs))]
+fn sim_batch(
+    py: Python<'_>,
+    phenotype: &str,
+    treatment: &str,
+    n: usize,
+    seed: u64,
+    kwargs: Option<HashMap<String, f64>>,
+) -> PyResult<Py<PyDict>> {
+    let pheno = parse_phenotype(phenotype)?;
+    let tx = parse_treatment(treatment)?;
+    let mut params = Params::default();
+    if let Some(overrides) = &kwargs {
+        apply_overrides(&mut params, overrides)?;
+    }
+
+    // Run in parallel, releasing the GIL so Python threads aren't blocked
+    let results: Vec<(bool, f64, f64, f64)> = py.allow_threads(|| {
+        (0..n)
+            .into_par_iter()
+            .map(|i| {
+                let cell_seed = seed.wrapping_add((i as u64) * 2);
+                let mut cell_rng = StdRng::seed_from_u64(cell_seed);
+                let cell = gen_cell(pheno, &mut cell_rng);
+                let mut sim_rng = StdRng::seed_from_u64(cell_seed.wrapping_add(1));
+                rust_sim_cell(&cell, tx, &params, &mut sim_rng)
+            })
+            .collect()
+    });
+
+    let n_dead = results.iter().filter(|(dead, _, _, _)| *dead).count();
+    let death_rate = n_dead as f64 / n as f64;
+    let (ci_low, ci_high) = wilson_ci(n, n_dead);
+    let mean_lp = results.iter().map(|(_, lp, _, _)| lp).sum::<f64>() / n as f64;
+    let mean_gsh = results.iter().map(|(_, _, gsh, _)| gsh).sum::<f64>() / n as f64;
+    let mean_gpx4 = results.iter().map(|(_, _, _, gpx4)| gpx4).sum::<f64>() / n as f64;
+
+    let dict = PyDict::new(py);
+    dict.set_item("death_rate", death_rate)?;
+    dict.set_item("ci_low", ci_low)?;
+    dict.set_item("ci_high", ci_high)?;
+    dict.set_item("n_dead", n_dead)?;
+    dict.set_item("n_cells", n)?;
+    dict.set_item("mean_lp", mean_lp)?;
+    dict.set_item("mean_gsh", mean_gsh)?;
+    dict.set_item("mean_gpx4", mean_gpx4)?;
+    Ok(dict.into())
+}
+
+// ============================================================
+// Module registration
+// ============================================================
+
+#[pymodule]
+fn ferroptosis_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(default_params, m)?)?;
+    m.add_function(wrap_pyfunction!(invivo_params, m)?)?;
+    m.add_function(wrap_pyfunction!(sim_cell, m)?)?;
+    m.add_function(wrap_pyfunction!(sim_batch, m)?)?;
+    Ok(())
+}

--- a/simulations/ferroptosis-python/src/lib.rs
+++ b/simulations/ferroptosis-python/src/lib.rs
@@ -109,8 +109,13 @@ fn validate_params(params: &Params) -> PyResult<()> {
         ("death_threshold", params.death_threshold, 0.0, 1000.0),
         ("sdt_ros", params.sdt_ros, 0.0, 100.0),
         ("pdt_ros", params.pdt_ros, 0.0, 100.0),
+        ("nrf2_gsh_rate", params.nrf2_gsh_rate, 0.0, 10.0),
+        ("gpx4_degradation_by_ros", params.gpx4_degradation_by_ros, 0.0, 1.0),
+        ("gpx4_nrf2_upregulation", params.gpx4_nrf2_upregulation, 0.0, 1.0),
+        ("gpx4_nrf2_target_multiplier", params.gpx4_nrf2_target_multiplier, 0.0, 100.0),
         ("scd_mufa_rate", params.scd_mufa_rate, 0.0, 1.0),
         ("scd_mufa_max", params.scd_mufa_max, 0.0, 1.0),
+        ("scd_mufa_decay", params.scd_mufa_decay, 0.0, 1.0),
         ("initial_mufa_protection", params.initial_mufa_protection, 0.0, 1.0),
     ];
     for (name, val, lo, hi) in checks {

--- a/simulations/ferroptosis-python/src/lib.rs
+++ b/simulations/ferroptosis-python/src/lib.rs
@@ -55,6 +55,17 @@ fn parse_treatment(s: &str) -> PyResult<Treatment> {
     }
 }
 
+fn parse_context(s: &str) -> PyResult<Params> {
+    match s {
+        "2d" | "default" => Ok(Params::default()),
+        "invivo" | "in-vivo" | "in_vivo" => Ok(Params::invivo()),
+        _ => Err(PyValueError::new_err(format!(
+            "Unknown context '{}'. Valid: 2d, invivo",
+            s
+        ))),
+    }
+}
+
 // ============================================================
 // Params helpers
 // ============================================================
@@ -140,22 +151,24 @@ fn invivo_params(py: Python<'_>) -> PyResult<Py<PyDict>> {
 ///     phenotype: "Glycolytic", "OXPHOS", "Persister", "PersisterNrf2", or "Stromal"
 ///     treatment: "Control", "RSL3", "SDT", or "PDT"
 ///     seed: RNG seed for reproducibility
+///     context: "2d" (default) or "invivo" (enables SCD1/MUFA protection)
 ///     **kwargs: parameter overrides (e.g., rsl3_gpx4_inhib=0.5)
 ///
 /// Returns:
 ///     dict with keys: dead (bool), lp, gsh, gpx4 (floats)
 #[pyfunction]
-#[pyo3(signature = (phenotype, treatment, seed, **kwargs))]
+#[pyo3(signature = (phenotype, treatment, seed, context="2d", **kwargs))]
 fn sim_cell(
     py: Python<'_>,
     phenotype: &str,
     treatment: &str,
     seed: u64,
+    context: &str,
     kwargs: Option<HashMap<String, f64>>,
 ) -> PyResult<Py<PyDict>> {
     let pheno = parse_phenotype(phenotype)?;
     let tx = parse_treatment(treatment)?;
-    let mut params = Params::default();
+    let mut params = parse_context(context)?;
     if let Some(overrides) = &kwargs {
         apply_overrides(&mut params, overrides)?;
     }
@@ -183,24 +196,29 @@ fn sim_cell(
 ///     treatment: "Control", "RSL3", "SDT", or "PDT"
 ///     n: number of cells to simulate
 ///     seed: RNG seed for reproducibility
+///     context: "2d" (default) or "invivo" (enables SCD1/MUFA protection)
 ///     **kwargs: parameter overrides (e.g., rsl3_gpx4_inhib=0.5)
 ///
 /// Returns:
 ///     dict with keys: death_rate, ci_low, ci_high, n_dead, n_cells,
 ///                     mean_lp, mean_gsh, mean_gpx4
 #[pyfunction]
-#[pyo3(signature = (phenotype, treatment, n, seed, **kwargs))]
+#[pyo3(signature = (phenotype, treatment, n, seed, context="2d", **kwargs))]
 fn sim_batch(
     py: Python<'_>,
     phenotype: &str,
     treatment: &str,
     n: usize,
     seed: u64,
+    context: &str,
     kwargs: Option<HashMap<String, f64>>,
 ) -> PyResult<Py<PyDict>> {
     let pheno = parse_phenotype(phenotype)?;
     let tx = parse_treatment(treatment)?;
-    let mut params = Params::default();
+    if n == 0 {
+        return Err(PyValueError::new_err("n must be > 0"));
+    }
+    let mut params = parse_context(context)?;
     if let Some(overrides) = &kwargs {
         apply_overrides(&mut params, overrides)?;
     }

--- a/simulations/ferroptosis-python/src/lib.rs
+++ b/simulations/ferroptosis-python/src/lib.rs
@@ -95,6 +95,35 @@ fn params_to_dict(py: Python<'_>, params: &Params) -> PyResult<Py<PyDict>> {
     Ok(dict.into())
 }
 
+fn validate_params(params: &Params) -> PyResult<()> {
+    let checks: &[(&str, f64, f64, f64)] = &[
+        ("fenton_rate", params.fenton_rate, 0.0, 10.0),
+        ("gsh_scav_efficiency", params.gsh_scav_efficiency, 0.0, 1.0),
+        ("gsh_km", params.gsh_km, 0.0, 100.0),
+        ("lp_rate", params.lp_rate, 0.0, 10.0),
+        ("lp_propagation", params.lp_propagation, 0.0, 10.0),
+        ("gpx4_rate", params.gpx4_rate, 0.0, 10.0),
+        ("fsp1_rate", params.fsp1_rate, 0.0, 10.0),
+        ("rsl3_gpx4_inhib", params.rsl3_gpx4_inhib, 0.0, 1.0),
+        ("gsh_max", params.gsh_max, 0.0, 100.0),
+        ("death_threshold", params.death_threshold, 0.0, 1000.0),
+        ("sdt_ros", params.sdt_ros, 0.0, 100.0),
+        ("pdt_ros", params.pdt_ros, 0.0, 100.0),
+        ("scd_mufa_rate", params.scd_mufa_rate, 0.0, 1.0),
+        ("scd_mufa_max", params.scd_mufa_max, 0.0, 1.0),
+        ("initial_mufa_protection", params.initial_mufa_protection, 0.0, 1.0),
+    ];
+    for (name, val, lo, hi) in checks {
+        if *val < *lo || *val > *hi {
+            return Err(PyValueError::new_err(format!(
+                "Parameter '{}' = {} is out of range [{}, {}]",
+                name, val, lo, hi
+            )));
+        }
+    }
+    Ok(())
+}
+
 fn apply_overrides(params: &mut Params, overrides: &HashMap<String, f64>) -> PyResult<()> {
     for (key, val) in overrides {
         match key.as_str() {
@@ -172,6 +201,7 @@ fn sim_cell(
     if let Some(overrides) = &kwargs {
         apply_overrides(&mut params, overrides)?;
     }
+    validate_params(&params)?;
 
     let mut cell_rng = StdRng::seed_from_u64(seed);
     let cell = gen_cell(pheno, &mut cell_rng);
@@ -222,27 +252,35 @@ fn sim_batch(
     if let Some(overrides) = &kwargs {
         apply_overrides(&mut params, overrides)?;
     }
+    validate_params(&params)?;
 
-    // Run in parallel, releasing the GIL so Python threads aren't blocked
-    let results: Vec<(bool, f64, f64, f64)> = py.allow_threads(|| {
+    // Parallel fold/reduce — O(1) memory per thread, no Vec<> allocation.
+    let (n_dead, sum_lp, sum_gsh, sum_gpx4) = py.allow_threads(|| {
         (0..n)
             .into_par_iter()
-            .map(|i| {
-                let cell_seed = seed.wrapping_add((i as u64) * 2);
-                let mut cell_rng = StdRng::seed_from_u64(cell_seed);
-                let cell = gen_cell(pheno, &mut cell_rng);
-                let mut sim_rng = StdRng::seed_from_u64(cell_seed.wrapping_add(1));
-                rust_sim_cell(&cell, tx, &params, &mut sim_rng)
-            })
-            .collect()
+            .fold(
+                || (0usize, 0.0f64, 0.0f64, 0.0f64),
+                |(dead, lp, gsh, gpx4), i| {
+                    let cell_seed = seed.wrapping_add((i as u64) * 2);
+                    let mut cell_rng = StdRng::seed_from_u64(cell_seed);
+                    let cell = gen_cell(pheno, &mut cell_rng);
+                    let mut sim_rng = StdRng::seed_from_u64(cell_seed.wrapping_add(1));
+                    let (d, l, g, p) = rust_sim_cell(&cell, tx, &params, &mut sim_rng);
+                    (dead + d as usize, lp + l, gsh + g, gpx4 + p)
+                },
+            )
+            .reduce(
+                || (0, 0.0, 0.0, 0.0),
+                |(d1, l1, g1, p1), (d2, l2, g2, p2)| (d1 + d2, l1 + l2, g1 + g2, p1 + p2),
+            )
     });
 
-    let n_dead = results.iter().filter(|(dead, _, _, _)| *dead).count();
-    let death_rate = n_dead as f64 / n as f64;
+    let nf = n as f64;
+    let death_rate = n_dead as f64 / nf;
     let (ci_low, ci_high) = wilson_ci(n, n_dead);
-    let mean_lp = results.iter().map(|(_, lp, _, _)| lp).sum::<f64>() / n as f64;
-    let mean_gsh = results.iter().map(|(_, _, gsh, _)| gsh).sum::<f64>() / n as f64;
-    let mean_gpx4 = results.iter().map(|(_, _, _, gpx4)| gpx4).sum::<f64>() / n as f64;
+    let mean_lp = sum_lp / nf;
+    let mean_gsh = sum_gsh / nf;
+    let mean_gpx4 = sum_gpx4 / nf;
 
     let dict = PyDict::new(py);
     dict.set_item("death_rate", death_rate)?;

--- a/simulations/ferroptosis-python/test_bindings.py
+++ b/simulations/ferroptosis-python/test_bindings.py
@@ -1,0 +1,109 @@
+"""
+Test Python bindings for ferroptosis-core.
+
+Run: python test_bindings.py
+Or:  pytest test_bindings.py -v
+"""
+
+import ferroptosis_core as fc
+
+
+def test_default_params():
+    params = fc.default_params()
+    assert isinstance(params, dict)
+    assert len(params) == 20
+    assert params["death_threshold"] == 10.0
+    assert params["rsl3_gpx4_inhib"] == 0.92
+    assert params["fenton_rate"] == 0.02
+
+
+def test_invivo_params():
+    params = fc.invivo_params()
+    assert params["scd_mufa_rate"] > 0
+    assert params["initial_mufa_protection"] > 0.3
+
+
+def test_sim_cell_returns_dict():
+    result = fc.sim_cell("Persister", "RSL3", seed=42)
+    assert isinstance(result, dict)
+    assert "dead" in result
+    assert "lp" in result
+    assert "gsh" in result
+    assert "gpx4" in result
+    assert isinstance(result["dead"], bool)
+    assert isinstance(result["lp"], float)
+
+
+def test_sim_cell_determinism():
+    r1 = fc.sim_cell("Persister", "RSL3", seed=42)
+    r2 = fc.sim_cell("Persister", "RSL3", seed=42)
+    assert r1 == r2, "Same seed should produce identical results"
+
+
+def test_sim_cell_different_seeds():
+    r1 = fc.sim_cell("Persister", "RSL3", seed=42)
+    r2 = fc.sim_cell("Persister", "RSL3", seed=99)
+    # Different seeds should generally produce different lp values
+    # (not guaranteed but overwhelmingly likely)
+    assert r1["lp"] != r2["lp"], "Different seeds should produce different results"
+
+
+def test_sim_batch():
+    stats = fc.sim_batch("Persister", "RSL3", n=1000, seed=42)
+    assert isinstance(stats, dict)
+    assert 0.3 < stats["death_rate"] < 0.5, f"Expected ~40%, got {stats['death_rate']}"
+    assert stats["ci_low"] < stats["death_rate"] < stats["ci_high"]
+    assert stats["n_dead"] > 0
+    assert stats["n_cells"] == 1000
+    assert stats["mean_lp"] > 0
+    assert stats["mean_gsh"] > 0
+    assert stats["mean_gpx4"] > 0
+
+
+def test_sim_batch_param_override():
+    full = fc.sim_batch("Persister", "RSL3", n=1000, seed=42)
+    weak = fc.sim_batch("Persister", "RSL3", n=1000, seed=42, rsl3_gpx4_inhib=0.5)
+    assert weak["death_rate"] < full["death_rate"], "Weaker drug should kill fewer cells"
+
+
+def test_control_low_death_rate():
+    stats = fc.sim_batch("Glycolytic", "Control", n=1000, seed=42)
+    assert stats["death_rate"] < 0.05, f"Control should have very low death rate, got {stats['death_rate']}"
+
+
+def test_sdt_high_kill():
+    stats = fc.sim_batch("Persister", "SDT", n=1000, seed=42)
+    assert stats["death_rate"] > 0.95, f"SDT should kill most persisters, got {stats['death_rate']}"
+
+
+def test_bad_phenotype_raises():
+    try:
+        fc.sim_cell("InvalidPhenotype", "RSL3", seed=42)
+        assert False, "Should have raised ValueError"
+    except ValueError as e:
+        assert "InvalidPhenotype" in str(e)
+
+
+def test_bad_treatment_raises():
+    try:
+        fc.sim_cell("Persister", "BadTreatment", seed=42)
+        assert False, "Should have raised ValueError"
+    except ValueError as e:
+        assert "BadTreatment" in str(e)
+
+
+def test_bad_param_override_raises():
+    try:
+        fc.sim_cell("Persister", "RSL3", seed=42, nonexistent_param=1.0)
+        assert False, "Should have raised ValueError"
+    except ValueError as e:
+        assert "nonexistent_param" in str(e)
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in globals().items() if k.startswith("test_") and callable(v)]
+    for test in tests:
+        print(f"  {test.__name__}...", end=" ")
+        test()
+        print("PASS")
+    print(f"\n{len(tests)} tests passed")


### PR DESCRIPTION
Closes #59 (Python bindings — C FFI and crates.io are follow-up)

## Summary
Adds a Python extension module via PyO3 that lets researchers call ferroptosis simulations directly from Python. No Rust knowledge required to use.

## Design: functional API, not class wrappers

```python
import ferroptosis_core as fc

# Population simulation — runs N cells in parallel via rayon fold/reduce
stats = fc.sim_batch("Persister", "RSL3", n=1000, seed=42)
# → {"death_rate": 0.40, "ci_low": 0.37, "ci_high": 0.43, ...}

# In-vivo context (SCD1/MUFA protection)
stats = fc.sim_batch("Persister", "RSL3", n=1000, seed=42, context="invivo")

# Parameter sweep
for inhib in [0.5, 0.7, 0.9]:
    s = fc.sim_batch("Persister", "RSL3", n=1000, seed=42,
                     rsl3_gpx4_inhib=inhib)

# Single cell (for debugging)
result = fc.sim_cell("Persister", "RSL3", seed=42)

# Inspect defaults
fc.default_params()  # → dict of all 20 params
fc.invivo_params()   # → dict with SCD1/MUFA protection
```

## What changed (3 new files + 1 modified)
| File | Change |
|------|--------|
| `ferroptosis-python/Cargo.toml` | **New** — wrapper crate with PyO3 + rayon |
| `ferroptosis-python/src/lib.rs` | **New** — enum parsing, param validation, 4 Python functions with fold/reduce batch |
| `ferroptosis-python/test_bindings.py` | **New** — 12 tests |
| `simulations/Cargo.toml` | Add workspace member (1 line) |

## Key implementation details
- **O(1) memory batch**: `sim_batch` uses rayon `fold/reduce` accumulator, not `Vec` collection. Scales to millions of cells.
- **Input validation**: `validate_params()` checks bounded parameters (rates ≥ 0, inhibition ≤ 1, thresholds > 0) and raises `ValueError` with the parameter name, value, and valid range.
- **Context parameter**: `context="2d"` (default) or `context="invivo"` selects base params without manual kwargs.
- **GIL release**: `py.allow_threads()` around the rayon computation so Python threads are not blocked.

## Blast radius
Zero on ferroptosis-core and all existing binaries. Separate wrapper crate.

## Build and test
```bash
cd simulations
python -m venv .venv && source .venv/bin/activate
pip install maturin
maturin develop -m ferroptosis-python/Cargo.toml --release
python ferroptosis-python/test_bindings.py  # 12/12 pass
```

Generated with [Claude Code](https://claude.com/claude-code)