### PR TITLE
Fix code scanning alerts: sensitive logging and missing permissions

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -11,6 +11,9 @@ on:
       - 'simulations/**'
       - '.github/workflows/cargo-test.yml'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/scripts/fetch_semantic_scholar.py
+++ b/scripts/fetch_semantic_scholar.py
@@ -297,7 +297,7 @@ def main():
         print("ERROR: SEMANTIC_SCHOLAR_API_KEY not set in .env", file=sys.stderr)
         sys.exit(1)
 
-    print(f"Semantic Scholar API key: ...{SEMANTIC_SCHOLAR_API_KEY[-6:]}")
+    print("Semantic Scholar API key: configured")
     print(f"Mode: {args.mode}\n")
 
     if args.mode == "search":


### PR DESCRIPTION
## Summary
Fixes 2 open code scanning alerts from https://github.com/ELares/cancer_research/security/code-scanning

### Alert #2: Clear-text logging of sensitive data
**File:** `scripts/fetch_semantic_scholar.py:300`
**Fix:** Replace `print(f"Semantic Scholar API key: ...{key[-6:]}")` with `print("Semantic Scholar API key: configured")`. Logging even partial API keys is flagged as sensitive data exposure.

### Alert #1: Missing workflow permissions
**File:** `.github/workflows/cargo-test.yml`
**Fix:** Add `permissions: contents: read` block. Follows principle of least privilege — the workflow only needs to read the repo, not write.

## Test plan
- [x] `python3 -m pytest tests/ -q` — 79 passed
- [x] No functional behavior change (confirmation message still prints, workflow still runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)