### PR TITLE
Add CAF-mediated stromal protection to TME simulation

### DIFF
--- a/simulations/sim-tme/src/main.rs
+++ b/simulations/sim-tme/src/main.rs
@@ -244,7 +244,81 @@ impl ImmuneConfig {
     }
 }
 
+// ============================================================
+// Stromal protection (Feature C)
+// ============================================================
+
+/// Parameters for CAF-mediated protection of stromal-adjacent tumor cells.
+/// Biology: cancer-associated fibroblasts (CAFs) supply cysteine and oleic
+/// acid to adjacent tumor cells, boosting GSH antioxidant capacity and MUFA
+/// membrane protection. All parameters are ESTIMATED — no textbook coverage
+/// exists for CAF biology. Refs: PMID 34373744 (CAF metabolic reprogramming),
+/// PMID 31813804 (ACSL3-mediated oleic acid), PMID 30842648 (MUFA ferroptosis).
+struct StromalConfig {
+    /// Per-step GSH boost for stromal-adjacent tumor cells.
+    /// GGT1-mediated cysteine supply: CAFs cleave extracellular GSH, tumor
+    /// cells reimport cysteine via SLC7A11. ~2.5× endogenous NRF2 rate (0.025).
+    gsh_boost_per_step: f64,
+    /// Maximum GSH from CAF supply (1.5× normal gsh_max of 12.0).
+    gsh_boost_cap: f64,
+    /// Per-step MUFA boost from ACSL3-mediated oleic acid uptake.
+    /// ~30% of in-vivo SCD1 rate; CAF supply is supplementary.
+    mufa_boost_per_step: f64,
+    /// Maximum MUFA from CAF supply (50% of in-vivo SCD1 max).
+    mufa_boost_cap: f64,
+}
+
+impl StromalConfig {
+    fn default() -> Self {
+        StromalConfig {
+            gsh_boost_per_step: 0.06,
+            gsh_boost_cap: 18.0,
+            mufa_boost_per_step: 0.003,
+            mufa_boost_cap: 0.25,
+        }
+    }
+}
+
+/// Compute a boolean mask: true for tumor cells with at least one stromal
+/// (is_tumor=false) Moore neighbor. These cells receive CAF-mediated protection.
+fn stromal_adjacency_mask(grid: &TumorGrid) -> Vec<bool> {
+    let n = grid.rows * grid.cols;
+    let mut mask = vec![false; n];
+    for r in 0..grid.rows {
+        for c in 0..grid.cols {
+            let idx = r * grid.cols + c;
+            if !grid.cells[idx].is_tumor {
+                continue;
+            }
+            let (neighbors, count) = grid.neighbors(r, c);
+            for &(nr, nc) in &neighbors[..count] {
+                if !grid.cells[nr * grid.cols + nc].is_tumor {
+                    mask[idx] = true;
+                    break;
+                }
+            }
+        }
+    }
+    mask
+}
+
+/// Kill rate among stromal-adjacent tumor cells only.
+fn stromal_adjacent_kill_rate(grid: &TumorGrid, mask: &[bool]) -> f64 {
+    let mut total = 0usize;
+    let mut dead = 0usize;
+    for (idx, gc) in grid.cells.iter().enumerate() {
+        if gc.is_tumor && mask[idx] {
+            total += 1;
+            if gc.state.dead {
+                dead += 1;
+            }
+        }
+    }
+    if total > 0 { dead as f64 / total as f64 } else { 0.0 }
+}
+
 /// Run spatial sim WITH immune coupling: DAMP diffusion + immune kill.
+/// Optionally applies CAF-mediated stromal protection to masked cells.
 /// Returns (ferroptosis_kills, immune_kills, final_damp_field).
 fn run_spatial_with_immune(
     grid: &mut TumorGrid,
@@ -252,6 +326,7 @@ fn run_spatial_with_immune(
     params: &Params,
     spatial_params: &SpatialParams,
     immune: &ImmuneConfig,
+    stromal: Option<(&[bool], &StromalConfig)>,
     seed: u64,
 ) -> (usize, usize, Vec<f64>) {
     let base_ros = match tx {
@@ -330,6 +405,22 @@ fn run_spatial_with_immune(
                         _ => immune.pharmacologic_overshoot,
                     };
                     damp_field[idx] += gc.lp_at_death * immune.damp_per_lp * overshoot;
+                }
+
+                // CAF-mediated protection: boost GSH and MUFA for stromal-adjacent cells.
+                // Applied AFTER sim_cell_step so the boost takes effect on the next step
+                // (biologically: cysteine/oleic acid must be transported before use).
+                if !died {
+                    if let Some((mask, cfg)) = &stromal {
+                        if mask[idx] {
+                            let gc = &mut grid.cells[idx];
+                            gc.state.gsh = (gc.state.gsh + cfg.gsh_boost_per_step)
+                                .min(cfg.gsh_boost_cap);
+                            gc.state.mufa_protection = (gc.state.mufa_protection
+                                + cfg.mufa_boost_per_step)
+                                .min(cfg.mufa_boost_cap);
+                        }
+                    }
                 }
             }
         }
@@ -420,6 +511,15 @@ struct ConditionResult {
     /// LP overshoot multiplier used for this condition (None when immune is off).
     #[serde(skip_serializing_if = "Option::is_none")]
     lp_overshoot_multiplier: Option<f64>,
+    /// Stromal protection mode: "off" or "stromal_on".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stromal_mode: Option<String>,
+    /// Kill rate among stromal-adjacent tumor cells specifically.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stromal_adjacent_kill_rate: Option<f64>,
+    /// Number of tumor cells receiving CAF protection.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stromal_adjacent_count: Option<usize>,
 }
 
 /// Compute kill rates for three O2-defined zones:
@@ -539,6 +639,9 @@ fn main() {
             transition_kill_rate: trans_r,
             hypoxic_kill_rate: hyp_r,
             lp_overshoot_multiplier: None,
+            stromal_mode: None,
+            stromal_adjacent_kill_rate: None,
+            stromal_adjacent_count: None,
         });
 
         let label = format!("{}_uniform", tx_name);
@@ -584,6 +687,9 @@ fn main() {
                 transition_kill_rate: trans_r,
                 hypoxic_kill_rate: hyp_r,
                 lp_overshoot_multiplier: None,
+                stromal_mode: None,
+                stromal_adjacent_kill_rate: None,
+                stromal_adjacent_count: None,
             });
 
             let label = format!("{}_{}", tx_name, lambda as u64);
@@ -626,7 +732,7 @@ fn main() {
             apply_o2_gradient(&mut grid, 120.0);
 
             let (ferr_kills, imm_kills, final_damp) = run_spatial_with_immune(
-                &mut grid, *tx, &params, &spatial_params, immune_cfg,
+                &mut grid, *tx, &params, &spatial_params, immune_cfg, None,
                 SEED.wrapping_add((*tx as u64) * 10_000_000),
             );
 
@@ -676,12 +782,113 @@ fn main() {
                 transition_kill_rate: trans_r,
                 hypoxic_kill_rate: hyp_r,
                 lp_overshoot_multiplier: Some(overshoot),
+                stromal_mode: Some("off".to_string()),
+                stromal_adjacent_kill_rate: None,
+                stromal_adjacent_count: None,
             });
 
             let label = format!("{}_120_{}", tx_name, immune_label);
             all_depth_curves.push((label, depth_kill_curve(&grid)));
         }
         eprintln!();
+    }
+
+    // --- Stromal protection (Feature C) at λ=120μm with immune_on ---
+    let stromal_cfg = StromalConfig::default();
+    // Compute adjacency mask on a fresh grid (mask is grid-geometry-dependent, not treatment-dependent)
+    let mask_grid = TumorGrid::generate(GRID_SIZE, GRID_SIZE, CELL_SIZE_UM, SEED);
+    let stromal_mask = stromal_adjacency_mask(&mask_grid);
+    let stromal_adj_count = stromal_mask.iter().filter(|&&b| b).count();
+
+    eprintln!("\n=== Stromal Protection / CAF-Mediated Shielding (O2 gradient λ=120μm) ===");
+    eprintln!("Stromal-adjacent tumor cells: {} ({:.1}% of tumor)",
+        stromal_adj_count,
+        stromal_adj_count as f64 / mask_grid.census().total_tumor as f64 * 100.0);
+    eprintln!("CAF boost: GSH +{:.3}/step (cap {:.0}), MUFA +{:.4}/step (cap {:.2})",
+        stromal_cfg.gsh_boost_per_step, stromal_cfg.gsh_boost_cap,
+        stromal_cfg.mufa_boost_per_step, stromal_cfg.mufa_boost_cap);
+    eprintln!("All parameters ESTIMATED (no textbook coverage). Refs: PMID 34373744, 31813804.\n");
+
+    let stromal_immune_modes: Vec<(&str, ImmuneConfig)> = vec![
+        ("immune_on", ImmuneConfig::default_no_pd1()),
+        ("immune_anti_pd1", ImmuneConfig::default_no_pd1().with_anti_pd1()),
+    ];
+
+    for (immune_label, immune_cfg) in &stromal_immune_modes {
+        eprintln!("--- Stromal ON + {} (brake={:.0}%) ---\n",
+            immune_label, immune_cfg.effective_brake() * 100.0);
+
+        for (tx, tx_name) in &treatments {
+            let mut grid = TumorGrid::generate(GRID_SIZE, GRID_SIZE, CELL_SIZE_UM, SEED);
+            apply_o2_gradient(&mut grid, 120.0);
+
+            let (ferr_kills, imm_kills, _final_damp) = run_spatial_with_immune(
+                &mut grid, *tx, &params, &spatial_params, &immune_cfg,
+                Some((&stromal_mask, &stromal_cfg)),
+                SEED.wrapping_add((*tx as u64) * 10_000_000),
+            );
+
+            let census = grid.census();
+            let overall = census.total_dead as f64 / census.total_tumor.max(1) as f64;
+            let (norm_r, trans_r, hyp_r) = zone_kill_rates(&grid, ZONE_REF_LAMBDA);
+            let adj_rate = stromal_adjacent_kill_rate(&grid, &stromal_mask);
+            eprintln!("  {}: overall={:.1}% (ferr={}, immune={}), normoxic={:.1}%, hypoxic={:.1}%, stromal_adj={:.1}%",
+                tx_name, overall * 100.0, ferr_kills, imm_kills,
+                norm_r * 100.0, hyp_r * 100.0, adj_rate * 100.0);
+
+            // Export death heatmap for stromal_on + immune_on
+            if *immune_label == "immune_on" {
+                let death_hm = death_heatmap(&grid);
+                let path = output_dir.join(format!("death_{}_stromal.csv", tx_name.to_lowercase()));
+                write_heatmap_csv(&path, &death_hm).expect("Failed to write stromal death heatmap");
+            }
+
+            let overshoot = match tx {
+                Treatment::SDT | Treatment::PDT => immune_cfg.physical_modality_overshoot,
+                _ => immune_cfg.pharmacologic_overshoot,
+            };
+            all_results.push(ConditionResult {
+                treatment: tx_name.to_string(),
+                o2_condition: "gradient_120um".to_string(),
+                o2_lambda_um: Some(120.0),
+                immune_mode: immune_label.to_string(),
+                total_tumor: census.total_tumor,
+                total_dead: census.total_dead,
+                ferroptosis_kills: Some(ferr_kills),
+                immune_kills: Some(imm_kills),
+                overall_kill_rate: overall,
+                normoxic_kill_rate: norm_r,
+                transition_kill_rate: trans_r,
+                hypoxic_kill_rate: hyp_r,
+                lp_overshoot_multiplier: Some(overshoot),
+                stromal_mode: Some("stromal_on".to_string()),
+                stromal_adjacent_kill_rate: Some(adj_rate),
+                stromal_adjacent_count: Some(stromal_adj_count),
+            });
+
+            let label = format!("{}_120_{}_stromal", tx_name, immune_label);
+            all_depth_curves.push((label, depth_kill_curve(&grid)));
+        }
+        eprintln!();
+    }
+
+    // Export stromal adjacency mask as heatmap (0=stromal, 1=adjacent tumor, 2=non-adjacent tumor)
+    {
+        let mut mask_hm = ndarray::Array2::<u8>::zeros((mask_grid.rows, mask_grid.cols));
+        for r in 0..mask_grid.rows {
+            for c in 0..mask_grid.cols {
+                let idx = r * mask_grid.cols + c;
+                if !mask_grid.cells[idx].is_tumor {
+                    mask_hm[[r, c]] = 0;
+                } else if stromal_mask[idx] {
+                    mask_hm[[r, c]] = 1;
+                } else {
+                    mask_hm[[r, c]] = 2;
+                }
+            }
+        }
+        let path = output_dir.join("stromal_mask.csv");
+        write_heatmap_csv(&path, &mask_hm).expect("Failed to write stromal mask");
     }
 
     // --- Write aggregated outputs ---

--- a/simulations/sim-tme/src/main.rs
+++ b/simulations/sim-tme/src/main.rs
@@ -901,14 +901,15 @@ fn main() {
     // --- Print comparison table ---
     eprintln!("\n=== Comparison Table ===\n");
     eprintln!(
-        "{:<10} {:<20} {:<18} {:>10} {:>10} {:>10} {:>10}",
-        "Treatment", "O2 Condition", "Immune", "Overall", "Normoxic", "Transit.", "Hypoxic"
+        "{:<10} {:<20} {:<18} {:<12} {:>10} {:>10} {:>10} {:>10}",
+        "Treatment", "O2 Condition", "Immune", "Stromal", "Overall", "Normoxic", "Transit.", "Hypoxic"
     );
-    eprintln!("{}", "-".repeat(100));
+    eprintln!("{}", "-".repeat(112));
     for r in &all_results {
+        let stromal_label = r.stromal_mode.as_deref().unwrap_or("off");
         eprintln!(
-            "{:<10} {:<20} {:<18} {:>9.1}% {:>9.1}% {:>9.1}% {:>9.1}%",
-            r.treatment, r.o2_condition, r.immune_mode,
+            "{:<10} {:<20} {:<18} {:<12} {:>9.1}% {:>9.1}% {:>9.1}% {:>9.1}%",
+            r.treatment, r.o2_condition, r.immune_mode, stromal_label,
             r.overall_kill_rate * 100.0,
             r.normoxic_kill_rate * 100.0,
             r.transition_kill_rate * 100.0,

--- a/simulations/sim-tme/src/main.rs
+++ b/simulations/sim-tme/src/main.rs
@@ -712,6 +712,12 @@ fn main() {
         }
     }
 
+    // --- Compute stromal adjacency mask (used by both Feature B and C) ---
+    // Mask is grid-geometry-dependent, not treatment-dependent.
+    let mask_grid = TumorGrid::generate(GRID_SIZE, GRID_SIZE, CELL_SIZE_UM, SEED);
+    let stromal_mask = stromal_adjacency_mask(&mask_grid);
+    let stromal_adj_count = stromal_mask.iter().filter(|&&b| b).count();
+
     // --- Immune coupling (Feature B) at λ=120μm ---
     let immune_modes: Vec<(&str, ImmuneConfig)> = vec![
         ("immune_on", ImmuneConfig::default_no_pd1()),
@@ -739,8 +745,9 @@ fn main() {
             let census = grid.census();
             let overall = census.total_dead as f64 / census.total_tumor.max(1) as f64;
             let (norm_r, trans_r, hyp_r) = zone_kill_rates(&grid, ZONE_REF_LAMBDA);
-            eprintln!("  {}: overall={:.1}% (ferr={}, immune={}), hypoxic={:.1}%",
-                tx_name, overall * 100.0, ferr_kills, imm_kills, hyp_r * 100.0);
+            let adj_rate_baseline = stromal_adjacent_kill_rate(&grid, &stromal_mask);
+            eprintln!("  {}: overall={:.1}% (ferr={}, immune={}), hypoxic={:.1}%, stromal_adj={:.1}%",
+                tx_name, overall * 100.0, ferr_kills, imm_kills, hyp_r * 100.0, adj_rate_baseline * 100.0);
 
             // Export DAMP and immune-kill heatmaps for the first immune mode only
             if *immune_label == "immune_on" {
@@ -783,8 +790,8 @@ fn main() {
                 hypoxic_kill_rate: hyp_r,
                 lp_overshoot_multiplier: Some(overshoot),
                 stromal_mode: Some("off".to_string()),
-                stromal_adjacent_kill_rate: None,
-                stromal_adjacent_count: None,
+                stromal_adjacent_kill_rate: Some(adj_rate_baseline),
+                stromal_adjacent_count: Some(stromal_adj_count),
             });
 
             let label = format!("{}_120_{}", tx_name, immune_label);
@@ -795,10 +802,6 @@ fn main() {
 
     // --- Stromal protection (Feature C) at λ=120μm with immune_on ---
     let stromal_cfg = StromalConfig::default();
-    // Compute adjacency mask on a fresh grid (mask is grid-geometry-dependent, not treatment-dependent)
-    let mask_grid = TumorGrid::generate(GRID_SIZE, GRID_SIZE, CELL_SIZE_UM, SEED);
-    let stromal_mask = stromal_adjacency_mask(&mask_grid);
-    let stromal_adj_count = stromal_mask.iter().filter(|&&b| b).count();
 
     eprintln!("\n=== Stromal Protection / CAF-Mediated Shielding (O2 gradient λ=120μm) ===");
     eprintln!("Stromal-adjacent tumor cells: {} ({:.1}% of tumor)",

--- a/simulations/sim-tme/src/main.rs
+++ b/simulations/sim-tme/src/main.rs
@@ -520,6 +520,12 @@ struct ConditionResult {
     /// Number of tumor cells receiving CAF protection.
     #[serde(skip_serializing_if = "Option::is_none")]
     stromal_adjacent_count: Option<usize>,
+    /// CAF GSH boost rate per step (None when stromal is off).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stromal_gsh_boost: Option<f64>,
+    /// CAF MUFA boost rate per step (None when stromal is off).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stromal_mufa_boost: Option<f64>,
 }
 
 /// Compute kill rates for three O2-defined zones:
@@ -642,6 +648,8 @@ fn main() {
             stromal_mode: None,
             stromal_adjacent_kill_rate: None,
             stromal_adjacent_count: None,
+            stromal_gsh_boost: None,
+            stromal_mufa_boost: None,
         });
 
         let label = format!("{}_uniform", tx_name);
@@ -690,6 +698,8 @@ fn main() {
                 stromal_mode: None,
                 stromal_adjacent_kill_rate: None,
                 stromal_adjacent_count: None,
+                stromal_gsh_boost: None,
+                stromal_mufa_boost: None,
             });
 
             let label = format!("{}_{}", tx_name, lambda as u64);
@@ -792,6 +802,8 @@ fn main() {
                 stromal_mode: Some("off".to_string()),
                 stromal_adjacent_kill_rate: Some(adj_rate_baseline),
                 stromal_adjacent_count: Some(stromal_adj_count),
+                stromal_gsh_boost: None,
+                stromal_mufa_boost: None,
             });
 
             let label = format!("{}_120_{}", tx_name, immune_label);
@@ -867,6 +879,8 @@ fn main() {
                 stromal_mode: Some("stromal_on".to_string()),
                 stromal_adjacent_kill_rate: Some(adj_rate),
                 stromal_adjacent_count: Some(stromal_adj_count),
+                stromal_gsh_boost: Some(stromal_cfg.gsh_boost_per_step),
+                stromal_mufa_boost: Some(stromal_cfg.mufa_boost_per_step),
             });
 
             let label = format!("{}_120_{}_stromal", tx_name, immune_label);


### PR DESCRIPTION
## Summary
Stromal cells at the tumor boundary now actively protect adjacent tumor cells via CAF-mediated GSH and MUFA supply. This is TME Feature C from issue #76.

## Key finding
CAF protection is **treatment-selective** — it meaningfully reduces pharmacologic (RSL3) kills but has negligible effect on physical modality (SDT) kills:

| Treatment | Stromal OFF | Stromal ON | Delta | Relative |
|-----------|------------|------------|-------|----------|
| RSL3 | 163 kills | 136 kills | -27 | **-16.6%** |
| SDT | 139,641 kills | 139,551 kills | -90 | -0.06% |

Stromal-adjacent cell-specific comparison (the 1,796 cells at the tumor-stroma interface):
| Treatment | Adj rate OFF | Adj rate ON | Delta |
|-----------|-------------|-------------|-------|
| RSL3 | 3.0% | 1.5% | **-50% relative** |
| SDT | 96.1% | 91.1% | -5.2% relative |

Hypoxic zone: unchanged for all treatments (CAFs don't reach the core).

## Implementation
- StromalConfig struct: GSH boost +0.06/step (cap 18.0), MUFA +0.003/step (cap 0.25)
- stromal_adjacency_mask(): Moore neighbor check identifies 1,796 cells (1.1%) at tumor-stroma interface
- Per-step GSH/MUFA boost applied AFTER sim_cell_step (zero ferroptosis-core changes)
- Comparison runs: stromal_on vs stromal_off x immune_on/anti_pd1 x 3 treatments
- Stromal-adjacent baseline rate reported for both ON and OFF conditions
- Stromal parameters (gsh_boost, mufa_boost) recorded in tme_summary.json for traceability

## Blast radius
Single file: sim-tme/src/main.rs. Zero ferroptosis-core changes. Existing immune coupling kill rates are numerically identical (stromal=None). Output format extended with new optional fields (skip_serializing_if for backward compatibility).

## All parameters ESTIMATED
No textbook coverage for CAF biology (verified across Biology2e, A&P 2e, Microbiology, Chemistry2e). Refs: PMID 34373744 (CAF metabolic reprogramming, 381 citations, in corpus), PMID 31813804, 30842648 (external literature).

## Test plan
- [x] 19 ferroptosis-core tests pass (zero core changes)
- [x] sim-tme compiles and runs successfully
- [x] Existing immune coupling kill rates numerically identical (stromal=None)
- [x] Stromal-adjacent cells correctly identified (1,796 = 1.1%)
- [x] RSL3 adj rate halves (3.0% -> 1.5%) with CAF protection
- [x] SDT adj rate drops modestly (96.1% -> 91.1%)
- [x] Hypoxic zone unchanged
- [x] tme_summary.json includes stromal parameters for traceability

Closes #76