### PR TITLE
Upgrade pyo3 0.23 → 0.24 to fix buffer overflow vulnerability

### DIFF
--- a/simulations/ferroptosis-python/Cargo.toml
+++ b/simulations/ferroptosis-python/Cargo.toml
@@ -12,6 +12,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 ferroptosis-core = { path = "../ferroptosis-core" }
-pyo3 = { version = "0.23", features = ["extension-module"] }
+pyo3 = { version = "0.24", features = ["extension-module"] }
 rand = "0.8"
 rayon = "1.10"


### PR DESCRIPTION
## Summary
Fixes Dependabot alerts #1 and #3: pyo3 < 0.24.1 has a risk of buffer overflow in `PyString::from_object` (low severity).

**Change:** `simulations/ferroptosis-python/Cargo.toml`: pyo3 `0.23` → `0.24`

## Test plan
- [x] `maturin develop -m ferroptosis-python/Cargo.toml --release` — builds
- [x] Python bindings work: `fc.sim_batch('Persister', 'SDT', n=100, seed=42)` returns correct result
- [x] `cargo test --workspace` — 31 passed
- [x] `python3 -m pytest tests/ -q` — 79 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)