### PR TITLE
Add PyPI publishing for ferroptosis-core Python package

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -94,7 +94,7 @@ jobs:
 
   publish-testpypi:
     name: Publish to TestPyPI
-    needs: test-wheels
+    needs: [test-wheels, build-sdist]
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' && !inputs.publish_to_pypi
     steps:
@@ -112,7 +112,7 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    needs: test-wheels
+    needs: [test-wheels, build-sdist]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish_to_pypi)
     steps:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,128 @@
+name: Build & Publish Python Wheels
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish_to_pypi:
+        description: 'Publish to real PyPI (false = TestPyPI only)'
+        required: true
+        type: boolean
+        default: false
+  push:
+    tags:
+      - 'v*-python'
+
+permissions:
+  contents: read
+
+jobs:
+  build-wheels:
+    name: Build wheel (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - { os: ubuntu-latest,  target: x86_64-unknown-linux-gnu,  manylinux: auto }
+          - { os: ubuntu-latest,  target: aarch64-unknown-linux-gnu, manylinux: auto }
+          - { os: macos-13,       target: x86_64-apple-darwin }
+          - { os: macos-14,       target: aarch64-apple-darwin }
+          - { os: windows-latest, target: x86_64-pc-windows-msvc }
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - uses: PyO3/maturin-action@v1
+        with:
+          command: build
+          args: --release --strip --out dist --manifest-path simulations/ferroptosis-python/Cargo.toml
+          target: ${{ matrix.target }}
+          manylinux: ${{ matrix.manylinux || 'auto' }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.target }}
+          path: dist/*.whl
+
+  build-sdist:
+    name: Build sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist --manifest-path simulations/ferroptosis-python/Cargo.toml
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-sdist
+          path: dist/*.tar.gz
+
+  test-wheels:
+    name: Test wheel (${{ matrix.os }})
+    needs: build-wheels
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - { os: ubuntu-latest,  target: x86_64-unknown-linux-gnu }
+          - { os: macos-13,       target: x86_64-apple-darwin }
+          - { os: macos-14,       target: aarch64-apple-darwin }
+          - { os: windows-latest, target: x86_64-pc-windows-msvc }
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheels-${{ matrix.target }}
+          path: dist
+
+      - name: Install wheel and run tests
+        shell: bash
+        run: |
+          pip install dist/*.whl
+          pip install pytest
+          pytest simulations/ferroptosis-python/test_bindings.py -v
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: test-wheels
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && !inputs.publish_to_pypi
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          packages-dir: dist/
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: test-wheels
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish_to_pypi)
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages-dir: dist/

--- a/simulations/Cargo.lock
+++ b/simulations/Cargo.lock
@@ -176,6 +176,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ferroptosis-python"
+version = "0.1.0"
+dependencies = [
+ "ferroptosis-core",
+ "pyo3",
+ "rand",
+ "rayon",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,6 +201,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -231,6 +250,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "ndarray"
@@ -276,6 +304,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +346,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+dependencies = [
+ "cfg-if",
+ "indoc",
+ "libc",
+ "memoffset",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -390,6 +487,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,6 +554,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sim-combo-mech"
+version = "0.1.0"
+dependencies = [
+ "csv",
+ "ferroptosis-core",
+ "rand",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "sim-icd"
 version = "0.2.0"
 dependencies = [
@@ -496,6 +610,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "sim-tissue-pk"
+version = "0.1.0"
+dependencies = [
+ "csv",
+ "ferroptosis-core",
+ "rand",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "sim-tme"
+version = "0.1.0"
+dependencies = [
+ "csv",
+ "ferroptosis-core",
+ "ndarray",
+ "rand",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "sim-window"
 version = "0.2.0"
 dependencies = [
@@ -525,10 +662,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unindent"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "utf8parse"

--- a/simulations/ferroptosis-python/Cargo.toml
+++ b/simulations/ferroptosis-python/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 description = "Python bindings for the ferroptosis-core biochemistry engine"
 license = "MIT"
+repository = "https://github.com/ELares/cancer_research"
 
 [lib]
 name = "ferroptosis_core"

--- a/simulations/ferroptosis-python/README.md
+++ b/simulations/ferroptosis-python/README.md
@@ -1,0 +1,90 @@
+# ferroptosis-core
+
+Mechanistic ferroptosis cell death simulation engine for cancer research.
+
+Models the ferroptosis pathway from ROS generation through GSH depletion, GPX4/FSP1 repair, lipid peroxidation, and cell death. Built in Rust for speed, exposed to Python via PyO3. Simulates 10,000 cells in ~50ms.
+
+## Install
+
+```bash
+pip install ferroptosis-core
+```
+
+No Rust toolchain required — pre-built wheels are provided for Linux, macOS, and Windows.
+
+## Quick start
+
+```python
+import ferroptosis_core as fc
+
+# Single cell
+result = fc.sim_cell("Persister", "RSL3", seed=42)
+print(result)  # {'dead': True, 'lp': 10.56, 'gsh': 0.02, 'gpx4': 0.40}
+
+# Population (10,000 cells, parallel)
+stats = fc.sim_batch("Persister", "RSL3", n=10000, seed=42)
+print(f"Death rate: {stats['death_rate']:.1%}")  # ~40%
+```
+
+## API
+
+### `default_params() -> dict`
+
+Returns the 20 default biochemistry rate constants (2D culture context).
+
+### `invivo_params() -> dict`
+
+Returns parameters with SCD1/MUFA lipid remodeling enabled (in-vivo context).
+
+### `sim_cell(phenotype, treatment, seed, context="2d", **kwargs) -> dict`
+
+Simulate a single cell through 180 timesteps.
+
+**Returns:** `{'dead': bool, 'lp': float, 'gsh': float, 'gpx4': float}`
+
+### `sim_batch(phenotype, treatment, n, seed, context="2d", **kwargs) -> dict`
+
+Simulate `n` cells in parallel and return population statistics.
+
+**Returns:** `{'death_rate': float, 'ci_low': float, 'ci_high': float, 'n_dead': int, 'n_cells': int, 'mean_lp': float, 'mean_gsh': float, 'mean_gpx4': float}`
+
+## Phenotypes
+
+`"Glycolytic"`, `"OXPHOS"`, `"Persister"`, `"PersisterNrf2"`, `"Stromal"`
+
+## Treatments
+
+`"Control"`, `"RSL3"`, `"SDT"`, `"PDT"`
+
+## Contexts
+
+- `"2d"` (default) — standard 2D culture parameters
+- `"invivo"` — SCD1/MUFA lipid remodeling enabled
+
+## Parameter overrides
+
+Any of the 20 biochemistry parameters can be overridden via keyword arguments:
+
+```python
+# Sweep GPX4 inhibition strength
+for inhib in [0.0, 0.25, 0.5, 0.75, 1.0]:
+    stats = fc.sim_batch("Persister", "RSL3", n=1000, seed=42,
+                         rsl3_gpx4_inhib=inhib)
+    print(f"inhib={inhib:.2f}  death_rate={stats['death_rate']:.1%}")
+```
+
+Use `fc.default_params()` to see all available parameters and their default values.
+
+## Performance
+
+`sim_batch` uses Rayon for parallel execution across all available CPU cores. The GIL is released during simulation, so Python threads are not blocked.
+
+## Part of the Cancer Research Synthesis project
+
+This package is the simulation engine from an open cancer research repository that combines cross-literature analysis of 4,830 research articles with Monte Carlo biochemical simulations.
+
+Full repository: https://github.com/ELares/cancer_research
+
+## License
+
+MIT

--- a/simulations/ferroptosis-python/README.md
+++ b/simulations/ferroptosis-python/README.md
@@ -18,12 +18,12 @@ No Rust toolchain required — pre-built wheels are provided for Linux, macOS, a
 import ferroptosis_core as fc
 
 # Single cell
-result = fc.sim_cell("Persister", "RSL3", seed=42)
-print(result)  # {'dead': True, 'lp': 10.56, 'gsh': 0.02, 'gpx4': 0.40}
+result = fc.sim_cell("Persister", "RSL3", seed=1)
+print(result)  # {'dead': True, 'lp': 10.34, 'gsh': 2.69, 'gpx4': 0.40}
 
 # Population (10,000 cells, parallel)
 stats = fc.sim_batch("Persister", "RSL3", n=10000, seed=42)
-print(f"Death rate: {stats['death_rate']:.1%}")  # ~40%
+print(f"Death rate: {stats['death_rate']:.1%}")  # 42.3%
 ```
 
 ## API

--- a/simulations/ferroptosis-python/pyproject.toml
+++ b/simulations/ferroptosis-python/pyproject.toml
@@ -1,0 +1,37 @@
+[build-system]
+requires = ["maturin>=1.7,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "ferroptosis-core"
+version = "0.1.0"
+description = "Mechanistic ferroptosis simulation engine for cancer research"
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.9"
+authors = [{ name = "Ezequiel Lares" }]
+keywords = ["ferroptosis", "cancer", "simulation", "biochemistry", "cell-death"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+]
+
+[project.urls]
+Repository = "https://github.com/ELares/cancer_research"
+Issues = "https://github.com/ELares/cancer_research/issues"
+
+[tool.maturin]
+features = ["pyo3/extension-module"]
+module-name = "ferroptosis_core"
+include = [
+    { path = "../ferroptosis-core/**/*", format = "sdist" },
+]

--- a/simulations/ferroptosis-python/pyproject.toml
+++ b/simulations/ferroptosis-python/pyproject.toml
@@ -32,6 +32,3 @@ Issues = "https://github.com/ELares/cancer_research/issues"
 [tool.maturin]
 features = ["pyo3/extension-module"]
 module-name = "ferroptosis_core"
-include = [
-    { path = "../ferroptosis-core/**/*", format = "sdist" },
-]


### PR DESCRIPTION
## Summary
Adds the infrastructure to publish pre-built wheels to PyPI so researchers can `pip install ferroptosis-core` without a Rust toolchain.

## What's new
| File | Purpose |
|------|---------|
| `simulations/ferroptosis-python/pyproject.toml` | maturin build config + PyPI metadata |
| `simulations/ferroptosis-python/README.md` | PyPI page: quick start, API reference, valid enums |
| `.github/workflows/pypi-publish.yml` | Cross-platform CI: build, test, publish |
| `simulations/ferroptosis-python/Cargo.toml` | Added `repository` field |
| `simulations/Cargo.lock` | Now includes pyo3 deps (previously missing) |

## CI workflow structure
```
build-wheels (5 targets: linux x64/arm64, macOS x64/arm64, Windows x64)
  -> test-wheels (4 targets: install wheel + pytest 12 tests)
build-sdist (ubuntu)
  -> [both feed into publish jobs]
    -> publish-testpypi (workflow_dispatch, default)
    -> publish-pypi (tag push v*-python, or workflow_dispatch opt-in)
```

Publish jobs depend on BOTH test-wheels AND build-sdist, ensuring the full artifact set (wheels + sdist) is present before any upload.

## Triggers
- **Manual dispatch**: `workflow_dispatch` with `publish_to_pypi` boolean. Default (false) publishes to TestPyPI for verification.
- **Tag push**: `v*-python` tags (e.g., `v0.1.0-python`) publish to real PyPI.

## Prerequisites
- [x] `PYPI_API_TOKEN` added as GitHub repository secret
- [x] `TEST_PYPI_API_TOKEN` added as GitHub repository secret

## Key design decisions
- **Python >=3.9** (3.8 is EOL since Oct 2024)
- **Independent versioning**: Python package 0.1.0, ferroptosis-core Rust 0.2.0
- **sdist bundling**: maturin automatically detects workspace path dependencies and includes ferroptosis-core source in the sdist (no explicit include directive needed)
- **Test before publish**: wheels are installed and tested on 4 platforms before any upload
- **Windows compatibility**: all test steps use `shell: bash` to avoid PowerShell glob issues

## Blast radius
Zero changes to ferroptosis-core library, existing CI workflows, or any simulation binary. All new files except one metadata field in Cargo.toml.

## Test plan
- [x] `cargo check -p ferroptosis-python` compiles clean
- [x] `cargo test --workspace` — 19 tests pass, all members compile
- [x] `maturin sdist` builds and includes ferroptosis-core source
- [x] `maturin build --release` produces working wheel
- [x] 12 tests pass against installed wheel
- [x] README example output verified against actual sim_cell/sim_batch results
- [ ] Trigger workflow_dispatch -> wheels build on all 5 platforms (post-merge)
- [ ] TestPyPI upload succeeds (post-merge)
- [ ] `pip install ferroptosis-core` works on clean Python without Rust

Closes #69