### PR TITLE
Add CI workflow for Python smoke tests

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -23,6 +23,7 @@ on:
 
 jobs:
   test-linux:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,0 +1,64 @@
+name: Python Tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/**'
+      - 'tests/**'
+      - 'corpus/INDEX.jsonl'
+      - 'analysis/**'
+      - 'requirements*.txt'
+      - '.github/workflows/python-test.yml'
+  pull_request:
+    paths:
+      - 'scripts/**'
+      - 'tests/**'
+      - 'corpus/INDEX.jsonl'
+      - 'analysis/**'
+      - 'requirements*.txt'
+      - '.github/workflows/python-test.yml'
+  schedule:
+    - cron: '0 8 * * 1'  # Weekly Monday 8am UTC (macOS only)
+
+jobs:
+  test-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          lfs: false
+          fetch-depth: 1
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install -r requirements-lock.txt
+
+      - name: Run smoke tests
+        run: python -m pytest tests/ -v --tb=short
+
+  test-macos:
+    if: github.event_name == 'schedule'
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          lfs: false
+          fetch-depth: 1
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install -r requirements-lock.txt
+
+      - name: Run smoke tests
+        run: python -m pytest tests/ -v --tb=short


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/python-test.yml` running all 50 Python smoke tests
- **Linux** on every push to main and every PR (path-filtered)
- **macOS** on weekly schedule only (Monday 8am UTC) — owner directive: too expensive for PR path
- Uses `requirements-lock.txt` for deterministic installs, Python 3.12, `lfs: false`, `fetch-depth: 1`

## Design decisions
- **Path filter:** `scripts/`, `tests/`, `corpus/INDEX.jsonl`, `analysis/`, `requirements*.txt`, self. Excludes `news/**` (tests import from scripts/ but don't read from news/).
- **No pip cache:** Install is ~30s. Caching adds complexity for negligible gain.
- **`python -m pytest` not `pytest`:** Ensures correct interpreter.

## Known items
- If `requirements-lock.txt` fails on Linux (generated on macOS), regenerate with: `python3 -m venv /tmp/lock-env && /tmp/lock-env/bin/pip install -r requirements.txt && /tmp/lock-env/bin/pip freeze > requirements-lock.txt`
- `test_score_formula_tier1` has a hardcoded date (2026-04-01) — pre-existing future flake, not introduced here
- Discovered: `cargo-test.yml` uses `@stable` instead of pinned 1.92.0 from `rust-toolchain.toml` — separate micro-fix needed

## Test plan
- [ ] Workflow self-triggers on this PR (`.github/workflows/python-test.yml` in path filter)
- [ ] All 50 tests pass on ubuntu-latest
- [ ] Total time < 3 minutes
- [ ] No LFS download in checkout step logs

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)