### PR TITLE
Add dependabot.yml to fix Cargo ecosystem discovery

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/simulations"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
Dependabot failed with "No Cargo.toml!" because the workspace is in `simulations/`, not the repo root.

Adds `.github/dependabot.yml` configuring three ecosystems:
- **Cargo:** `/simulations` (Rust workspace)
- **pip:** `/` (requirements.txt)
- **GitHub Actions:** `/` (workflow files)

Weekly schedule for all three.

Fixes: https://github.com/ELares/cancer_research/actions/runs/24943981472

🤖 Generated with [Claude Code](https://claude.com/claude-code)