### PR TITLE
Add C FFI bindings for ferroptosis-core (PhysiCell integration)

### DIFF
--- a/simulations/Cargo.lock
+++ b/simulations/Cargo.lock
@@ -53,10 +53,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "cbindgen"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fce8dd7fcfcbf3a0a87d8f515194b49d6135acab73e18bd380d1d93bb1a15eb"
+dependencies = [
+ "clap",
+ "heck 0.4.1",
+ "indexmap",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+ "tempfile",
+ "toml",
+]
 
 [[package]]
 name = "cfg-if"
@@ -92,7 +123,7 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -163,6 +194,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "ferroptosis-core"
 version = "0.2.0"
 dependencies = [
@@ -176,6 +229,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ferroptosis-ffi"
+version = "0.1.0"
+dependencies = [
+ "cbindgen",
+ "ferroptosis-core",
+ "rand",
+]
+
+[[package]]
 name = "ferroptosis-python"
 version = "0.1.0"
 dependencies = [
@@ -184,6 +246,12 @@ dependencies = [
  "rand",
  "rayon",
 ]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "getrandom"
@@ -197,10 +265,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "indoc"
@@ -224,6 +344,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +360,18 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "matrixmultiply"
@@ -340,6 +478,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -404,7 +552,7 @@ version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
@@ -419,6 +567,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -447,7 +601,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -487,6 +641,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,6 +664,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -539,6 +712,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -680,10 +862,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unindent"
@@ -704,6 +946,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -716,6 +1010,109 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]

--- a/simulations/Cargo.toml
+++ b/simulations/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "ferroptosis-python",
     "sim-tme",
     "sim-tumor-pk",
+    "ferroptosis-ffi",
 ]
 resolver = "2"
 

--- a/simulations/ferroptosis-ffi/.gitignore
+++ b/simulations/ferroptosis-ffi/.gitignore
@@ -1,0 +1,1 @@
+tests/test_ffi

--- a/simulations/ferroptosis-ffi/Cargo.toml
+++ b/simulations/ferroptosis-ffi/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "ferroptosis-ffi"
+version = "0.1.0"
+edition = "2021"
+description = "C FFI bindings for the ferroptosis-core biochemistry engine"
+license = "MIT"
+repository = "https://github.com/ELares/cancer_research"
+
+[lib]
+crate-type = ["cdylib", "staticlib"]
+
+[dependencies]
+ferroptosis-core = { path = "../ferroptosis-core" }
+rand = { workspace = true }
+
+[build-dependencies]
+cbindgen = "0.27"

--- a/simulations/ferroptosis-ffi/build.rs
+++ b/simulations/ferroptosis-ffi/build.rs
@@ -11,16 +11,11 @@ fn main() {
     let config = cbindgen::Config::from_file(&config_path)
         .unwrap_or_default();
 
-    match cbindgen::Builder::new()
+    let bindings = cbindgen::Builder::new()
         .with_crate(&crate_dir)
         .with_config(config)
         .generate()
-    {
-        Ok(bindings) => {
-            bindings.write_to_file(&output_path);
-        }
-        Err(e) => {
-            eprintln!("cargo:warning=cbindgen failed: {e}");
-        }
-    }
+        .expect("cbindgen failed to generate ferroptosis.h — FFI header must stay in sync with Rust code");
+
+    bindings.write_to_file(&output_path);
 }

--- a/simulations/ferroptosis-ffi/build.rs
+++ b/simulations/ferroptosis-ffi/build.rs
@@ -1,0 +1,26 @@
+use std::path::PathBuf;
+
+fn main() {
+    let crate_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    let config_path = crate_dir.join("cbindgen.toml");
+    let output_path = crate_dir.join("include").join("ferroptosis.h");
+
+    // Ensure include directory exists
+    std::fs::create_dir_all(crate_dir.join("include")).ok();
+
+    let config = cbindgen::Config::from_file(&config_path)
+        .unwrap_or_default();
+
+    match cbindgen::Builder::new()
+        .with_crate(&crate_dir)
+        .with_config(config)
+        .generate()
+    {
+        Ok(bindings) => {
+            bindings.write_to_file(&output_path);
+        }
+        Err(e) => {
+            eprintln!("cargo:warning=cbindgen failed: {e}");
+        }
+    }
+}

--- a/simulations/ferroptosis-ffi/cbindgen.toml
+++ b/simulations/ferroptosis-ffi/cbindgen.toml
@@ -1,0 +1,7 @@
+language = "C"
+include_guard = "FERROPTOSIS_CORE_H"
+cpp_compat = true
+sys_includes = ["stdbool.h", "stdint.h"]
+
+[export]
+include = ["FerroCell", "FerroParams", "FerroResult", "FerroRng"]

--- a/simulations/ferroptosis-ffi/include/ferroptosis.h
+++ b/simulations/ferroptosis-ffi/include/ferroptosis.h
@@ -1,0 +1,125 @@
+#ifndef FERROPTOSIS_CORE_H
+#define FERROPTOSIS_CORE_H
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+/**
+ * Opaque random number generator. Create with ferro_rng_new, free with ferro_rng_free.
+ */
+typedef struct FerroRng FerroRng;
+
+/**
+ * Simulation parameters (20 f64 + 1 u32 = 21 fields).
+ * Use ferro_params_default() or ferro_params_invivo() to create.
+ */
+typedef struct FerroParams {
+  double fenton_rate;
+  double gsh_scav_efficiency;
+  double gsh_km;
+  double nrf2_gsh_rate;
+  double lp_rate;
+  double lp_propagation;
+  double gpx4_rate;
+  double fsp1_rate;
+  double scd_mufa_rate;
+  double scd_mufa_max;
+  double initial_mufa_protection;
+  double scd_mufa_decay;
+  double gpx4_degradation_by_ros;
+  double gpx4_nrf2_upregulation;
+  double sdt_ros;
+  double pdt_ros;
+  double rsl3_gpx4_inhib;
+  double gsh_max;
+  double gpx4_nrf2_target_multiplier;
+  double death_threshold;
+  uint32_t post_death_steps;
+} FerroParams;
+
+/**
+ * Cell biochemical parameters (7 fields, all f64).
+ */
+typedef struct FerroCell {
+  double iron;
+  double gsh;
+  double gpx4;
+  double fsp1;
+  double basal_ros;
+  double lipid_unsat;
+  double nrf2;
+} FerroCell;
+
+/**
+ * Result of a single-cell ferroptosis simulation.
+ */
+typedef struct FerroResult {
+  bool dead;
+  double final_lp;
+  double final_gsh;
+  double final_gpx4;
+} FerroResult;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+/**
+ * Create a new random number generator seeded with the given value.
+ * The caller owns the returned pointer and MUST free it with ferro_rng_free.
+ * Each thread should own its own FerroRng instance.
+ */
+struct FerroRng *ferro_rng_new(uint64_t seed);
+
+/**
+ * Free a FerroRng created by ferro_rng_new. Passing NULL is safe (no-op).
+ * Do NOT double-free or use after free.
+ */
+void ferro_rng_free(struct FerroRng *rng);
+
+/**
+ * Create default simulation parameters (2D culture).
+ * Returns a FerroParams struct by value (all fields populated).
+ */
+struct FerroParams ferro_params_default(void);
+
+/**
+ * Create in-vivo simulation parameters (3D/in-vivo with SCD1/MUFA protection).
+ * Returns a FerroParams struct by value.
+ */
+struct FerroParams ferro_params_invivo(void);
+
+/**
+ * Generate a stochastic cell with phenotype-specific biochemical parameters.
+ *
+ * phenotype: 0=Glycolytic, 1=OXPHOS, 2=Persister, 3=PersisterNrf2, 4=Stromal.
+ * Invalid values default to Glycolytic.
+ *
+ * rng: Must be a valid FerroRng pointer (from ferro_rng_new). Must not be NULL.
+ */
+struct FerroCell ferro_gen_cell(int32_t phenotype, struct FerroRng *rng);
+
+/**
+ * Run a full 180-step ferroptosis simulation for one cell.
+ *
+ * cell: Pointer to a FerroCell (from ferro_gen_cell). Must not be NULL.
+ * treatment: 0=Control, 1=RSL3, 2=SDT, 3=PDT. Invalid values default to Control.
+ * params: Pointer to FerroParams (from ferro_params_default/invivo). Must not be NULL.
+ * rng: Must be a valid FerroRng pointer. Must not be NULL.
+ *
+ * Returns a FerroResult with dead status and final LP/GSH/GPX4 values.
+ */
+struct FerroResult ferro_sim_cell(const struct FerroCell *cell,
+                                  int32_t treatment,
+                                  const struct FerroParams *params,
+                                  struct FerroRng *rng);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  /* FERROPTOSIS_CORE_H */

--- a/simulations/ferroptosis-ffi/src/lib.rs
+++ b/simulations/ferroptosis-ffi/src/lib.rs
@@ -1,0 +1,285 @@
+//! C FFI bindings for ferroptosis-core.
+//!
+//! Provides a C-compatible API for embedding the ferroptosis biochemistry
+//! engine in C/C++ frameworks such as PhysiCell, CompuCell3D, or Chaste.
+//!
+//! ## Quick start (C)
+//! ```c
+//! #include "ferroptosis.h"
+//!
+//! FerroRng* rng = ferro_rng_new(42);
+//! FerroParams params = ferro_params_default();
+//! FerroCell cell = ferro_gen_cell(2, rng);  // Persister
+//! FerroResult res = ferro_sim_cell(&cell, 1, &params, rng);  // RSL3
+//! printf("Dead: %d, LP: %.2f\n", res.dead, res.final_lp);
+//! ferro_rng_free(rng);
+//! ```
+//!
+//! ## Enum values
+//! - Phenotype: 0=Glycolytic, 1=OXPHOS, 2=Persister, 3=PersisterNrf2, 4=Stromal
+//! - Treatment: 0=Control, 1=RSL3, 2=SDT, 3=PDT
+//!
+//! ## Safety
+//! - Each thread must own its own FerroRng (not shared across threads)
+//! - Caller must free FerroRng with ferro_rng_free (no double-free)
+//! - Pointers must be valid and non-null (undefined behavior otherwise)
+
+use ferroptosis_core::biochem::sim_cell;
+use ferroptosis_core::cell::{gen_cell, Cell, Phenotype, Treatment};
+use ferroptosis_core::params::Params;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+
+// ============================================================
+// C-compatible types
+// ============================================================
+
+/// Opaque random number generator. Create with ferro_rng_new, free with ferro_rng_free.
+pub struct FerroRng {
+    _private: [u8; 0],
+}
+
+/// Cell biochemical parameters (7 fields, all f64).
+#[repr(C)]
+pub struct FerroCell {
+    pub iron: f64,
+    pub gsh: f64,
+    pub gpx4: f64,
+    pub fsp1: f64,
+    pub basal_ros: f64,
+    pub lipid_unsat: f64,
+    pub nrf2: f64,
+}
+
+/// Simulation parameters (20 f64 + 1 u32 = 21 fields).
+/// Use ferro_params_default() or ferro_params_invivo() to create.
+#[repr(C)]
+pub struct FerroParams {
+    pub fenton_rate: f64,
+    pub gsh_scav_efficiency: f64,
+    pub gsh_km: f64,
+    pub nrf2_gsh_rate: f64,
+    pub lp_rate: f64,
+    pub lp_propagation: f64,
+    pub gpx4_rate: f64,
+    pub fsp1_rate: f64,
+    pub scd_mufa_rate: f64,
+    pub scd_mufa_max: f64,
+    pub initial_mufa_protection: f64,
+    pub scd_mufa_decay: f64,
+    pub gpx4_degradation_by_ros: f64,
+    pub gpx4_nrf2_upregulation: f64,
+    pub sdt_ros: f64,
+    pub pdt_ros: f64,
+    pub rsl3_gpx4_inhib: f64,
+    pub gsh_max: f64,
+    pub gpx4_nrf2_target_multiplier: f64,
+    pub death_threshold: f64,
+    pub post_death_steps: u32,
+}
+
+/// Result of a single-cell ferroptosis simulation.
+#[repr(C)]
+pub struct FerroResult {
+    pub dead: bool,
+    pub final_lp: f64,
+    pub final_gsh: f64,
+    pub final_gpx4: f64,
+}
+
+// ============================================================
+// Type conversions (internal)
+// ============================================================
+
+fn ferro_cell_to_cell(fc: &FerroCell) -> Cell {
+    Cell {
+        iron: fc.iron,
+        gsh: fc.gsh,
+        gpx4: fc.gpx4,
+        fsp1: fc.fsp1,
+        basal_ros: fc.basal_ros,
+        lipid_unsat: fc.lipid_unsat,
+        nrf2: fc.nrf2,
+    }
+}
+
+fn cell_to_ferro_cell(c: &Cell) -> FerroCell {
+    FerroCell {
+        iron: c.iron,
+        gsh: c.gsh,
+        gpx4: c.gpx4,
+        fsp1: c.fsp1,
+        basal_ros: c.basal_ros,
+        lipid_unsat: c.lipid_unsat,
+        nrf2: c.nrf2,
+    }
+}
+
+fn ferro_params_to_params(fp: &FerroParams) -> Params {
+    Params {
+        fenton_rate: fp.fenton_rate,
+        gsh_scav_efficiency: fp.gsh_scav_efficiency,
+        gsh_km: fp.gsh_km,
+        nrf2_gsh_rate: fp.nrf2_gsh_rate,
+        lp_rate: fp.lp_rate,
+        lp_propagation: fp.lp_propagation,
+        gpx4_rate: fp.gpx4_rate,
+        fsp1_rate: fp.fsp1_rate,
+        scd_mufa_rate: fp.scd_mufa_rate,
+        scd_mufa_max: fp.scd_mufa_max,
+        initial_mufa_protection: fp.initial_mufa_protection,
+        scd_mufa_decay: fp.scd_mufa_decay,
+        gpx4_degradation_by_ros: fp.gpx4_degradation_by_ros,
+        gpx4_nrf2_upregulation: fp.gpx4_nrf2_upregulation,
+        sdt_ros: fp.sdt_ros,
+        pdt_ros: fp.pdt_ros,
+        rsl3_gpx4_inhib: fp.rsl3_gpx4_inhib,
+        gsh_max: fp.gsh_max,
+        gpx4_nrf2_target_multiplier: fp.gpx4_nrf2_target_multiplier,
+        death_threshold: fp.death_threshold,
+        post_death_steps: fp.post_death_steps,
+    }
+}
+
+fn params_to_ferro_params(p: &Params) -> FerroParams {
+    FerroParams {
+        fenton_rate: p.fenton_rate,
+        gsh_scav_efficiency: p.gsh_scav_efficiency,
+        gsh_km: p.gsh_km,
+        nrf2_gsh_rate: p.nrf2_gsh_rate,
+        lp_rate: p.lp_rate,
+        lp_propagation: p.lp_propagation,
+        gpx4_rate: p.gpx4_rate,
+        fsp1_rate: p.fsp1_rate,
+        scd_mufa_rate: p.scd_mufa_rate,
+        scd_mufa_max: p.scd_mufa_max,
+        initial_mufa_protection: p.initial_mufa_protection,
+        scd_mufa_decay: p.scd_mufa_decay,
+        gpx4_degradation_by_ros: p.gpx4_degradation_by_ros,
+        gpx4_nrf2_upregulation: p.gpx4_nrf2_upregulation,
+        sdt_ros: p.sdt_ros,
+        pdt_ros: p.pdt_ros,
+        rsl3_gpx4_inhib: p.rsl3_gpx4_inhib,
+        gsh_max: p.gsh_max,
+        gpx4_nrf2_target_multiplier: p.gpx4_nrf2_target_multiplier,
+        death_threshold: p.death_threshold,
+        post_death_steps: p.post_death_steps,
+    }
+}
+
+fn i32_to_phenotype(v: i32) -> Phenotype {
+    match v {
+        0 => Phenotype::Glycolytic,
+        1 => Phenotype::OXPHOS,
+        2 => Phenotype::Persister,
+        3 => Phenotype::PersisterNrf2,
+        4 => Phenotype::Stromal,
+        _ => Phenotype::Glycolytic, // default for invalid values
+    }
+}
+
+fn i32_to_treatment(v: i32) -> Treatment {
+    match v {
+        0 => Treatment::Control,
+        1 => Treatment::RSL3,
+        2 => Treatment::SDT,
+        3 => Treatment::PDT,
+        _ => Treatment::Control, // default for invalid values
+    }
+}
+
+// ============================================================
+// FFI functions
+// ============================================================
+
+/// Create a new random number generator seeded with the given value.
+/// The caller owns the returned pointer and MUST free it with ferro_rng_free.
+/// Each thread should own its own FerroRng instance.
+#[no_mangle]
+pub extern "C" fn ferro_rng_new(seed: u64) -> *mut FerroRng {
+    let rng = Box::new(StdRng::seed_from_u64(seed));
+    Box::into_raw(rng) as *mut FerroRng
+}
+
+/// Free a FerroRng created by ferro_rng_new. Passing NULL is safe (no-op).
+/// Do NOT double-free or use after free.
+#[no_mangle]
+pub extern "C" fn ferro_rng_free(rng: *mut FerroRng) {
+    if !rng.is_null() {
+        let _ = unsafe { Box::from_raw(rng as *mut StdRng) };
+    }
+}
+
+/// Create default simulation parameters (2D culture).
+/// Returns a FerroParams struct by value (all fields populated).
+#[no_mangle]
+pub extern "C" fn ferro_params_default() -> FerroParams {
+    params_to_ferro_params(&Params::default())
+}
+
+/// Create in-vivo simulation parameters (3D/in-vivo with SCD1/MUFA protection).
+/// Returns a FerroParams struct by value.
+#[no_mangle]
+pub extern "C" fn ferro_params_invivo() -> FerroParams {
+    params_to_ferro_params(&Params::invivo())
+}
+
+/// Generate a stochastic cell with phenotype-specific biochemical parameters.
+///
+/// phenotype: 0=Glycolytic, 1=OXPHOS, 2=Persister, 3=PersisterNrf2, 4=Stromal.
+/// Invalid values default to Glycolytic.
+///
+/// rng: Must be a valid FerroRng pointer (from ferro_rng_new). Must not be NULL.
+#[no_mangle]
+pub extern "C" fn ferro_gen_cell(phenotype: i32, rng: *mut FerroRng) -> FerroCell {
+    if rng.is_null() {
+        // Return zeroed cell on null RNG (defensive)
+        return FerroCell {
+            iron: 0.0, gsh: 0.0, gpx4: 0.0, fsp1: 0.0,
+            basal_ros: 0.0, lipid_unsat: 0.0, nrf2: 0.0,
+        };
+    }
+    let rng_ref = unsafe { &mut *(rng as *mut StdRng) };
+    let pheno = i32_to_phenotype(phenotype);
+    let cell = gen_cell(pheno, rng_ref);
+    cell_to_ferro_cell(&cell)
+}
+
+/// Run a full 180-step ferroptosis simulation for one cell.
+///
+/// cell: Pointer to a FerroCell (from ferro_gen_cell). Must not be NULL.
+/// treatment: 0=Control, 1=RSL3, 2=SDT, 3=PDT. Invalid values default to Control.
+/// params: Pointer to FerroParams (from ferro_params_default/invivo). Must not be NULL.
+/// rng: Must be a valid FerroRng pointer. Must not be NULL.
+///
+/// Returns a FerroResult with dead status and final LP/GSH/GPX4 values.
+#[no_mangle]
+pub extern "C" fn ferro_sim_cell(
+    cell: *const FerroCell,
+    treatment: i32,
+    params: *const FerroParams,
+    rng: *mut FerroRng,
+) -> FerroResult {
+    if cell.is_null() || params.is_null() || rng.is_null() {
+        return FerroResult {
+            dead: false, final_lp: 0.0, final_gsh: 0.0, final_gpx4: 0.0,
+        };
+    }
+
+    let cell_ref = unsafe { &*cell };
+    let params_ref = unsafe { &*params };
+    let rng_ref = unsafe { &mut *(rng as *mut StdRng) };
+
+    let rust_cell = ferro_cell_to_cell(cell_ref);
+    let rust_params = ferro_params_to_params(params_ref);
+    let tx = i32_to_treatment(treatment);
+
+    let (dead, lp, gsh, gpx4) = sim_cell(&rust_cell, tx, &rust_params, rng_ref);
+
+    FerroResult {
+        dead,
+        final_lp: lp,
+        final_gsh: gsh,
+        final_gpx4: gpx4,
+    }
+}

--- a/simulations/ferroptosis-ffi/tests/test_ffi.c
+++ b/simulations/ferroptosis-ffi/tests/test_ffi.c
@@ -1,0 +1,76 @@
+/**
+ * C integration test for ferroptosis-core FFI bindings.
+ *
+ * Compile and run:
+ *   cargo build --release -p ferroptosis-ffi
+ *   cc -o test_ffi tests/test_ffi.c -L ../target/release -lferroptosis_ffi -lm
+ *   DYLD_LIBRARY_PATH=../target/release ./test_ffi     # macOS
+ *   LD_LIBRARY_PATH=../target/release ./test_ffi        # Linux
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include "../include/ferroptosis.h"
+
+int main(void) {
+    printf("=== ferroptosis-core C FFI test ===\n\n");
+
+    /* Create RNG */
+    FerroRng *rng = ferro_rng_new(42);
+    if (!rng) {
+        fprintf(stderr, "ERROR: ferro_rng_new returned NULL\n");
+        return 1;
+    }
+
+    /* Get default params */
+    FerroParams params = ferro_params_default();
+    printf("Params: death_threshold=%.1f, rsl3_gpx4_inhib=%.2f\n",
+           params.death_threshold, params.rsl3_gpx4_inhib);
+
+    /* Simulate 1000 Persister + RSL3 cells */
+    int n_cells = 1000;
+    int n_dead = 0;
+    double sum_lp = 0.0;
+
+    for (int i = 0; i < n_cells; i++) {
+        FerroCell cell = ferro_gen_cell(2, rng);  /* 2 = Persister */
+        FerroResult res = ferro_sim_cell(&cell, 1, &params, rng);  /* 1 = RSL3 */
+        if (res.dead) n_dead++;
+        sum_lp += res.final_lp;
+    }
+
+    double death_rate = (double)n_dead / (double)n_cells;
+    double mean_lp = sum_lp / (double)n_cells;
+    printf("\nPersister + RSL3 (n=%d):\n", n_cells);
+    printf("  Death rate: %.1f%%\n", death_rate * 100.0);
+    printf("  Mean LP: %.2f\n", mean_lp);
+
+    /* Verify death rate is in expected range (30-55% for Persister+RSL3) */
+    if (death_rate < 0.30 || death_rate > 0.55) {
+        fprintf(stderr, "FAIL: Death rate %.1f%% outside expected range [30-55%%]\n",
+                death_rate * 100.0);
+        ferro_rng_free(rng);
+        return 1;
+    }
+
+    /* Test invivo params */
+    FerroParams invivo = ferro_params_invivo();
+    printf("\nIn-vivo params: scd_mufa_rate=%.3f, initial_mufa=%.2f\n",
+           invivo.scd_mufa_rate, invivo.initial_mufa_protection);
+
+    /* Test NULL safety */
+    FerroResult null_res = ferro_sim_cell(NULL, 0, &params, rng);
+    if (null_res.dead) {
+        fprintf(stderr, "FAIL: NULL cell should not return dead\n");
+        ferro_rng_free(rng);
+        return 1;
+    }
+
+    /* Cleanup */
+    ferro_rng_free(rng);
+    ferro_rng_free(NULL);  /* Should be a no-op */
+
+    printf("\nAll tests PASSED.\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
C FFI bindings so ferroptosis-core can be embedded in PhysiCell and other C/C++ frameworks. Follows the same wrapper-crate pattern as the Python bindings.

## C API

| Function | Purpose |
|----------|---------|
| `ferro_rng_new(seed)` | Create opaque RNG |
| `ferro_rng_free(rng)` | Free RNG (NULL-safe) |
| `ferro_params_default()` | 2D culture parameters |
| `ferro_params_invivo()` | In-vivo parameters |
| `ferro_gen_cell(phenotype, rng)` | Generate stochastic cell |
| `ferro_sim_cell(cell, treatment, params, rng)` | Full 180-step simulation |

## Types

- `FerroRng`: opaque pointer (Box<StdRng> internally)
- `FerroCell`: 7 f64 (iron, gsh, gpx4, fsp1, basal_ros, lipid_unsat, nrf2)
- `FerroParams`: 21 fields (20 f64 + 1 u32), `#[repr(C)]`
- `FerroResult`: dead (bool) + final_lp/gsh/gpx4

## Header generation
`include/ferroptosis.h` generated by cbindgen at build time. Includes `<stdbool.h>`, `<stdint.h>`. C++ compatible (`extern "C"` guards).

## C integration test
1000 Persister+RSL3 cells → 39.7% death rate (expected 30-55%). Verifies null safety, params, invivo, and death rate range.

## Blast radius
Zero changes to ferroptosis-core. New crate only.

## Test plan
- [x] `cargo build -p ferroptosis-ffi` produces cdylib + staticlib
- [x] `include/ferroptosis.h` generated with all types/functions
- [x] C test compiles, links, runs, passes (39.7% death rate)
- [x] 31 ferroptosis-core tests unchanged
- [x] NULL pointer safety verified
- [x] Invalid enum values default safely (no panic)

Closes #71