### PR TITLE
Update word count after citation footnote conversion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ The repo exists to compare therapeutic mechanisms, evidence depth, resistant-sta
 - evidence tagging is improved but still incomplete (gold-set measured)
 - tissue-of-origin and weighted-evidence layers are active
 - diagnostic-therapy matching layer covers 6 chains across 4 modalities (radioligand, checkpoint, mRNA vaccine, oncolytic)
-- manuscript: 112 pages (book format), 11 chapters + 3 appendices, 20 figures, ~34,600 words
+- manuscript: 112 pages (book format), 11 chapters + 3 appendices, 20 figures, ~36,700 words
 - simulation suite: 10 binaries (incl. sim-tumor-pk) + ferroptosis-core library (MIT licensed, 10 modules, 31 unit tests) + Python bindings + 79 Python tests (50 pipeline smoke + 10 figure traceability + 19 invariant/integration)
 - news authentication pipeline: 5 scripts (fetch, extract claims, verify against PubMed, score credibility, build claim-centric index) implementing the 3-tier source framework from analysis/news-source-criteria.md
 - simulation calibration: 5 targets documented, evaluate script operational

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you have expertise in oncology, biochemistry, ferroptosis, immunology, comput
 - **10 Rust simulation binaries** modeling ferroptosis biochemistry: single-cell Monte Carlo, spatial tumors, drug penetration, drug combinations, tumor microenvironment (oxygen gradients, spatial immune zones, DAMP-mediated T cell activation), vulnerability windows, ICD immune cascades, tumor PK
 - **ferroptosis-core library** (MIT, with Python bindings) — embeddable ferroptosis biochemistry engine with 10 modules and 31 unit tests
 - **Calibration infrastructure** linking simulation parameters to published experimental data
-- **112-page book-format manuscript** with 11 chapters, 3 appendices, and 20 figures (~34,600 words), cross-referenced against all analysis outputs
+- **112-page book-format manuscript** with 11 chapters, 3 appendices, and 20 figures (~36,700 words), cross-referenced against all analysis outputs
 
 Everything is organised so you can re-run the pipeline, challenge the conclusions, or extend the work in directions we haven't thought of yet.
 


### PR DESCRIPTION
## Summary
- README.md + CLAUDE.md: word count ~34,600 → ~36,700 (footnote definitions added ~2,100 words)

## Test plan
- [ ] No code changes — doc-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)