### PR TITLE
Update docs: test count 33→50, add news pipeline mentions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ The repo exists to compare therapeutic mechanisms, evidence depth, resistant-sta
 - tissue-of-origin analysis layer (5 tissue categories, 62% coverage)
 - simulation work: ferroptosis biochemistry, drug penetration, calibration
 - ferroptosis-core library packaging for external use
+- news source authentication pipeline (fetch, extract claims, verify, score, index)
 - broader strategy review of alternative therapies and biological bottlenecks
 
 ## Current Repo State
@@ -46,7 +47,8 @@ The repo exists to compare therapeutic mechanisms, evidence depth, resistant-sta
 - tissue-of-origin and weighted-evidence layers are active
 - diagnostic-therapy matching layer covers 6 chains across 4 modalities (radioligand, checkpoint, mRNA vaccine, oncolytic)
 - manuscript: 112 pages (book format), 11 chapters + 3 appendices, 19 figures, 33,344 words
-- simulation suite: 10 binaries (incl. sim-tumor-pk) + ferroptosis-core library (MIT licensed, 10 modules, 31 unit tests) + Python bindings + 33 Python smoke tests
+- simulation suite: 10 binaries (incl. sim-tumor-pk) + ferroptosis-core library (MIT licensed, 10 modules, 31 unit tests) + Python bindings + 50 Python smoke tests
+- news authentication pipeline: 5 scripts (fetch, extract claims, verify against PubMed, score credibility, build claim-centric index) implementing the 3-tier source framework from analysis/news-source-criteria.md
 - simulation calibration: 5 targets documented, evaluate script operational
 - drug penetration module: 3 tissue types, exponential Krogh approximation
 - drug combination modeling: 4 drugs, pairwise Bliss synergy scoring with pathway traces

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ These are computational predictions with documented assumptions and caveats, not
 |-----------|-----------------|
 | `analysis/` | 15+ analysis outputs: evidence tiers, tissue-of-origin, diagnostic-therapy matching, combination audits, gap analysis |
 | `article/drafts/` | Manuscript (v1.md + v1.tex) with 19 figures |
-| `scripts/` | Python pipeline: tagging, indexing, analysis, figure generation, LaTeX generation |
+| `scripts/` | Python pipeline: tagging, indexing, analysis, figure generation, LaTeX generation, news authentication pipeline |
 | `simulations/` | [10 Rust binaries](simulations/README.md) + ferroptosis-core library + [Python bindings](simulations/ferroptosis-python/) + calibration infrastructure |
 | `corpus/` | Full-text articles by PubMed ID + INDEX.jsonl |
 | `tags/` | Precomputed tag indexes (mechanism, cancer type, tissue, evidence level, diagnostic-therapy) |
-| `tests/` | 33 Python smoke tests for the analysis pipeline |
+| `tests/` | 50 Python smoke tests for the analysis and news pipelines |
 
 Start with the files in `analysis/` if you want to see what we've concluded so far—and where we're still uncertain.
 


### PR DESCRIPTION
## Summary

Post-#99 doc freshness fix. The news pipeline added 17 tests (33→50) and 5 new scripts that weren't mentioned in README or CLAUDE.md.

### Changes

| File | Fix |
|------|-----|
| README.md | Test count 33→50, scripts/ description includes news pipeline |
| CLAUDE.md | Test count 33→50, workstreams includes news pipeline, repo state describes 5 pipeline scripts |

### Verification
- 50 tests pass
- No manuscript or code changes