### PR TITLE
Photosensitizer PK + DLI scaling for PDT physics (#200)

### DIFF
--- a/simulations/Cargo.lock
+++ b/simulations/Cargo.lock
@@ -217,7 +217,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferroptosis-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "csv",
  "ndarray",

--- a/simulations/calibration/parameter_provenance.md
+++ b/simulations/calibration/parameter_provenance.md
@@ -40,6 +40,8 @@ Every simulation parameter, its default value, source, and whether it is experim
 | `sdt_freq_mhz` | 1.0 | Typical SDT frequency | Grounded | Moderate — operating frequency |
 | `sdt_i0` | 1.0 | Relative units | N/A | Low — incident intensity normalization |
 | `neighbor_iron_fraction` | 0.1 | Mechanistic estimate (8-neighborhood) | Assumed | Low |
+| `photosensitizer` | `Uniform(1.0)` (default) | `Photosensitizer::Porfimer { t_half_h: 504.0 }` from Bellnier DA et al., Lasers Surg Med 2006 (PMID 16634075): porfimer terminal plasma t½ ≈ 21 d in humans; reported range ~250–500+ h depending on infusion protocol | Estimated (porfimer); N/A (`Uniform` default) | Low at DLI ≪ t½; scales linearly with DLI/t½ ratio |
+| `t_drug_light_interval_h` | 0.0 | Operational parameter (clinical schedule choice, not biology) | N/A | High — at DLI = 0 has no effect; at DLI ~ t½ halves PDT dose |
 
 ## Immune Cascade (`ImmuneParams`)
 
@@ -68,3 +70,11 @@ Every simulation parameter, its default value, source, and whether it is experim
 - **Estimated** (informed by literature ranges but not directly calibrated): most biochemistry rates
 - **Assumed** (mechanistic placeholder with no direct data): `gsh_km`, `gpx4_degradation_by_ros`, `gpx4_nrf2_upregulation`, `death_threshold`, immune cascade parameters
 - **Derived** (calculated from other parameters): `initial_mufa_protection`
+
+## RSL3 pharmacokinetics: known uncalibrated
+
+`tumor_pk::TumorPKParams` and the Krogh penetration model in `drug_transport` use RSL3-like parameters (e.g., plasma t½ ≈ 30 min, `k_uptake_bulk`, `km_uptake`) that are **order-of-magnitude estimates from chemical-probe literature, not clinical measurements.** RSL3 has no published clinical PK profile — it is widely cited as a research probe with poor pharmacokinetics, not a development candidate (e.g., review in Yang et al., Nature 2023, on ferroptosis therapeutics). Sensitivity of manuscript claims to these values is bounded by the protection-factor range reported in Chapter 8.2 (4.8×–27×) — qualitative conclusions about tumor-PK barriers are robust, but absolute kill rates should be read as approximate. A future issue should anchor PK parameters either to a clinically published ferroptosis inducer (e.g., IKE) or to a non-RSL3 reference compound.
+
+## Photosensitizer pharmacokinetics: plasma vs. cellular
+
+`Photosensitizer::Porfimer { t_half_h }` represents *plasma* terminal half-life. Cellular concentration is assumed to track plasma proportionally — a reasonable approximation for porfimer (slow-distributing, weeks-scale t½, ~100% serum-protein bound, Vd ≈ plasma volume per Bellnier 2006) but explicitly wrong for 5-ALA/PpIX, which accumulates intracellularly via ferrochelatase deficiency rather than decaying. The current model captures *intra-drug temporal* PK only; it does not account for inter-drug singlet-O₂ quantum-yield differences (`phi_so2`), which are implicit in the calibrated `Params::pdt_ros`. Inter-drug ROS-yield comparisons require explicit `phi_so2` normalization — see issue #200 follow-ups.

--- a/simulations/calibration/parameter_provenance.md
+++ b/simulations/calibration/parameter_provenance.md
@@ -41,7 +41,7 @@ Every simulation parameter, its default value, source, and whether it is experim
 | `sdt_i0` | 1.0 | Relative units | N/A | Low — incident intensity normalization |
 | `neighbor_iron_fraction` | 0.1 | Mechanistic estimate (8-neighborhood) | Assumed | Low |
 | `photosensitizer` | `Uniform(1.0)` (default) | `Photosensitizer::Porfimer { t_half_h: 504.0 }` from Bellnier DA et al., Lasers Surg Med 2006 (PMID 16634075): porfimer terminal plasma t½ ≈ 21 d in humans; reported range ~250–500+ h depending on infusion protocol | Estimated (porfimer); N/A (`Uniform` default) | Low at DLI ≪ t½; scales linearly with DLI/t½ ratio |
-| `t_drug_light_interval_h` | 0.0 | Operational parameter (clinical schedule choice, not biology) | N/A | High — at DLI = 0 has no effect; at DLI ~ t½ halves PDT dose |
+| `t_drug_light_interval_h` | 0.0 | Operational parameter. Hours from photosensitizer post-distribution peak to light, passed to `Photosensitizer::concentration_at`. **Not** the clinical DLI from injection — clinical DLI ≈ distribution_phase + this. Distribution phase is ~24–48 h for porfimer (Bellnier 2006); larger relative error for short-t½ drugs. | N/A | High — at DLI = 0 has no effect; at DLI ~ t½ halves PDT dose |
 
 ## Immune Cascade (`ImmuneParams`)
 

--- a/simulations/ferroptosis-core/Cargo.toml
+++ b/simulations/ferroptosis-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferroptosis-core"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Embeddable ferroptosis biochemistry engine for cancer simulation"
 license = "MIT"

--- a/simulations/ferroptosis-core/README.md
+++ b/simulations/ferroptosis-core/README.md
@@ -28,6 +28,7 @@ Run the included example: `cargo run -p ferroptosis-core --example basic_usage`
 | Module | Purpose |
 |--------|---------|
 | `cell` | Cell types, phenotypes (Glycolytic, OXPHOS, Persister, PersisterNrf2, Stromal), treatments, stochastic cell generation |
+| `photosensitizer_pk` | Photosensitizer plasma PK and drug-light-interval scaling for PDT |
 | `params` | All rate constants: `Params` (biochemistry), `SpatialParams` (physics), `ImmuneParams` (immune cascade), `RecoveryRates` |
 | `biochem` | Core simulation engine: `sim_cell` (full 180-step loop), `sim_cell_step` (single timestep for spatial interleaving) |
 | `stats` | Wilson confidence intervals, parallel Monte Carlo execution via rayon |
@@ -37,7 +38,6 @@ Run the included example: `cargo run -p ferroptosis-core --example basic_usage`
 | `io` | JSON and CSV output helpers |
 | `drug_transport` | Krogh cylinder drug penetration model |
 | `tumor_pk` | Two-compartment vascular/interstitial pharmacokinetics |
-| `photosensitizer_pk` | Photosensitizer plasma PK and drug-light-interval scaling for PDT |
 
 ## Key API
 

--- a/simulations/ferroptosis-core/README.md
+++ b/simulations/ferroptosis-core/README.md
@@ -37,6 +37,7 @@ Run the included example: `cargo run -p ferroptosis-core --example basic_usage`
 | `io` | JSON and CSV output helpers |
 | `drug_transport` | Krogh cylinder drug penetration model |
 | `tumor_pk` | Two-compartment vascular/interstitial pharmacokinetics |
+| `photosensitizer_pk` | Photosensitizer plasma PK and drug-light-interval scaling for PDT |
 
 ## Key API
 

--- a/simulations/ferroptosis-core/src/lib.rs
+++ b/simulations/ferroptosis-core/src/lib.rs
@@ -28,6 +28,7 @@
 //! | [`io`] | JSON and CSV output helpers |
 //! | [`drug_transport`] | Tissue-specific drug penetration (Krogh cylinder approximation) |
 //! | [`tumor_pk`] | Two-compartment vascular/interstitial pharmacokinetics |
+//! | [`photosensitizer_pk`] | Photosensitizer plasma PK and drug-light-interval scaling for PDT |
 
 pub mod cell;
 pub mod params;
@@ -39,3 +40,4 @@ pub mod immune;
 pub mod io;
 pub mod drug_transport;
 pub mod tumor_pk;
+pub mod photosensitizer_pk;

--- a/simulations/ferroptosis-core/src/lib.rs
+++ b/simulations/ferroptosis-core/src/lib.rs
@@ -19,6 +19,7 @@
 //! | Module | Purpose |
 //! |--------|---------|
 //! | [`cell`] | Phenotypes, treatments, stochastic cell generation |
+//! | [`photosensitizer_pk`] | Photosensitizer plasma PK and drug-light-interval scaling for PDT |
 //! | [`params`] | Rate constants for biochemistry, physics, immune cascade |
 //! | [`biochem`] | Core simulation engine |
 //! | [`stats`] | Wilson CIs, parallel Monte Carlo execution |
@@ -28,9 +29,13 @@
 //! | [`io`] | JSON and CSV output helpers |
 //! | [`drug_transport`] | Tissue-specific drug penetration (Krogh cylinder approximation) |
 //! | [`tumor_pk`] | Two-compartment vascular/interstitial pharmacokinetics |
-//! | [`photosensitizer_pk`] | Photosensitizer plasma PK and drug-light-interval scaling for PDT |
 
+// `photosensitizer_pk` is declared before `params` because `SpatialParams`
+// holds a `Photosensitizer`. Rust resolves all `mod` declarations together
+// so the order is not required by the compiler, but listing the dependency
+// first matches reading order.
 pub mod cell;
+pub mod photosensitizer_pk;
 pub mod params;
 pub mod biochem;
 pub mod stats;
@@ -40,4 +45,3 @@ pub mod immune;
 pub mod io;
 pub mod drug_transport;
 pub mod tumor_pk;
-pub mod photosensitizer_pk;

--- a/simulations/ferroptosis-core/src/lib.rs
+++ b/simulations/ferroptosis-core/src/lib.rs
@@ -30,11 +30,8 @@
 //! | [`drug_transport`] | Tissue-specific drug penetration (Krogh cylinder approximation) |
 //! | [`tumor_pk`] | Two-compartment vascular/interstitial pharmacokinetics |
 
-// `photosensitizer_pk` is declared before `params` because `SpatialParams`
-// holds a `Photosensitizer`. Rust resolves all `mod` declarations together
-// so the order is not required by the compiler, but listing the dependency
-// first matches reading order.
 pub mod cell;
+// Listed before `params` because `SpatialParams` holds a `Photosensitizer`.
 pub mod photosensitizer_pk;
 pub mod params;
 pub mod biochem;

--- a/simulations/ferroptosis-core/src/params.rs
+++ b/simulations/ferroptosis-core/src/params.rs
@@ -157,11 +157,20 @@ pub struct SpatialParams {
     /// See `photosensitizer_pk` module.
     #[serde(default)]
     pub photosensitizer: Photosensitizer,
-    /// Drug-light interval (DLI) in hours: time between photosensitizer
-    /// administration and light delivery. Used by PDT physics to scale
-    /// light intensity by `photosensitizer.concentration_at(this)`.
-    /// Default 0.0 (light delivered at administration) preserves
-    /// pre-PK behavior when combined with `Photosensitizer::Uniform(1.0)`.
+    /// Hours from photosensitizer **post-distribution peak** to light
+    /// delivery, passed directly to `photosensitizer.concentration_at(t_h)`.
+    ///
+    /// This is NOT the standard clinical "drug-light interval" measured
+    /// from injection. The model's `t = 0` is post-distribution peak, so
+    /// clinical DLI ≈ distribution_phase + this field. For porfimer the
+    /// distribution phase is roughly 24–48 h (Bellnier 2006); for drugs
+    /// with shorter t½ (e.g., 5-ALA at ~24 h) ignoring the distribution
+    /// phase is a large error. Explicit distribution-phase modeling is a
+    /// follow-up — see the `photosensitizer_pk` module docstring.
+    ///
+    /// Default 0.0 (light delivered at peak) combined with the default
+    /// `Photosensitizer::Uniform(1.0)` reproduces pre-PK PDT physics
+    /// exactly.
     #[serde(default)]
     pub t_drug_light_interval_h: f64,
 }

--- a/simulations/ferroptosis-core/src/params.rs
+++ b/simulations/ferroptosis-core/src/params.rs
@@ -2,6 +2,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::photosensitizer_pk::Photosensitizer;
+
 /// Core biochemistry parameters. Identical to v3 simulation defaults.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Params {
@@ -149,6 +151,19 @@ pub struct SpatialParams {
     pub sdt_i0: f64,
     /// Fraction of released iron reaching each neighbor cell.
     pub neighbor_iron_fraction: f64,
+    /// Photosensitizer PK model. `Uniform(1.0)` (default) reproduces
+    /// pre-PK PDT physics exactly. `Porfimer { t_half_h }` enables
+    /// drug-light-interval-aware scaling of the PDT dose.
+    /// See `photosensitizer_pk` module.
+    #[serde(default)]
+    pub photosensitizer: Photosensitizer,
+    /// Drug-light interval (DLI) in hours: time between photosensitizer
+    /// administration and light delivery. Used by PDT physics to scale
+    /// light intensity by `photosensitizer.concentration_at(this)`.
+    /// Default 0.0 (light delivered at administration) preserves
+    /// pre-PK behavior when combined with `Photosensitizer::Uniform(1.0)`.
+    #[serde(default)]
+    pub t_drug_light_interval_h: f64,
 }
 
 impl Default for SpatialParams {
@@ -163,6 +178,8 @@ impl Default for SpatialParams {
             sdt_freq_mhz: 1.0,
             sdt_i0: 1.0,
             neighbor_iron_fraction: 0.1,
+            photosensitizer: Photosensitizer::default(),
+            t_drug_light_interval_h: 0.0,
         }
     }
 }
@@ -197,5 +214,32 @@ impl Default for ImmuneParams {
             pd1_brake: 0.7,
             anti_pd1_efficacy: 0.8,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// SpatialParams JSON written before the photosensitizer/DLI fields
+    /// existed must still deserialize, with new fields filled by serde
+    /// defaults that reproduce pre-PK behavior.
+    #[test]
+    fn spatial_params_legacy_json_deserializes_with_defaults() {
+        let legacy = r#"{
+            "cell_size_um": 20.0,
+            "iron_diffusion_coeff": 281.0,
+            "iron_release_per_death": 2.0,
+            "pdt_mu_eff": 0.31,
+            "pdt_i0": 1.0,
+            "sdt_alpha": 0.7,
+            "sdt_freq_mhz": 1.0,
+            "sdt_i0": 1.0,
+            "neighbor_iron_fraction": 0.1
+        }"#;
+        let p: SpatialParams = serde_json::from_str(legacy).unwrap();
+        assert_eq!(p.photosensitizer, Photosensitizer::Uniform(1.0));
+        assert_eq!(p.t_drug_light_interval_h, 0.0);
+        assert_eq!(p.photosensitizer.concentration_at(p.t_drug_light_interval_h), 1.0);
     }
 }

--- a/simulations/ferroptosis-core/src/photosensitizer_pk.rs
+++ b/simulations/ferroptosis-core/src/photosensitizer_pk.rs
@@ -145,14 +145,22 @@ mod tests {
     }
 
     #[test]
-    fn porfimer_at_one_halflife_is_exactly_half() {
+    fn porfimer_at_one_halflife_is_half() {
         let p = Photosensitizer::Porfimer { t_half_h: 504.0 };
-        // exp(-ln(2)) is exactly 0.5 in IEEE 754 — strict equality.
-        assert_eq!(p.concentration_at(504.0), 0.5);
+        // `exp(-ln(2))` lands on 0.5 on most libm implementations but is
+        // not guaranteed bit-exact across platforms (intermediate rounding
+        // in `ln(2)/504 * 504` may not round-trip). Compare with a tight
+        // tolerance instead of strict equality.
+        let c = p.concentration_at(504.0);
+        assert!(
+            (c - 0.5).abs() < 1e-12,
+            "concentration_at(t_half_h) = {c}, expected ~0.5"
+        );
     }
 
     #[test]
     fn porfimer_at_zero_is_one() {
+        // `exp(0.0) == 1.0` is required by IEEE 754 — strict equality is safe here.
         let p = Photosensitizer::Porfimer { t_half_h: 504.0 };
         assert_eq!(p.concentration_at(0.0), 1.0);
     }
@@ -165,8 +173,21 @@ mod tests {
         let c2 = p.concentration_at(168.0);
         let c3 = p.concentration_at(504.0);
         assert!(c0 > c1 && c1 > c2 && c2 > c3);
+        // exp(0.0) == 1.0 exactly per IEEE 754; one-half-life value is
+        // libm-dependent so use epsilon comparison.
         assert_eq!(c0, 1.0);
-        assert_eq!(c3, 0.5);
+        assert!((c3 - 0.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn uniform_constant_at_all_times() {
+        // Uniform(c) returns c regardless of t_h, including c != 1.0.
+        let p = Photosensitizer::Uniform(0.5);
+        assert_eq!(p.concentration_at(0.0), 0.5);
+        assert_eq!(p.concentration_at(100.0), 0.5);
+        assert_eq!(p.concentration_at(1e9), 0.5);
+        // Non-default value must not be silently treated as 1.0.
+        assert_ne!(p.concentration_at(50.0), 1.0);
     }
 
     #[test]

--- a/simulations/ferroptosis-core/src/photosensitizer_pk.rs
+++ b/simulations/ferroptosis-core/src/photosensitizer_pk.rs
@@ -1,0 +1,255 @@
+//! Photosensitizer plasma pharmacokinetics for PDT.
+//!
+//! Models the time-decaying concentration of a systemically administered
+//! photosensitizer between dosing and light delivery (the drug-light
+//! interval, DLI). Used by `physics::pdt_intensity_at_depth` to scale
+//! depth-attenuated light intensity by the fraction of drug still present
+//! when illumination occurs.
+//!
+//! v1 captures the *temporal* PK only — intra-drug C(t) decay between
+//! administration and illumination. It does NOT capture inter-drug
+//! ROS-yield differences (singlet-O2 quantum yield phi_so2), 5-ALA → PpIX
+//! intracellular accumulation, photobleaching during illumination, or
+//! formulation-dependent Vd / protein binding. Those are intentional
+//! follow-ups; see issue #200.
+//!
+//! `t_half_h` represents *plasma* terminal half-life. Cellular
+//! concentration is assumed to track plasma proportionally — a reasonable
+//! approximation for porfimer (slow-distributing, weeks-scale t½) but
+//! explicitly wrong for 5-ALA/PpIX, which accumulates intracellularly via
+//! ferrochelatase deficiency rather than decaying. ALA kinetics need a
+//! different variant.
+//!
+//! The model's `t = 0` represents *post-distribution peak*, not the moment
+//! of IV bolus. Porfimer distribution takes 1–2 days; users setting
+//! `t_drug_light_interval_h = 0` are modeling "light at peak," not
+//! "light at injection."
+//!
+//! Reference: Bellnier DA et al., Lasers Surg Med 38(5):439-444, 2006 —
+//! clinical PK of porfimer sodium, Photochlor, and 5-ALA-induced PpIX
+//! in humans (PMID 16634075).
+
+use serde::{Deserialize, Serialize};
+
+/// Photosensitizer pharmacokinetic model used to scale PDT light dose by
+/// the fraction of drug present at the moment of illumination.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum Photosensitizer {
+    /// Drug at constant fraction `c` of peak for all `t`. The default
+    /// `Uniform(1.0)` is the identity case (no scaling, byte-exact pre-PK
+    /// behavior). `Uniform(0.5)` asserts "drug constant at half-peak forever"
+    /// — itself a PK assertion, not "no PK model."
+    Uniform(f64),
+    /// Porfimer sodium (Photofrin). Single-exponential plasma decay.
+    /// Bellnier 2006 reports terminal t½ ~21 d (504 h) in humans, with
+    /// substantial infusion-protocol-dependent variability (~250–500+ h).
+    Porfimer {
+        /// Plasma terminal half-life in hours. Must be strictly positive.
+        t_half_h: f64,
+    },
+}
+
+impl Default for Photosensitizer {
+    fn default() -> Self {
+        Self::Uniform(1.0)
+    }
+}
+
+impl Photosensitizer {
+    /// Validate that the photosensitizer's parameters are physically
+    /// reasonable. Returns `Ok(())` for valid configurations and a
+    /// descriptive `Err` otherwise.
+    ///
+    /// Default `Uniform(1.0)` is always valid. Use this when loading a
+    /// `Photosensitizer` from a config file or external source where you
+    /// don't trust the values.
+    ///
+    /// `concentration_at` itself uses `debug_assert!` against this contract
+    /// — invalid configs panic in test/debug builds and produce non-physical
+    /// outputs in release builds.
+    pub fn validate(&self) -> Result<(), String> {
+        match self {
+            Self::Uniform(c) => {
+                if !c.is_finite() {
+                    Err(format!(
+                        "Photosensitizer::Uniform multiplier must be finite, got {c}"
+                    ))
+                } else if *c < 0.0 {
+                    Err(format!(
+                        "Photosensitizer::Uniform multiplier must be >= 0, got {c}"
+                    ))
+                } else {
+                    Ok(())
+                }
+            }
+            Self::Porfimer { t_half_h } => {
+                if !t_half_h.is_finite() {
+                    Err(format!(
+                        "Photosensitizer::Porfimer.t_half_h must be finite, got {t_half_h}"
+                    ))
+                } else if *t_half_h <= 0.0 {
+                    Err(format!(
+                        "Photosensitizer::Porfimer.t_half_h must be > 0, got {t_half_h}"
+                    ))
+                } else {
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    /// Fractional drug presence at time `t_h` after administration,
+    /// relative to peak (post-distribution).
+    ///
+    /// - `Uniform(c)` returns `c` for any `t_h`.
+    /// - `Porfimer { t_half_h }` returns `exp(-ln(2) * t_h / t_half_h)`
+    ///   for non-negative `t_h`. Negative `t_h` (illumination "before"
+    ///   the post-distribution peak) saturates to peak (returns 1.0 for
+    ///   the porfimer kinetics).
+    ///
+    /// Invalid configurations (NaN, non-positive `t_half_h`, negative
+    /// `Uniform` multiplier) trigger `debug_assert!` failures in tests
+    /// and CI. Use [`Self::validate`] to check ahead of time when loading
+    /// from untrusted sources.
+    pub fn concentration_at(&self, t_h: f64) -> f64 {
+        debug_assert!(
+            self.validate().is_ok(),
+            "invalid Photosensitizer: {:?}",
+            self.validate().err()
+        );
+        // f64::max treats NaN as smaller than any value, so NaN inputs
+        // saturate to 0.0 and produce a deterministic result.
+        let t_h = t_h.max(0.0);
+        match self {
+            Self::Uniform(c) => *c,
+            Self::Porfimer { t_half_h } => {
+                let k = 2.0_f64.ln() / *t_half_h;
+                (-k * t_h).exp()
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_uniform_one() {
+        assert_eq!(Photosensitizer::default(), Photosensitizer::Uniform(1.0));
+        // Default photosensitizer must return 1.0 at every t for byte-exact
+        // backwards-compat with pre-PK PDT physics.
+        assert_eq!(Photosensitizer::default().concentration_at(0.0), 1.0);
+        assert_eq!(Photosensitizer::default().concentration_at(24.0), 1.0);
+        assert_eq!(Photosensitizer::default().concentration_at(1e6), 1.0);
+    }
+
+    #[test]
+    fn porfimer_at_one_halflife_is_exactly_half() {
+        let p = Photosensitizer::Porfimer { t_half_h: 504.0 };
+        // exp(-ln(2)) is exactly 0.5 in IEEE 754 — strict equality.
+        assert_eq!(p.concentration_at(504.0), 0.5);
+    }
+
+    #[test]
+    fn porfimer_at_zero_is_one() {
+        let p = Photosensitizer::Porfimer { t_half_h: 504.0 };
+        assert_eq!(p.concentration_at(0.0), 1.0);
+    }
+
+    #[test]
+    fn porfimer_decays_monotonically() {
+        let p = Photosensitizer::Porfimer { t_half_h: 504.0 };
+        let c0 = p.concentration_at(0.0);
+        let c1 = p.concentration_at(24.0);
+        let c2 = p.concentration_at(168.0);
+        let c3 = p.concentration_at(504.0);
+        assert!(c0 > c1 && c1 > c2 && c2 > c3);
+        assert_eq!(c0, 1.0);
+        assert_eq!(c3, 0.5);
+    }
+
+    #[test]
+    fn serde_roundtrip_uniform() {
+        let p = Photosensitizer::Uniform(0.7);
+        let json = serde_json::to_string(&p).unwrap();
+        let q: Photosensitizer = serde_json::from_str(&json).unwrap();
+        assert_eq!(p, q);
+    }
+
+    #[test]
+    fn serde_roundtrip_porfimer() {
+        let p = Photosensitizer::Porfimer { t_half_h: 504.0 };
+        let json = serde_json::to_string(&p).unwrap();
+        let q: Photosensitizer = serde_json::from_str(&json).unwrap();
+        assert_eq!(p, q);
+    }
+
+    // -- input validation --
+
+    #[test]
+    fn validate_uniform_accepts_valid() {
+        assert!(Photosensitizer::Uniform(0.0).validate().is_ok());
+        assert!(Photosensitizer::Uniform(0.5).validate().is_ok());
+        assert!(Photosensitizer::Uniform(1.0).validate().is_ok());
+        // Values > 1.0 are intentionally permissive (forward-compat hook
+        // for enrichment factors). Tighten in a follow-up if needed.
+        assert!(Photosensitizer::Uniform(2.0).validate().is_ok());
+    }
+
+    #[test]
+    fn validate_uniform_rejects_invalid() {
+        assert!(Photosensitizer::Uniform(-0.5).validate().is_err());
+        assert!(Photosensitizer::Uniform(f64::NAN).validate().is_err());
+        assert!(Photosensitizer::Uniform(f64::INFINITY).validate().is_err());
+        assert!(Photosensitizer::Uniform(f64::NEG_INFINITY)
+            .validate()
+            .is_err());
+    }
+
+    #[test]
+    fn validate_porfimer_accepts_valid() {
+        assert!(Photosensitizer::Porfimer { t_half_h: 504.0 }
+            .validate()
+            .is_ok());
+        assert!(Photosensitizer::Porfimer { t_half_h: 0.001 }
+            .validate()
+            .is_ok());
+    }
+
+    #[test]
+    fn validate_porfimer_rejects_invalid() {
+        assert!(Photosensitizer::Porfimer { t_half_h: 0.0 }
+            .validate()
+            .is_err());
+        assert!(Photosensitizer::Porfimer { t_half_h: -100.0 }
+            .validate()
+            .is_err());
+        assert!(Photosensitizer::Porfimer { t_half_h: f64::NAN }
+            .validate()
+            .is_err());
+        assert!(Photosensitizer::Porfimer {
+            t_half_h: f64::INFINITY
+        }
+        .validate()
+        .is_err());
+    }
+
+    #[test]
+    fn negative_dli_saturates_to_peak() {
+        // Negative DLI is non-physical (illumination before drug peak);
+        // saturate to t=0 to keep outputs in [0, 1] for valid params.
+        let p = Photosensitizer::Porfimer { t_half_h: 504.0 };
+        assert_eq!(p.concentration_at(-1.0), 1.0);
+        assert_eq!(p.concentration_at(-1e6), 1.0);
+        assert_eq!(p.concentration_at(f64::NEG_INFINITY), 1.0);
+    }
+
+    #[test]
+    fn nan_dli_saturates_to_peak() {
+        // f64::max treats NaN as smaller than any value, so NaN.max(0.0)
+        // returns 0.0 and concentration_at(NaN) is deterministic.
+        let p = Photosensitizer::Porfimer { t_half_h: 504.0 };
+        assert_eq!(p.concentration_at(f64::NAN), 1.0);
+    }
+}

--- a/simulations/ferroptosis-core/src/physics.rs
+++ b/simulations/ferroptosis-core/src/physics.rs
@@ -31,11 +31,18 @@ use crate::params::SpatialParams;
 /// Ref: Bellnier DA et al., Lasers Surg Med 38(5):439-444, 2006 — clinical
 ///      photosensitizer PK (porfimer, Photochlor, 5-ALA-PpIX).
 ///
-/// Returns intensity multiplier in [0, 1] relative to surface, assuming
-/// the configured `Photosensitizer` and `t_drug_light_interval_h` pass
-/// [`Photosensitizer::validate`]. Invalid configurations trigger
-/// `debug_assert!` failures in test/debug builds and produce non-physical
-/// values in release.
+/// Returns a non-negative intensity multiplier relative to surface.
+///
+/// For valid `Photosensitizer::Uniform(c)` with `c ≤ 1.0` or any valid
+/// `Photosensitizer::Porfimer`, the value stays in `[0, 1]`. `Uniform(c)`
+/// with `c > 1.0` is intentionally permitted (forward-compat hook for
+/// drug-enrichment models) and can produce multipliers above 1.0.
+///
+/// Invalid configurations (NaN, negative, non-positive `t_half_h`) trigger
+/// `debug_assert!` failures in test/debug builds. In release builds those
+/// asserts are compiled out and outputs are not bounded — call
+/// [`Photosensitizer::validate`] explicitly when loading from untrusted
+/// sources.
 ///
 /// [`Photosensitizer::validate`]: crate::photosensitizer_pk::Photosensitizer::validate
 pub fn pdt_intensity_at_depth(z_um: f64, params: &SpatialParams) -> f64 {
@@ -158,7 +165,7 @@ mod tests {
     }
 
     #[test]
-    fn pdt_with_porfimer_at_one_halflife_is_exactly_half_of_default() {
+    fn pdt_with_porfimer_at_one_halflife_is_half_of_default() {
         use crate::photosensitizer_pk::Photosensitizer;
 
         let z_um = 1000.0; // arbitrary depth
@@ -172,9 +179,13 @@ mod tests {
         };
         let with_pk = pdt_intensity_at_depth(z_um, &pk_params);
 
-        // exp(-ln(2)) is exactly 0.5 in IEEE 754, and multiplying by 0.5
-        // is exact for any finite f64. Strict equality, not epsilon.
-        assert_eq!(with_pk, baseline * 0.5);
+        // `exp(-ln(2))` lands on 0.5 on most libms but is not guaranteed
+        // bit-exact across platforms; use a tight relative tolerance.
+        let expected = baseline * 0.5;
+        assert!(
+            (with_pk - expected).abs() < 1e-12,
+            "with_pk = {with_pk}, expected ~{expected}"
+        );
     }
 
     #[test]

--- a/simulations/ferroptosis-core/src/physics.rs
+++ b/simulations/ferroptosis-core/src/physics.rs
@@ -6,22 +6,44 @@
 use crate::cell::Treatment;
 use crate::params::SpatialParams;
 
-/// PDT: Modified Beer-Lambert law for light in tissue.
+/// PDT: Modified Beer-Lambert law for light in tissue, scaled by the
+/// fraction of photosensitizer present at the drug-light interval.
 ///
-/// I(z) = I₀ × exp(-µ_eff × z)
+/// I_eff(z, t_DLI) = I₀ × exp(-µ_eff × z) × C_drug(t_DLI)
 ///
 /// µ_eff = sqrt(3 × µ_a × (µ_a + µ_s'))
 ///
 /// At 630nm red light: δ = 1/µ_eff ≈ 3.2mm
 /// At 660nm red light: δ ≈ 4-10mm
 ///
+/// The drug-presence multiplier `C_drug(t_DLI)` comes from
+/// `SpatialParams::photosensitizer.concentration_at(t_drug_light_interval_h)`.
+/// The default `Photosensitizer::Uniform(1.0)` with DLI=0 returns exactly
+/// 1.0, preserving pre-PK behavior bit-for-bit.
+///
+/// TODO(#200): inter-drug singlet-O₂ quantum yield (phi_so2) is NOT in
+/// this scalar — it is implicit in `Params::pdt_ros`. Inter-drug
+/// comparisons (porfimer vs Photochlor vs 5-ALA) need explicit phi_so2
+/// normalization. Spawn a follow-up issue.
+///
 /// Ref: Jacques SL, "Optical properties of biological tissues: a review",
 ///      Phys Med Biol 58(11):R37-61, 2013
+/// Ref: Bellnier DA et al., Lasers Surg Med 38(5):439-444, 2006 — clinical
+///      photosensitizer PK (porfimer, Photochlor, 5-ALA-PpIX).
 ///
-/// Returns intensity multiplier in [0, 1] relative to surface.
+/// Returns intensity multiplier in [0, 1] relative to surface, assuming
+/// the configured `Photosensitizer` and `t_drug_light_interval_h` pass
+/// [`Photosensitizer::validate`]. Invalid configurations trigger
+/// `debug_assert!` failures in test/debug builds and produce non-physical
+/// values in release.
+///
+/// [`Photosensitizer::validate`]: crate::photosensitizer_pk::Photosensitizer::validate
 pub fn pdt_intensity_at_depth(z_um: f64, params: &SpatialParams) -> f64 {
     let z_mm = z_um / 1000.0;
-    params.pdt_i0 * (-params.pdt_mu_eff * z_mm).exp()
+    let drug_at_dli = params
+        .photosensitizer
+        .concentration_at(params.t_drug_light_interval_h);
+    params.pdt_i0 * (-params.pdt_mu_eff * z_mm).exp() * drug_at_dli
 }
 
 /// SDT: Ultrasound attenuation in soft tissue.
@@ -133,6 +155,39 @@ mod tests {
     #[test]
     fn rsl3_is_uniform() {
         assert_eq!(rsl3_concentration(0.0), rsl3_concentration(100_000.0));
+    }
+
+    #[test]
+    fn pdt_with_porfimer_at_one_halflife_is_exactly_half_of_default() {
+        use crate::photosensitizer_pk::Photosensitizer;
+
+        let z_um = 1000.0; // arbitrary depth
+        let baseline_params = SpatialParams::default();
+        let baseline = pdt_intensity_at_depth(z_um, &baseline_params);
+
+        let pk_params = SpatialParams {
+            photosensitizer: Photosensitizer::Porfimer { t_half_h: 504.0 },
+            t_drug_light_interval_h: 504.0,
+            ..Default::default()
+        };
+        let with_pk = pdt_intensity_at_depth(z_um, &pk_params);
+
+        // exp(-ln(2)) is exactly 0.5 in IEEE 754, and multiplying by 0.5
+        // is exact for any finite f64. Strict equality, not epsilon.
+        assert_eq!(with_pk, baseline * 0.5);
+    }
+
+    #[test]
+    fn pdt_with_default_photosensitizer_unchanged() {
+        // The default Uniform(1.0) + DLI=0 must not perturb existing physics.
+        let params = SpatialParams::default();
+        let z_um = 3226.0; // 1/µ_eff at default 0.31 /mm
+        let intensity = pdt_intensity_at_depth(z_um, &params);
+        let expected = 1.0 / std::f64::consts::E;
+        assert!(
+            (intensity - expected).abs() < 0.01,
+            "expected ~{expected:.4}, got {intensity:.4}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Connects drug temporal-PK to PDT physics: `pdt_intensity_at_depth` now multiplies by `photosensitizer.concentration_at(t_drug_light_interval_h)`
- Adds new `ferroptosis-core::photosensitizer_pk` module with `Photosensitizer` enum (`Uniform`/`Porfimer`), single-exponential kinetics, `validate()` for input checking
- `SpatialParams` gains `photosensitizer` + `t_drug_light_interval_h` fields with `#[serde(default)]` for legacy JSON compat
- Calibration `parameter_provenance.md` adds porfimer reference (Bellnier 2006, PMID 16634075), DLI row, RSL3-uncalibrated honesty paragraph, and plasma-vs-cellular concentration caveat

Closes #200 (P1+P2 — the two MVP priorities; out-of-scope items spawn follow-ups).

## Backwards compatibility
Default `Photosensitizer::Uniform(1.0)` + `t_drug_light_interval_h = 0.0` reproduces pre-change PDT physics **bit-exactly**. The new code path computes `existing_value × 1.0`, which is exact for all finite f64 in IEEE 754.

Verified empirically by `sim-spatial` snapshot diffs:
- 100×100 grid: byte-identical (SHA-256 match for `spatial_summary.json` and `depth_kill_curves.csv`)
- 500×500 grid: byte-identical (SHA-256 match for both)

All 8 binaries that use PDT physics keep producing identical output unless they explicitly opt into a non-default photosensitizer.

## Intentional divergences from issue #200 body
1. **`Porfimer` carries only `t_half_h`** — the issue lists `t_half_h, vd_l_kg, f_u, phi_so2`. Three of those four aren't consumed by v1 code; storing unused fields creates the illusion of completeness while drifting from reality. They land when load-bearing.
2. **`pdt_intensity_at_depth` is not renamed to `pdt_dose_at`** — the issue proposes a rename. Multiplying inside the existing function has zero blast radius across the 8 PDT-using binaries.
3. **No `targets.yaml` entry** — the calibration framework (`calibrate.py`) keys extractors by binary name and compares simulation *outputs* to experimental targets. Porfimer t½ is an *input parameter*, not an output. Honesty intent is captured in `parameter_provenance.md` instead. A real porfimer-PK calibration target would require extending `sim-tumor-pk` to support porfimer + emit a plasma-C(t) CSV — separate issue.

## Input validation (revised)
`Photosensitizer::concentration_at` is hardened against:
- `t_half_h <= 0` (was: NaN output via `ln(2)/0 = inf`)
- Negative `t_half_h` (was: drug "grows" exponentially)
- Negative `t_h` / DLI (was: drug "exists" before administration; saturated via `f64::max`)
- NaN `t_h` (saturated to 0.0)

Invalid configurations trigger `debug_assert!` failures in **test/debug builds only**. In release builds those asserts are compiled out and outputs are not bounded — `Uniform(NaN)` returns NaN, `Porfimer { t_half_h: 0.0 }` at `t_h=0` returns NaN, etc. Use `Photosensitizer::validate() -> Result<(), String>` for explicit pre-checks when loading from untrusted sources. Documented in the module and `pdt_intensity_at_depth` docstrings.

## Out of scope (spawn separate issues)
- DLI-as-CLI flag for `sim-spatial`/`sim-combo` — tracked in #202
- 5-ALA → PpIX with ferrochelatase-deficiency selectivity (enzymatic, not just PK)
- Photobleaching kinetics during illumination
- Photochlor + sonosensitizer (e.g. hematoporphyrin) parameter rows
- `phi_so2` inter-drug normalization
- Multi-dose scheduling (requires extending simulation horizon — currently 180 min)
- Simeoni-style PK-tumor-growth coupling
- IFP gel-fluid decomposition + PEGPH20 intervention
- Plasma protein binding (`f_u`) as first-class parameter
- PK-Sim / pysb-pkpd cross-validation for doxorubicin
- PyO3 + FFI exposure of the new types
- `SpatialParams` nested-struct refactor (it's becoming a god-struct)

## Cargo
- `ferroptosis-core` 0.2.0 → 0.3.0 (additive minor bump)
- All workspace consumers use path deps; no version pins to update
- `Cargo.lock` change is a single line (the version bump)

## Review feedback addressed (commit 2)
- **Loosened libm-dependent floating-point equality** from `assert_eq!(c, 0.5)` to epsilon comparison `(c - 0.5).abs() < 1e-12` in `photosensitizer_pk.rs` and `physics.rs`. Renamed tests to drop "exactly" since the equality isn't IEEE-guaranteed. `exp(0.0) == 1.0` *is* IEEE-guaranteed and uses strict equality.
- **Corrected `[0, 1]` doc claim** in `pdt_intensity_at_depth`: now says "non-negative intensity multiplier" with a note that `Uniform(c > 1.0)` (forward-compat enrichment-factor hook) can exceed 1.0.
- **Reordered `photosensitizer_pk`** above `params` in `lib.rs` (and `README.md` table) to match dependency direction.
- **Added `Uniform(c).concentration_at(t > 0) == c` test** for `c ≠ 1.0` (closing the coverage gap flagged in review).
- **Spawned follow-up issue #202** for DLI-as-CLI flag work.

## Test plan
- [x] `cargo test --workspace` — 47 in ferroptosis-core (17 new), all green
- [x] `pytest tests/ simulations/ferroptosis-python/` — 91/91 green
- [x] `cargo clippy -p ferroptosis-core --all-targets` — no new warnings in changed files (4 pre-existing in `io.rs`/`immune.rs`)
- [x] `cargo fmt --check -p ferroptosis-core` — no diff in changed files
- [x] Snapshot diff `sim-spatial` 100×100 — byte-identical
- [x] Snapshot diff `sim-spatial` 500×500 — byte-identical
- [x] Legacy `SpatialParams` JSON without new fields deserializes via `#[serde(default)]`

## Note for reviewers
Calibration outputs will report STALE until simulations are re-run after this lands; this is expected (mtime of `ferroptosis-core/src/*.rs` newer than cached outputs). Re-run `cargo run --release -p sim-spatial` etc. when convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)