### PR TITLE
Fix tumor PBPK 2D baseline: inactivation rate model calibrated to 42%

### DIFF
--- a/simulations/ferroptosis-core/src/tumor_pk.rs
+++ b/simulations/ferroptosis-core/src/tumor_pk.rs
@@ -172,7 +172,9 @@ pub fn rsl3_iv_bolus() -> PlasmaModel {
 
 /// 2D culture reference: constant drug concentration = 1.0 for all time.
 /// With the inactivation rate model (k_inact=0.015), this produces ~41%
-/// kill for Persisters — matching the repo's standard sim_cell RSL3 baseline.
+/// kill for Persisters — matching the repo's Persister+RSL3 death rate (~42.5%).
+/// Note: internal state (LP, GSH, GPX4) differs from sim_cell due to the
+/// continuous inactivation model vs one-time init reduction.
 pub fn constant_reference() -> PlasmaModel {
     PlasmaModel::Constant { concentration: 1.0 }
 }
@@ -283,7 +285,8 @@ pub struct PKCellResult {
 
 /// GPX4 inactivation rate for RSL3-like covalent GPX4 inhibitors.
 /// Calibrated directly in Rust (10K Persister cells, constant conc=1.0):
-/// k_inact=0.015 gives ~41% kill, matching sim_cell RSL3+Persister (~42.5%).
+/// k_inact=0.015 gives ~41% death rate, matching sim_cell RSL3+Persister
+/// death rate (~42.5%). Internal state (LP, GSH, GPX4) differs.
 pub const RSL3_INACTIVATION_RATE: f64 = 0.015;
 
 /// Simulate a single cell with time-varying drug concentration.
@@ -295,7 +298,8 @@ pub const RSL3_INACTIVATION_RATE: f64 = 0.015;
 /// depends on the ratio of production to inactivation.
 ///
 /// At constant conc=1.0 with RSL3_INACTIVATION_RATE (0.015), this produces
-/// ~41% kill for Persisters — matching the repo's standard 2D baseline.
+/// ~41% kill for Persisters — matching the Persister+RSL3 death rate.
+/// Internal state (LP, GSH, GPX4) differs from sim_cell's init model.
 /// When drug washes out (IV bolus), inactivation drops and GPX4 recovers.
 ///
 /// The cell is initialized as Treatment::Control (no initial GPX4 reduction).

--- a/simulations/ferroptosis-core/src/tumor_pk.rs
+++ b/simulations/ferroptosis-core/src/tumor_pk.rs
@@ -314,7 +314,7 @@ pub fn sim_cell_with_pk(
     for step in 0..n_steps as u32 {
         // Covalent GPX4 inactivation: drug destroys enzyme proportional to
         // drug concentration and available GPX4. NRF2 makes new GPX4 inside
-        // sim_cell_step. At conc=1.0, steady-state GPX4 ≈ 0.15-0.20.
+        // sim_cell_step. At conc=1.0, effective GPX4 ≈ 0.20-0.25.
         if !state.dead {
             let conc = conc_schedule[step as usize].clamp(0.0, 1.0);
             state.gpx4 -= gpx4_inactivation_rate * conc * state.gpx4;

--- a/simulations/ferroptosis-core/src/tumor_pk.rs
+++ b/simulations/ferroptosis-core/src/tumor_pk.rs
@@ -170,11 +170,9 @@ pub fn rsl3_iv_bolus() -> PlasmaModel {
     }
 }
 
-/// Constant max-exposure reference: concentration = 1.0 for all time.
-/// NOT equivalent to the standard sim_cell RSL3 baseline (~42%): this model
-/// applies continuous inhibition via GPX4 clamp (preventing NRF2 recovery),
-/// while sim_cell applies one-time GPX4 reduction at init. Use as a
-/// theoretical maximum for computing relative protection factors.
+/// 2D culture reference: constant drug concentration = 1.0 for all time.
+/// With the inactivation rate model (k_inact=0.015), this produces ~41%
+/// kill for Persisters — matching the repo's standard sim_cell RSL3 baseline.
 pub fn constant_reference() -> PlasmaModel {
     PlasmaModel::Constant { concentration: 1.0 }
 }
@@ -283,12 +281,22 @@ pub struct PKCellResult {
     pub final_gpx4: f64,
 }
 
+/// GPX4 inactivation rate for RSL3-like covalent GPX4 inhibitors.
+/// Calibrated directly in Rust (10K Persister cells, constant conc=1.0):
+/// k_inact=0.015 gives ~41% kill, matching sim_cell RSL3+Persister (~42.5%).
+pub const RSL3_INACTIVATION_RATE: f64 = 0.015;
+
 /// Simulate a single cell with time-varying drug concentration.
 ///
-/// At each timestep, GPX4 inhibition tracks the interstitial drug
-/// concentration: `effective_gpx4 = intrinsic_gpx4 × (1 - base_inhib × conc[step])`.
-/// This models competitive inhibition where the drug and NRF2 upregulation
-/// fight for GPX4 control at each moment.
+/// Models drug as a covalent GPX4 inhibitor: at each timestep, the drug
+/// inactivates GPX4 at a rate proportional to concentration × available
+/// enzyme: dGPX4/dt_drug = -k_inact × conc × GPX4. NRF2 produces new
+/// GPX4 inside sim_cell_step, balancing destruction. The steady state
+/// depends on the ratio of production to inactivation.
+///
+/// At constant conc=1.0 with RSL3_INACTIVATION_RATE (0.015), this produces
+/// ~41% kill for Persisters — matching the repo's standard 2D baseline.
+/// When drug washes out (IV bolus), inactivation drops and GPX4 recovers.
 ///
 /// The cell is initialized as Treatment::Control (no initial GPX4 reduction).
 /// Drug effect is applied dynamically through the concentration schedule.
@@ -296,7 +304,7 @@ pub fn sim_cell_with_pk(
     cell: &Cell,
     params: &Params,
     conc_schedule: &[f64],
-    base_gpx4_inhib: f64,
+    gpx4_inactivation_rate: f64,
     seed: u64,
 ) -> PKCellResult {
     let n_steps = conc_schedule.len().min(180);
@@ -304,16 +312,13 @@ pub fn sim_cell_with_pk(
     let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
 
     for step in 0..n_steps as u32 {
-        // Time-varying drug inhibition: CLAMP GPX4 BEFORE the step so the
-        // repair calculation uses the drug-limited level. The drug is a
-        // reversible competitive inhibitor that prevents GPX4 from exceeding
-        // a concentration-dependent ceiling. NRF2 can upregulate GPX4 between
-        // steps, but the drug caps it before the next repair calculation.
-        // When drug washes out (conc→0), the cap lifts and GPX4 recovers.
+        // Covalent GPX4 inactivation: drug destroys enzyme proportional to
+        // drug concentration and available GPX4. NRF2 makes new GPX4 inside
+        // sim_cell_step. At conc=1.0, steady-state GPX4 ≈ 0.15-0.20.
         if !state.dead {
-            let conc = conc_schedule[step as usize];
-            let max_gpx4 = cell.gpx4 * (1.0 - base_gpx4_inhib * conc.clamp(0.0, 1.0));
-            state.gpx4 = state.gpx4.min(max_gpx4);
+            let conc = conc_schedule[step as usize].clamp(0.0, 1.0);
+            state.gpx4 -= gpx4_inactivation_rate * conc * state.gpx4;
+            state.gpx4 = state.gpx4.max(0.0);
         }
 
         let _died = sim_cell_step(&mut state, cell, params, step, 0.0, &mut rng);

--- a/simulations/sim-tumor-pk/src/main.rs
+++ b/simulations/sim-tumor-pk/src/main.rs
@@ -90,7 +90,8 @@ fn main() {
     // --- 2D culture reference (conc = 1.0 at all steps) ---
     // Drug at full concentration for all 180 steps with no PK barriers.
     // With the inactivation rate model (k_inact=0.015), this produces
-    // ~41% kill — matching the repo's standard sim_cell RSL3 baseline.
+    // ~41% death rate — matching the Persister+RSL3 death rate (~42.5%).
+    // Internal state (LP, GSH, GPX4) differs from sim_cell's init model.
     let ref_death_rate;
     {
         let conc_schedule: Vec<f64> = vec![1.0; N_STEPS];

--- a/simulations/sim-tumor-pk/src/main.rs
+++ b/simulations/sim-tumor-pk/src/main.rs
@@ -26,7 +26,7 @@ const N_STEPS: usize = 180;
 #[derive(Serialize)]
 struct ScenarioResult {
     tumor_type: String,
-    context: String, // "tumor_pk" or "max_exposure_ref"
+    context: String, // "tumor_pk" or "2d_culture_ref"
     n_cells: usize,
     n_dead: usize,
     death_rate: f64,
@@ -51,7 +51,8 @@ fn run_scenario(
             let cell_seed = seed.wrapping_add(i as u64).wrapping_add(1_000_000);
             let mut rng = rand::rngs::StdRng::seed_from_u64(cell_seed);
             let cell = gen_cell(Phenotype::Persister, &mut rng);
-            sim_cell_with_pk(&cell, params, conc_schedule, params.rsl3_gpx4_inhib, cell_seed)
+            // Use a different seed for sim vs gen_cell to avoid RNG correlation
+            sim_cell_with_pk(&cell, params, conc_schedule, RSL3_INACTIVATION_RATE, cell_seed.wrapping_add(500_000))
         })
         .collect();
 
@@ -86,13 +87,10 @@ fn main() {
     eprintln!("All tumor PK parameters ESTIMATED (no textbook coverage).\n");
 
     let mut all_results: Vec<ScenarioResult> = Vec::new();
-    // --- Constant max-exposure reference (conc = 1.0 at all steps) ---
-    // This is the theoretical maximum: drug at full concentration for all
-    // 180 steps with no PK barriers. NOT equivalent to the repo's standard
-    // 2D RSL3 baseline (~42.5% in sim-original), which uses a one-time
-    // GPX4 reduction at init. The clamp model here applies continuous
-    // inhibition (preventing NRF2 recovery), producing ~100% kill.
-    // Protection factors are relative to this max-exposure reference.
+    // --- 2D culture reference (conc = 1.0 at all steps) ---
+    // Drug at full concentration for all 180 steps with no PK barriers.
+    // With the inactivation rate model (k_inact=0.015), this produces
+    // ~41% kill — matching the repo's standard sim_cell RSL3 baseline.
     let ref_death_rate;
     {
         let conc_schedule: Vec<f64> = vec![1.0; N_STEPS];
@@ -102,7 +100,7 @@ fn main() {
         ref_death_rate = n_dead as f64 / N_CELLS as f64;
 
         eprintln!(
-            "  Max-exposure ref: death_rate={:.1}% [{:.1}-{:.1}], LP={:.2}, GSH={:.2}, GPX4={:.3}",
+            "  2D culture ref: death_rate={:.1}% [{:.1}-{:.1}], LP={:.2}, GSH={:.2}, GPX4={:.3}",
             ref_death_rate * 100.0,
             ci_lo * 100.0,
             ci_hi * 100.0,
@@ -112,8 +110,8 @@ fn main() {
         );
 
         all_results.push(ScenarioResult {
-            tumor_type: "Max exposure ref".to_string(),
-            context: "max_exposure_ref".to_string(),
+            tumor_type: "2D culture ref".to_string(),
+            context: "2d_culture_ref".to_string(),
             n_cells: N_CELLS,
             n_dead,
             death_rate: ref_death_rate,


### PR DESCRIPTION
## Summary
Fixes the 2D baseline calibration issue from PR #106 review. The clamp model gave 100% kill instead of the expected ~42.5%. Now uses a pharmacologically correct GPX4 inactivation rate model.

## The fix
Replace the GPX4 clamp (state.gpx4 = min(state.gpx4, ceiling) every step) with a covalent inactivation rate:
```
state.gpx4 -= k_inact * conc * state.gpx4
```

## Calibration
k_inact=0.015 calibrated directly in Rust to match the Persister+RSL3 **death rate** (~42.5%):

| k_inact | Death rate |
|---------|-----------|
| 0.010 | 20.8% |
| 0.012 | 28.8% |
| **0.015** | **41.4%** |
| 0.018 | 54.9% |

**Important caveat**: the 2D reference matches the death RATE but not the internal state. LP is 8.61 (vs sim_cell 4.62), GPX4 is 0.255 (vs 0.500). The continuous inactivation model produces a different trajectory than the one-time init reduction. All documentation explicitly says 'matching death rate' not 'matching baseline.'

## Results
| Tumor Type | Death Rate | Protection Factor |
|-----------|-----------|------------------|
| 2D culture ref | 41.4% | reference |
| Breast | 2.6% | 15.7x |
| Pancreatic | 2.0% | 21.0x |
| GBM | 1.6% | 26.7x |

## Test plan
- [x] 24 tests pass
- [x] 2D reference death rate: 41.4% (within 5% of target 42.5%)
- [x] Protection factor ordering: breast < pancreatic < GBM
- [x] All wording says 'matching death rate' (4 sites checked)
- [x] Steady-state GPX4 comment corrected (0.20-0.25)

Partial progress on #48