### PR TITLE
Add invariant and integration tests for scientific validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ The repo exists to compare therapeutic mechanisms, evidence depth, resistant-sta
 - tissue-of-origin and weighted-evidence layers are active
 - diagnostic-therapy matching layer covers 6 chains across 4 modalities (radioligand, checkpoint, mRNA vaccine, oncolytic)
 - manuscript: 112 pages (book format), 11 chapters + 3 appendices, 20 figures, ~34,200 words
-- simulation suite: 10 binaries (incl. sim-tumor-pk) + ferroptosis-core library (MIT licensed, 10 modules, 31 unit tests) + Python bindings + 60 Python tests (50 pipeline smoke + 10 figure traceability)
+- simulation suite: 10 binaries (incl. sim-tumor-pk) + ferroptosis-core library (MIT licensed, 10 modules, 31 unit tests) + Python bindings + 79 Python tests (50 pipeline smoke + 10 figure traceability + 19 invariant/integration)
 - news authentication pipeline: 5 scripts (fetch, extract claims, verify against PubMed, score credibility, build claim-centric index) implementing the 3-tier source framework from analysis/news-source-criteria.md
 - simulation calibration: 5 targets documented, evaluate script operational
 - drug penetration module: 3 tissue types, exponential Krogh approximation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ cd ..
 ## Running Tests
 
 ```bash
-# Python pipeline, news, and figure traceability tests (60 tests)
+# Python pipeline, news, figure traceability, invariant, and integration tests (79 tests)
 python3 -m pytest tests/ -q
 
 # Rust simulation tests (31+ tests)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ These are computational predictions with documented assumptions and caveats, not
 | `corpus/` | Full-text articles by PubMed ID + INDEX.jsonl |
 | `tags/` | Precomputed tag indexes (mechanism, cancer type, tissue, evidence level, diagnostic-therapy) |
 | `news/` | News source scaffolding: fetched articles, extracted claims, verification results, credibility scores |
-| `tests/` | 60 Python tests (50 pipeline smoke + 10 figure traceability) |
+| `tests/` | 79 Python tests (50 pipeline smoke + 10 figure traceability + 19 invariant/integration) |
 
 Start with the files in `analysis/` if you want to see what we've concluded so far—and where we're still uncertain.
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,132 @@
+"""
+Integration tests for pipeline functions.
+
+These test actual function logic with known inputs and expected
+outputs (using tolerance bands for floats). They catch formula
+errors, keyword matching regressions, and scoring bugs.
+
+Run: pytest tests/test_integration.py -v
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+# ============================================================
+# Tagging integration
+# ============================================================
+
+class TestTaggingIntegration:
+    """Tagging functions should produce correct, deterministic results."""
+
+    def test_match_keywords_deterministic(self):
+        """Same input must always produce the same output."""
+        from tag_articles import match_keywords
+        from config import MECHANISM_KEYWORDS
+
+        text = "immunotherapy checkpoint inhibitor combined with sonodynamic therapy"
+        r1 = match_keywords(text, MECHANISM_KEYWORDS)
+        r2 = match_keywords(text, MECHANISM_KEYWORDS)
+        assert r1 == r2
+
+    def test_match_keywords_crispr(self):
+        """CRISPR-related text should match the crispr mechanism."""
+        from tag_articles import match_keywords
+        from config import MECHANISM_KEYWORDS
+
+        text = "this study uses CRISPR-Cas9 gene editing to target tumor cells"
+        result = match_keywords(text, MECHANISM_KEYWORDS)
+        assert "crispr" in result, f"Expected 'crispr' in {result}"
+
+    def test_match_keywords_no_match(self):
+        """Text with no mechanism-related content should return empty."""
+        from tag_articles import match_keywords
+        from config import MECHANISM_KEYWORDS
+
+        text = "this paper is about cooking recipes and gardening tips"
+        result = match_keywords(text, MECHANISM_KEYWORDS)
+        assert len(result) == 0, f"Expected no matches, got {result}"
+
+    def test_match_keywords_multi_mechanism(self):
+        """Text mentioning multiple mechanisms should return all of them."""
+        from tag_articles import match_keywords
+        from config import MECHANISM_KEYWORDS
+
+        text = "nanoparticle-based delivery of checkpoint immunotherapy with CAR-T cell combination"
+        result = match_keywords(text, MECHANISM_KEYWORDS)
+        assert len(result) >= 2, f"Expected 2+ mechanisms, got {result}"
+        assert "nanoparticle" in result
+        assert "immunotherapy" in result
+
+
+# ============================================================
+# Evidence weight integration
+# ============================================================
+
+class TestEvidenceWeightIntegration:
+    """Evidence weight function should return consistent values for known inputs.
+
+    All comparisons use tolerance bands, not exact floating-point matching.
+    """
+
+    def test_phase3_high_citation_recent(self):
+        """Phase III with high citation and recent year should score ~18.8."""
+        from analyze_corpus import evidence_weight
+
+        entry = {"evidence_level": "phase3-clinical", "icite_percentile": 90, "year": 2025}
+        w = evidence_weight(entry)
+        # phase3(12) × citation(1.45) × recency(~1.082) ≈ 18.82
+        assert 18.0 < w < 20.0, f"Expected ~18.8, got {w:.2f}"
+
+    def test_preclinical_low_citation_old(self):
+        """Preclinical in-vitro with low citation and old year should score ~0.96."""
+        from analyze_corpus import evidence_weight
+
+        entry = {"evidence_level": "preclinical-invitro", "icite_percentile": 10, "year": 2016}
+        w = evidence_weight(entry)
+        # invitro(1.0) × citation(1.05) × recency(~0.918) ≈ 0.96
+        assert 0.9 < w < 1.1, f"Expected ~0.96, got {w:.2f}"
+
+    def test_missing_percentile_defaults_gracefully(self):
+        """Missing citation percentile should still produce a positive weight."""
+        from analyze_corpus import evidence_weight
+
+        entry = {"evidence_level": "phase1-clinical", "year": 2022}
+        w = evidence_weight(entry)
+        assert w > 0, f"Should produce positive weight with missing percentile, got {w}"
+
+    def test_missing_year_defaults_gracefully(self):
+        """Missing year should still produce a positive weight."""
+        from analyze_corpus import evidence_weight
+
+        entry = {"evidence_level": "phase2-clinical", "icite_percentile": 50}
+        w = evidence_weight(entry)
+        assert w > 0, f"Should produce positive weight with missing year, got {w}"
+
+
+# ============================================================
+# News pipeline integration
+# ============================================================
+
+class TestNewsScoreIntegration:
+    """News scoring should produce bounded results for edge-case inputs."""
+
+    def test_compute_score_within_bounds(self):
+        """Score for any valid input must be in [0, 100]."""
+        from score_news import compute_score
+
+        fm = {
+            "tier": 1,
+            "claims": [],
+            "author_credentialed": False,
+            "author": "",
+            "date_published": None,
+        }
+        score = compute_score(fm)
+        assert 0 <= score <= 100, f"Score {score} out of [0, 100] range"

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -1,0 +1,163 @@
+"""
+Invariant and property tests for corpus analysis outputs.
+
+These tests verify mathematical properties that must hold regardless
+of corpus size or content: monotonicity, positivity, ordering,
+schema consistency. They catch broken formulas and configuration
+drift without relying on exact floating-point matching.
+
+Run: pytest tests/test_invariants.py -v
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+INDEX_FILE = REPO_ROOT / "corpus" / "INDEX.jsonl"
+
+
+# ============================================================
+# INDEX.jsonl schema invariants
+# ============================================================
+
+class TestIndexSchema:
+    """INDEX.jsonl should have consistent required fields in every entry."""
+
+    REQUIRED_FIELDS = {
+        "pmid", "title", "mechanisms", "cancer_types", "evidence_level",
+        "journal", "year", "doi", "is_oa", "oa_status", "author_count",
+        "biology_processes", "pathway_targets", "resistant_states",
+        "tissue_categories", "date_added", "pmcid", "cited_by_count", "month",
+    }
+
+    @pytest.fixture
+    def entries(self):
+        if not INDEX_FILE.exists():
+            pytest.skip("INDEX.jsonl not found")
+        return [json.loads(line) for line in INDEX_FILE.read_text().splitlines() if line.strip()]
+
+    def test_all_entries_have_required_fields(self, entries):
+        """Every entry must contain all 19 required fields."""
+        for i, entry in enumerate(entries):
+            missing = self.REQUIRED_FIELDS - set(entry.keys())
+            assert not missing, (
+                f"Entry {i} (PMID {entry.get('pmid', '?')}) missing fields: {missing}"
+            )
+
+    def test_all_entries_have_nonempty_pmid(self, entries):
+        """Every entry must have a non-empty pmid."""
+        for entry in entries:
+            assert entry.get("pmid"), (
+                f"Entry missing or empty pmid: {entry.get('title', '?')[:60]}"
+            )
+
+    def test_mechanisms_is_list(self, entries):
+        """Mechanisms field must be a list (possibly empty)."""
+        for entry in entries:
+            assert isinstance(entry.get("mechanisms"), list), (
+                f"PMID {entry['pmid']}: mechanisms is {type(entry.get('mechanisms'))}, expected list"
+            )
+
+    def test_evidence_levels_valid(self, entries):
+        """Evidence level must be from the valid set or empty string."""
+        valid = {
+            "phase3-clinical", "phase2-clinical", "phase1-clinical",
+            "clinical-other", "preclinical-invivo", "preclinical-invitro",
+            "theoretical", "",
+        }
+        for entry in entries:
+            level = entry.get("evidence_level", "")
+            assert level in valid, (
+                f"PMID {entry['pmid']}: invalid evidence_level '{level}'"
+            )
+
+
+# ============================================================
+# Evidence weight formula invariants
+# ============================================================
+
+class TestWeightInvariants:
+    """Evidence weighting formula must satisfy mathematical properties."""
+
+    def test_tier_monotonicity(self):
+        """Higher evidence tier must always produce higher weight (same citation/year)."""
+        from analyze_corpus import evidence_weight
+
+        tiers = [
+            "theoretical", "preclinical-invitro", "preclinical-invivo",
+            "clinical-other", "phase1-clinical", "phase2-clinical", "phase3-clinical",
+        ]
+        base_entry = {"icite_percentile": 50, "year": 2023}
+        prev = 0.0
+        for tier in tiers:
+            w = evidence_weight({**base_entry, "evidence_level": tier})
+            assert w > prev, f"{tier} weight {w:.2f} should exceed previous {prev:.2f}"
+            prev = w
+
+    def test_all_tiers_produce_positive_weight(self):
+        """Every valid evidence tier must produce a positive weight."""
+        from analyze_corpus import evidence_weight, EVIDENCE_TIER_WEIGHTS
+
+        for tier in EVIDENCE_TIER_WEIGHTS:
+            entry = {"evidence_level": tier, "icite_percentile": 0, "year": 2015}
+            w = evidence_weight(entry)
+            assert w > 0, f"Weight for {tier} should be positive, got {w}"
+
+    def test_weight_upper_bound(self):
+        """Max weight must not exceed theoretical maximum (~19.8)."""
+        from analyze_corpus import evidence_weight
+
+        # Max: phase3(12) × citation(1.5) × recency(1.1) = 19.8
+        entry = {"evidence_level": "phase3-clinical", "icite_percentile": 100, "year": 2026}
+        w = evidence_weight(entry)
+        assert w <= 20.0, f"Max weight {w:.2f} exceeds theoretical max ~19.8"
+        assert w > 19.0, f"Max weight {w:.2f} unexpectedly low (expected ~19.8)"
+
+    def test_no_evidence_returns_zero(self):
+        """Missing or invalid evidence level must return zero weight."""
+        from analyze_corpus import evidence_weight
+
+        assert evidence_weight({}) == 0.0
+        assert evidence_weight({"evidence_level": ""}) == 0.0
+        assert evidence_weight({"evidence_level": "garbage"}) == 0.0
+
+
+# ============================================================
+# Corpus-level invariants
+# ============================================================
+
+class TestCorpusInvariants:
+    """Properties that must hold for any valid corpus."""
+
+    @pytest.fixture
+    def entries(self):
+        if not INDEX_FILE.exists():
+            pytest.skip("INDEX.jsonl not found")
+        return [json.loads(line) for line in INDEX_FILE.read_text().splitlines() if line.strip()]
+
+    def test_immunotherapy_is_rank_1_by_count(self, entries):
+        """Immunotherapy should be the most-published mechanism by article count."""
+        from collections import Counter
+
+        counts = Counter()
+        for e in entries:
+            for m in e.get("mechanisms", []):
+                counts[m] += 1
+        top_mechanism, top_count = counts.most_common(1)[0]
+        assert top_mechanism == "immunotherapy", (
+            f"Expected immunotherapy as rank 1, got {top_mechanism} ({top_count} articles)"
+        )
+
+    def test_majority_have_mechanism_tags(self, entries):
+        """At least 80% of entries should have one or more mechanism tags."""
+        with_mechs = sum(1 for e in entries if e.get("mechanisms"))
+        pct = with_mechs / len(entries)
+        assert pct > 0.80, (
+            f"Only {pct:.1%} of entries have mechanism tags (expected >80%)"
+        )

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -141,23 +141,30 @@ class TestCorpusInvariants:
             pytest.skip("INDEX.jsonl not found")
         return [json.loads(line) for line in INDEX_FILE.read_text().splitlines() if line.strip()]
 
-    def test_immunotherapy_is_rank_1_by_count(self, entries):
-        """Immunotherapy should be the most-published mechanism by article count."""
+    def test_mechanism_counts_are_non_negative(self, entries):
+        """No mechanism should have a negative article count (sanity check on Counter logic)."""
         from collections import Counter
 
         counts = Counter()
         for e in entries:
             for m in e.get("mechanisms", []):
                 counts[m] += 1
-        top_mechanism, top_count = counts.most_common(1)[0]
-        assert top_mechanism == "immunotherapy", (
-            f"Expected immunotherapy as rank 1, got {top_mechanism} ({top_count} articles)"
-        )
+        for mech, count in counts.items():
+            assert count > 0, f"Mechanism {mech} has non-positive count {count}"
 
-    def test_majority_have_mechanism_tags(self, entries):
-        """At least 80% of entries should have one or more mechanism tags."""
-        with_mechs = sum(1 for e in entries if e.get("mechanisms"))
-        pct = with_mechs / len(entries)
-        assert pct > 0.80, (
-            f"Only {pct:.1%} of entries have mechanism tags (expected >80%)"
-        )
+    def test_weighted_scores_consistent_with_tagged_counts(self, entries):
+        """Mechanisms with more tagged evidence articles cannot have zero total weight."""
+        from analyze_corpus import evidence_weight
+
+        from collections import defaultdict
+        mech_tagged = defaultdict(list)
+        for e in entries:
+            if e.get("evidence_level"):
+                for m in e.get("mechanisms", []):
+                    mech_tagged[m].append(e)
+
+        for mech, tagged in mech_tagged.items():
+            total_weight = sum(evidence_weight(e) for e in tagged)
+            assert total_weight > 0, (
+                f"Mechanism {mech} has {len(tagged)} tagged articles but zero total weight"
+            )


### PR DESCRIPTION
## Summary
19 new tests across 2 new files expanding the suite from smoke checks to scientific validation. No exact floating-point matching — all comparisons use tolerance bands.

## New test files

**tests/test_invariants.py** (10 tests):
| Test | What it catches |
|------|----------------|
| 19 required INDEX fields | Schema drift (field removed/renamed) |
| Non-empty PMIDs | Data corruption |
| Mechanisms is list type | Serialization bugs |
| Valid evidence levels | Typo in evidence tagger |
| Tier weight monotonicity | Swapped tier weights in formula |
| All tiers positive | Accidental zero/negative weight |
| Weight upper bound ≤19.8 | Formula overflow |
| No-evidence returns zero | Missing guard clause |
| Mechanism counts non-negative | Counter logic sanity |
| Tagged evidence → positive weight | Weight formula consistency |

**tests/test_integration.py** (9 tests):
| Test | What it catches |
|------|----------------|
| match_keywords deterministic | Non-determinism introduced |
| CRISPR text matches | Keyword list regression |
| No-match text returns empty | False positive keywords |
| Multi-mechanism detection | Matching logic broken |
| Phase3/high-citation weight ~18.8 | Formula arithmetic error |
| Invitro/low-citation weight ~0.96 | Citation modifier bug |
| Missing percentile handled | Crash on missing data |
| Missing year handled | Crash on missing data |
| News score in [0, 100] | Score formula unbounded |

## Design decisions
- **Tolerance bands, not exact floats**: `18.0 < w < 20.0` catches formula errors but tolerates platform differences
- **No corpus-snapshot assertions**: All invariants hold across corpus evolution (no "immunotherapy is rank 1" or ">80% tagged" — those were removed after review)
- **No duplicate tests**: Verified all 38 existing test names — no overlap
- **No conftest.py**: Same import pattern as existing tests

## Test plan
- [x] `python3 -m pytest tests/ -q` — 79 passed (was 60)
- [x] Zero stale "60 test" references in docs
- [x] All assertions verified against real data during planning

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)