### PR TITLE
Remove bibtex from release-pdf.yml CI pipeline

### DIFF
--- a/.github/workflows/release-pdf.yml
+++ b/.github/workflows/release-pdf.yml
@@ -41,11 +41,9 @@ jobs:
       - name: Generate LaTeX from Markdown
         run: python3 scripts/generate_latex.py
 
-      - name: Compile PDF (pdflatex + bibtex, 3-pass)
+      - name: Compile PDF (pdflatex, 2-pass)
         working-directory: article/drafts
         run: |
-          pdflatex -interaction=nonstopmode v1.tex
-          bibtex v1
           pdflatex -interaction=nonstopmode v1.tex
           pdflatex -interaction=nonstopmode v1.tex
 


### PR DESCRIPTION
## Summary
PR #163 switched citations from `\cite{}`/bibtex to inline `\footnote{}`. The release-pdf.yml workflow still runs `bibtex v1`, which fails with exit code 2 because there are no `\citation`, `\bibdata`, or `\bibstyle` commands in the aux file.

**Fix:** 2-pass pdflatex (cross-refs + TOC), no bibtex step.

Fixes the failed action: https://github.com/ELares/cancer_research/actions/runs/24943779352

## Test plan
- [ ] CI action succeeds on merge (pdflatex 2-pass produces PDF)

🤖 Generated with [Claude Code](https://claude.com/claude-code)