### PR TITLE
Update stale docs after Phase 1 merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ The repo exists to compare therapeutic mechanisms, evidence depth, resistant-sta
 - ferroptosis-core library packaging for external use
 - news source authentication pipeline (fetch, extract claims, verify, score, index)
 - broader strategy review of alternative therapies and biological bottlenecks
+- operational maturity: CI, figure traceability, archival release (Phase 2 in progress)
 
 ## Current Repo State
 
@@ -54,6 +55,9 @@ The repo exists to compare therapeutic mechanisms, evidence depth, resistant-sta
 - drug combination modeling: 4 drugs, pairwise Bliss synergy scoring with pathway traces
 - tumor microenvironment: oxygen gradients, spatial immune zones (DAMP diffusion, T cell activation, anti-PD-1), LP overshoot multiplier, CAF-mediated stromal protection (GSH/MUFA supply), pH gradient (iron release + drug ion trapping)
 - some landmark papers are known to be missing from the local full-text archive
+- content provenance manifest (PROVENANCE.yaml) documents asset licensing and redistribution rights
+- pinned Python environment (requirements-lock.txt, 32 packages) and Rust toolchain (rust-toolchain.toml, 1.92.0)
+- contributor guide (CONTRIBUTING.md), citation metadata (CITATION.cff), and pytest in tracked dependencies
 
 ## What To Optimize For
 
@@ -91,6 +95,10 @@ tags/                                     precomputed tag indexes
 article/book-outline.md                   frozen book outline and chapter contracts
 article/AUTHORING.md                      writing rules and heading conventions
 news/                                     news source scaffolding (issue #99)
+PROVENANCE.yaml                           content provenance and redistribution rights
+CONTRIBUTING.md                           contributor setup, testing, and PR guide
+CITATION.cff                              citation metadata (renders GitHub "Cite" button)
+requirements-lock.txt                     pinned Python dependency versions
 ```
 
 ## Search Conventions

--- a/README.md
+++ b/README.md
@@ -51,16 +51,17 @@ These are computational predictions with documented assumptions and caveats, not
 | `simulations/` | [10 Rust binaries](simulations/README.md) + ferroptosis-core library + [Python bindings](simulations/ferroptosis-python/) + calibration infrastructure |
 | `corpus/` | Full-text articles by PubMed ID + INDEX.jsonl |
 | `tags/` | Precomputed tag indexes (mechanism, cancer type, tissue, evidence level, diagnostic-therapy) |
+| `news/` | News source scaffolding: fetched articles, extracted claims, verification results, credibility scores |
 | `tests/` | 50 Python smoke tests for the analysis and news pipelines |
 
 Start with the files in `analysis/` if you want to see what we've concluded so far—and where we're still uncertain.
 
 ## Get it running
 
-If you want to reproduce or modify the analysis:
+See [CONTRIBUTING.md](CONTRIBUTING.md) for full setup instructions, or the quick version:
 
 ```bash
-pip install -r requirements.txt
+pip install -r requirements.txt          # or requirements-lock.txt for exact versions
 cp .env.example .env
 
 python scripts/tag_articles.py
@@ -101,12 +102,17 @@ We'd rather publish a longer, clearer document that a graduate student can follo
 
 This project is most useful when it's questioned, expanded, and corrected. You don't need to be a cancer researcher—curiosity and a willingness to look at the evidence are enough.
 
+- Read [CONTRIBUTING.md](CONTRIBUTING.md) for setup, testing, and PR guidelines
 - Open an issue with a question, a counter-example, or a missing paper
 - Submit a pull request that improves the code, the corpus, or the manuscript
 - Fork the repo and go in a completely new direction—MIT license means you're free to do that
 
 We're not trying to steer everyone toward one answer. The goal is to build a shared space where good ideas can emerge.
 
+## Cite this work
+
+If you use this work in your research, GitHub renders a "Cite this repository" button from [CITATION.cff](CITATION.cff). Content provenance and redistribution rights for bundled assets are documented in [PROVENANCE.yaml](PROVENANCE.yaml).
+
 ## License
 
-MIT License. See [LICENSE](LICENSE).
+MIT License (code only). See [LICENSE](LICENSE). Bundled data assets have their own licenses — see [PROVENANCE.yaml](PROVENANCE.yaml) for details.

--- a/article/book-outline.md
+++ b/article/book-outline.md
@@ -2,7 +2,7 @@
 
 **Working title:** Mapping Cancer Therapy Mechanisms, Evidence Gaps, and Resistant-State Hypotheses
 
-**Target:** ~50,000 words (current: ~16,000). 5 Parts, 11 chapters, 3 appendices.
+**Target:** ~50,000 words (current: ~33,300). 5 Parts, 11 chapters, 3 appendices.
 
 > **Note:** This is a planning document, not manuscript content. Headings here
 > use the outline's own hierarchy for readability. The manuscript heading

--- a/article/book-outline.md
+++ b/article/book-outline.md
@@ -2,7 +2,7 @@
 
 **Working title:** Mapping Cancer Therapy Mechanisms, Evidence Gaps, and Resistant-State Hypotheses
 
-**Target:** ~50,000 words (current: ~33,300). 5 Parts, 11 chapters, 3 appendices.
+**Target:** ~50,000 words (current: ~33,600). 5 Parts, 11 chapters, 3 appendices.
 
 > **Note:** This is a planning document, not manuscript content. Headings here
 > use the outline's own hierarchy for readability. The manuscript heading
@@ -215,7 +215,7 @@ Step-by-step: clone, build, run analysis, run simulations, compile PDF.
 | III: Simulations | 5-8 | ~9,200 | 16,500 |
 | IV: What's Next | 9-11 | ~4,700 | 11,500 |
 | V: References/Tools | Apps A-C | ~9,600 | 8,000 |
-| **Total** | **11 + 3 apps** | **~33,300** | **~54,000** |
+| **Total** | **11 + 3 apps** | **~33,600** | **~54,000** |
 
 ## Chapter → Issue Mapping
 


### PR DESCRIPTION
## Summary
- **README.md**: Add `news/` to directory table, reference CONTRIBUTING.md in setup/contribute sections, mention requirements-lock.txt, add "Cite this work" section, clarify MIT scope
- **CLAUDE.md**: Add Phase 2 workstream, document new files (PROVENANCE.yaml, requirements-lock.txt, rust-toolchain.toml, CONTRIBUTING.md, CITATION.cff) in repo state and key files
- **book-outline.md**: Fix stale header and table word count (16,000 → 33,600)

## Test plan
- [ ] Verify all links in README.md resolve (CONTRIBUTING.md, CITATION.cff, PROVENANCE.yaml, LICENSE)
- [ ] Confirm no code changes — doc-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)