### PR TITLE
ferroptosis-core: move photosensitizer CLI parser into the type (#205)

### DIFF
--- a/simulations/Cargo.lock
+++ b/simulations/Cargo.lock
@@ -217,7 +217,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferroptosis-core"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "csv",
  "ndarray",

--- a/simulations/Cargo.lock
+++ b/simulations/Cargo.lock
@@ -217,7 +217,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferroptosis-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "csv",
  "ndarray",

--- a/simulations/ferroptosis-core/Cargo.toml
+++ b/simulations/ferroptosis-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferroptosis-core"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 description = "Embeddable ferroptosis biochemistry engine for cancer simulation"
 license = "MIT"

--- a/simulations/ferroptosis-core/Cargo.toml
+++ b/simulations/ferroptosis-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferroptosis-core"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Embeddable ferroptosis biochemistry engine for cancer simulation"
 license = "MIT"

--- a/simulations/ferroptosis-core/src/photosensitizer_pk.rs
+++ b/simulations/ferroptosis-core/src/photosensitizer_pk.rs
@@ -77,6 +77,53 @@ impl fmt::Display for Photosensitizer {
 }
 
 impl Photosensitizer {
+    /// Parse a CLI `--photosensitizer` SPEC string into a `Photosensitizer`.
+    ///
+    /// Accepted forms (case-insensitive on the variant name):
+    /// - `uniform` → `Uniform(1.0)`
+    /// - `uniform=N` → `Uniform(N)`
+    /// - `porfimer` → `Porfimer { t_half_h: 504.0 }` (Bellnier 2006 t½ in hours)
+    /// - `porfimer=N` → `Porfimer { t_half_h: N }`
+    ///
+    /// Errors on unknown variant, unparseable number, or any value that
+    /// fails [`Photosensitizer::validate`]. Round-trips with the
+    /// `Display` impl: `parse(format!("{ps}")) == Ok(ps)` for every valid
+    /// `Photosensitizer`.
+    pub fn from_cli_spec(s: &str) -> Result<Self, String> {
+        let s = s.trim();
+        let (name, value) = match s.split_once('=') {
+            Some((n, v)) => (n.trim(), Some(v.trim())),
+            None => (s, None),
+        };
+        let ps = match name.to_ascii_lowercase().as_str() {
+            "uniform" => {
+                let c = match value {
+                    Some(v) => v
+                        .parse::<f64>()
+                        .map_err(|e| format!("uniform=N: cannot parse N={v:?}: {e}"))?,
+                    None => 1.0,
+                };
+                Self::Uniform(c)
+            }
+            "porfimer" => {
+                let t_half_h = match value {
+                    Some(v) => v
+                        .parse::<f64>()
+                        .map_err(|e| format!("porfimer=N: cannot parse N={v:?}: {e}"))?,
+                    None => 504.0, // Bellnier 2006 terminal t½ in humans, hours.
+                };
+                Self::Porfimer { t_half_h }
+            }
+            _ => {
+                return Err(format!(
+                    "unknown photosensitizer {name:?}; expected one of: uniform, uniform=N, porfimer, porfimer=N (case-insensitive)"
+                ));
+            }
+        };
+        ps.validate()?;
+        Ok(ps)
+    }
+
     /// Validate that the photosensitizer's parameters are physically
     /// reasonable. Returns `Ok(())` for valid configurations and a
     /// descriptive `Err` otherwise.
@@ -149,6 +196,20 @@ impl Photosensitizer {
             }
         }
     }
+}
+
+/// Validate a CLI `--dli-h` argument: reject NaN, negative, and infinite
+/// values so they cannot reach `concentration_at` and produce silent
+/// non-physical PDT output. Pair with [`Photosensitizer::from_cli_spec`]
+/// at the same parse-time gate.
+pub fn validate_dli_h(dli_h: f64) -> Result<(), String> {
+    if !dli_h.is_finite() {
+        return Err(format!("--dli-h must be finite, got {dli_h}"));
+    }
+    if dli_h < 0.0 {
+        return Err(format!("--dli-h must be >= 0, got {dli_h}"));
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -317,5 +378,149 @@ mod tests {
         // returns 0.0 and concentration_at(NaN) is deterministic.
         let p = Photosensitizer::Porfimer { t_half_h: 504.0 };
         assert_eq!(p.concentration_at(f64::NAN), 1.0);
+    }
+
+    // -- from_cli_spec --
+
+    #[test]
+    fn from_cli_spec_uniform_default() {
+        assert_eq!(
+            Photosensitizer::from_cli_spec("uniform").unwrap(),
+            Photosensitizer::Uniform(1.0)
+        );
+    }
+
+    #[test]
+    fn from_cli_spec_uniform_with_value() {
+        assert_eq!(
+            Photosensitizer::from_cli_spec("uniform=0.5").unwrap(),
+            Photosensitizer::Uniform(0.5)
+        );
+    }
+
+    #[test]
+    fn from_cli_spec_porfimer_default_is_bellnier() {
+        assert_eq!(
+            Photosensitizer::from_cli_spec("porfimer").unwrap(),
+            Photosensitizer::Porfimer { t_half_h: 504.0 }
+        );
+    }
+
+    #[test]
+    fn from_cli_spec_porfimer_with_value() {
+        assert_eq!(
+            Photosensitizer::from_cli_spec("porfimer=336").unwrap(),
+            Photosensitizer::Porfimer { t_half_h: 336.0 }
+        );
+    }
+
+    #[test]
+    fn from_cli_spec_trims_whitespace() {
+        assert_eq!(
+            Photosensitizer::from_cli_spec("  porfimer = 504  ").unwrap(),
+            Photosensitizer::Porfimer { t_half_h: 504.0 }
+        );
+    }
+
+    #[test]
+    fn from_cli_spec_case_insensitive() {
+        assert_eq!(
+            Photosensitizer::from_cli_spec("Uniform").unwrap(),
+            Photosensitizer::Uniform(1.0)
+        );
+        assert_eq!(
+            Photosensitizer::from_cli_spec("PORFIMER=504").unwrap(),
+            Photosensitizer::Porfimer { t_half_h: 504.0 }
+        );
+        assert_eq!(
+            Photosensitizer::from_cli_spec("PorFimEr").unwrap(),
+            Photosensitizer::Porfimer { t_half_h: 504.0 }
+        );
+    }
+
+    #[test]
+    fn from_cli_spec_unknown_variant_errors() {
+        let err = Photosensitizer::from_cli_spec("photochlor").unwrap_err();
+        assert!(err.contains("photochlor"));
+        assert!(err.contains("uniform"));
+        assert!(err.contains("porfimer"));
+    }
+
+    #[test]
+    fn from_cli_spec_unparseable_number_errors() {
+        let err = Photosensitizer::from_cli_spec("porfimer=abc").unwrap_err();
+        assert!(err.contains("porfimer=N"));
+        assert!(err.contains("abc"));
+    }
+
+    #[test]
+    fn from_cli_spec_negative_t_half_h_rejected() {
+        let err = Photosensitizer::from_cli_spec("porfimer=-1").unwrap_err();
+        assert!(err.contains("t_half_h"));
+    }
+
+    #[test]
+    fn from_cli_spec_zero_t_half_h_rejected() {
+        let err = Photosensitizer::from_cli_spec("porfimer=0").unwrap_err();
+        assert!(err.contains("t_half_h"));
+    }
+
+    #[test]
+    fn from_cli_spec_negative_uniform_rejected() {
+        let err = Photosensitizer::from_cli_spec("uniform=-0.5").unwrap_err();
+        assert!(err.contains("must be >= 0"));
+    }
+
+    #[test]
+    fn from_cli_spec_nan_rejected() {
+        let err = Photosensitizer::from_cli_spec("uniform=NaN").unwrap_err();
+        assert!(err.contains("must be finite"));
+    }
+
+    #[test]
+    fn display_round_trips_through_from_cli_spec() {
+        // Display's contract is round-trip parseability via from_cli_spec.
+        for ps in [
+            Photosensitizer::Uniform(1.0),
+            Photosensitizer::Uniform(0.5),
+            Photosensitizer::Porfimer { t_half_h: 504.0 },
+            Photosensitizer::Porfimer { t_half_h: 336.5 },
+        ] {
+            let rendered = format!("{ps}");
+            let reparsed = Photosensitizer::from_cli_spec(&rendered)
+                .unwrap_or_else(|e| panic!("round-trip failed for {ps:?}: {e}"));
+            assert_eq!(reparsed, ps, "round-trip mismatch via {rendered:?}");
+        }
+    }
+
+    // -- validate_dli_h --
+
+    #[test]
+    fn validate_dli_h_accepts_zero_and_positive() {
+        assert!(validate_dli_h(0.0).is_ok());
+        assert!(validate_dli_h(24.0).is_ok());
+        assert!(validate_dli_h(504.0).is_ok());
+        assert!(validate_dli_h(1e9).is_ok());
+    }
+
+    #[test]
+    fn validate_dli_h_rejects_negative() {
+        let err = validate_dli_h(-1.0).unwrap_err();
+        assert!(err.contains("--dli-h"));
+        assert!(err.contains(">= 0"));
+    }
+
+    #[test]
+    fn validate_dli_h_rejects_nan() {
+        let err = validate_dli_h(f64::NAN).unwrap_err();
+        assert!(err.contains("finite"));
+    }
+
+    #[test]
+    fn validate_dli_h_rejects_infinity() {
+        assert!(validate_dli_h(f64::INFINITY).unwrap_err().contains("finite"));
+        assert!(validate_dli_h(f64::NEG_INFINITY)
+            .unwrap_err()
+            .contains("finite"));
     }
 }

--- a/simulations/ferroptosis-core/src/photosensitizer_pk.rs
+++ b/simulations/ferroptosis-core/src/photosensitizer_pk.rs
@@ -87,38 +87,37 @@ impl Photosensitizer {
     ///
     /// Errors on unknown variant, unparseable number, or any value that
     /// fails [`Photosensitizer::validate`]. Round-trips with the
-    /// `Display` impl: `parse(format!("{ps}")) == Ok(ps)` for every valid
-    /// `Photosensitizer`.
+    /// `Display` impl: `Photosensitizer::from_cli_spec(&format!("{ps}"))
+    /// == Ok(ps)` for every valid `Photosensitizer`.
     pub fn from_cli_spec(s: &str) -> Result<Self, String> {
         let s = s.trim();
         let (name, value) = match s.split_once('=') {
             Some((n, v)) => (n.trim(), Some(v.trim())),
             None => (s, None),
         };
-        let ps = match name.to_ascii_lowercase().as_str() {
-            "uniform" => {
-                let c = match value {
-                    Some(v) => v
-                        .parse::<f64>()
-                        .map_err(|e| format!("uniform=N: cannot parse N={v:?}: {e}"))?,
-                    None => 1.0,
-                };
-                Self::Uniform(c)
-            }
-            "porfimer" => {
-                let t_half_h = match value {
-                    Some(v) => v
-                        .parse::<f64>()
-                        .map_err(|e| format!("porfimer=N: cannot parse N={v:?}: {e}"))?,
-                    None => 504.0, // Bellnier 2006 terminal t½ in humans, hours.
-                };
-                Self::Porfimer { t_half_h }
-            }
-            _ => {
-                return Err(format!(
-                    "unknown photosensitizer {name:?}; expected one of: uniform, uniform=N, porfimer, porfimer=N (case-insensitive)"
-                ));
-            }
+        // `eq_ignore_ascii_case` avoids allocating a lowercased String
+        // for every CLI parse. Match-on-lowercase would be tidier syntax
+        // but allocates per call.
+        let ps = if name.eq_ignore_ascii_case("uniform") {
+            let c = match value {
+                Some(v) => v
+                    .parse::<f64>()
+                    .map_err(|e| format!("uniform=N: cannot parse N={v:?}: {e}"))?,
+                None => 1.0,
+            };
+            Self::Uniform(c)
+        } else if name.eq_ignore_ascii_case("porfimer") {
+            let t_half_h = match value {
+                Some(v) => v
+                    .parse::<f64>()
+                    .map_err(|e| format!("porfimer=N: cannot parse N={v:?}: {e}"))?,
+                None => 504.0, // Bellnier 2006 terminal t½ in humans, hours.
+            };
+            Self::Porfimer { t_half_h }
+        } else {
+            return Err(format!(
+                "unknown photosensitizer {name:?}; expected one of: uniform, uniform=N, porfimer, porfimer=N (case-insensitive)"
+            ));
         };
         ps.validate()?;
         Ok(ps)
@@ -198,16 +197,21 @@ impl Photosensitizer {
     }
 }
 
-/// Validate a CLI `--dli-h` argument: reject NaN, negative, and infinite
-/// values so they cannot reach `concentration_at` and produce silent
-/// non-physical PDT output. Pair with [`Photosensitizer::from_cli_spec`]
-/// at the same parse-time gate.
+/// Validate a drug-light-interval value (hours): reject NaN, negative,
+/// and infinite inputs so they cannot reach `concentration_at` and
+/// produce silent non-physical PDT output. Pair with
+/// [`Photosensitizer::from_cli_spec`] at the same parse-time gate.
+///
+/// Error messages refer to the field as `dli_h` (matching the parameter
+/// name) rather than embedding any specific CLI flag name; callers are
+/// free to prefix with their flag spelling — e.g. sim-spatial wraps the
+/// error as `--dli-h: <message>`.
 pub fn validate_dli_h(dli_h: f64) -> Result<(), String> {
     if !dli_h.is_finite() {
-        return Err(format!("--dli-h must be finite, got {dli_h}"));
+        return Err(format!("dli_h must be finite, got {dli_h}"));
     }
     if dli_h < 0.0 {
-        return Err(format!("--dli-h must be >= 0, got {dli_h}"));
+        return Err(format!("dli_h must be >= 0, got {dli_h}"));
     }
     Ok(())
 }
@@ -506,7 +510,9 @@ mod tests {
     #[test]
     fn validate_dli_h_rejects_negative() {
         let err = validate_dli_h(-1.0).unwrap_err();
-        assert!(err.contains("--dli-h"));
+        // Error message is library-friendly (`dli_h`), not CLI-coupled
+        // (`--dli-h`); callers are free to prefix with their flag name.
+        assert!(err.contains("dli_h"));
         assert!(err.contains(">= 0"));
     }
 

--- a/simulations/ferroptosis-core/src/photosensitizer_pk.rs
+++ b/simulations/ferroptosis-core/src/photosensitizer_pk.rs
@@ -30,6 +30,7 @@
 //! in humans (PMID 16634075).
 
 use std::fmt;
+use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
@@ -76,10 +77,11 @@ impl fmt::Display for Photosensitizer {
     }
 }
 
-impl Photosensitizer {
-    /// Parse a CLI `--photosensitizer` SPEC string into a `Photosensitizer`.
-    ///
-    /// Accepted forms (case-insensitive on the variant name):
+impl FromStr for Photosensitizer {
+    type Err = String;
+
+    /// Parse a SPEC string into a `Photosensitizer`. Accepted forms
+    /// (case-insensitive on the variant name):
     /// - `uniform` → `Uniform(1.0)`
     /// - `uniform=N` → `Uniform(N)`
     /// - `porfimer` → `Porfimer { t_half_h: 504.0 }` (Bellnier 2006 t½ in hours)
@@ -87,16 +89,21 @@ impl Photosensitizer {
     ///
     /// Errors on unknown variant, unparseable number, or any value that
     /// fails [`Photosensitizer::validate`]. Round-trips with the
-    /// `Display` impl: `Photosensitizer::from_cli_spec(&format!("{ps}"))
-    /// == Ok(ps)` for every valid `Photosensitizer`.
-    pub fn from_cli_spec(s: &str) -> Result<Self, String> {
+    /// `Display` impl: `format!("{ps}").parse::<Photosensitizer>() ==
+    /// Ok(ps)` for every valid `Photosensitizer`.
+    ///
+    /// Implementing `FromStr` (rather than a bespoke `from_cli_spec`)
+    /// gives free clap integration via `#[arg(value_parser =
+    /// clap::value_parser!(Photosensitizer))]` and ergonomic
+    /// `"porfimer=504".parse()?` syntax for non-CLI consumers.
+    fn from_str(s: &str) -> Result<Self, String> {
         let s = s.trim();
         let (name, value) = match s.split_once('=') {
             Some((n, v)) => (n.trim(), Some(v.trim())),
             None => (s, None),
         };
         // `eq_ignore_ascii_case` avoids allocating a lowercased String
-        // for every CLI parse. Match-on-lowercase would be tidier syntax
+        // for every parse. Match-on-lowercase would be tidier syntax
         // but allocates per call.
         let ps = if name.eq_ignore_ascii_case("uniform") {
             let c = match value {
@@ -122,7 +129,9 @@ impl Photosensitizer {
         ps.validate()?;
         Ok(ps)
     }
+}
 
+impl Photosensitizer {
     /// Validate that the photosensitizer's parameters are physically
     /// reasonable. Returns `Ok(())` for valid configurations and a
     /// descriptive `Err` otherwise.
@@ -199,19 +208,20 @@ impl Photosensitizer {
 
 /// Validate a drug-light-interval value (hours): reject NaN, negative,
 /// and infinite inputs so they cannot reach `concentration_at` and
-/// produce silent non-physical PDT output. Pair with
-/// [`Photosensitizer::from_cli_spec`] at the same parse-time gate.
+/// produce silent non-physical PDT output. Pair with the `FromStr` impl
+/// for [`Photosensitizer`] at the same parse-time gate.
 ///
-/// Error messages refer to the field as `dli_h` (matching the parameter
-/// name) rather than embedding any specific CLI flag name; callers are
-/// free to prefix with their flag spelling — e.g. sim-spatial wraps the
-/// error as `--dli-h: <message>`.
+/// Error messages name only the constraint, not the field or CLI flag
+/// (`"must be finite, got NaN"`). Callers are expected to prefix with
+/// their own field/flag context — e.g. sim-spatial wraps as
+/// `error: --dli-h: <message>` so the final user-facing line reads:
+/// `error: --dli-h: must be finite, got NaN` (no stutter).
 pub fn validate_dli_h(dli_h: f64) -> Result<(), String> {
     if !dli_h.is_finite() {
-        return Err(format!("dli_h must be finite, got {dli_h}"));
+        return Err(format!("must be finite, got {dli_h}"));
     }
     if dli_h < 0.0 {
-        return Err(format!("dli_h must be >= 0, got {dli_h}"));
+        return Err(format!("must be >= 0, got {dli_h}"));
     }
     Ok(())
 }
@@ -384,114 +394,119 @@ mod tests {
         assert_eq!(p.concentration_at(f64::NAN), 1.0);
     }
 
-    // -- from_cli_spec --
+    // -- FromStr --
 
     #[test]
-    fn from_cli_spec_uniform_default() {
+    fn parse_uniform_default() {
         assert_eq!(
-            Photosensitizer::from_cli_spec("uniform").unwrap(),
+            "uniform".parse::<Photosensitizer>().unwrap(),
             Photosensitizer::Uniform(1.0)
         );
     }
 
     #[test]
-    fn from_cli_spec_uniform_with_value() {
+    fn parse_uniform_with_value() {
         assert_eq!(
-            Photosensitizer::from_cli_spec("uniform=0.5").unwrap(),
+            "uniform=0.5".parse::<Photosensitizer>().unwrap(),
             Photosensitizer::Uniform(0.5)
         );
     }
 
     #[test]
-    fn from_cli_spec_porfimer_default_is_bellnier() {
+    fn parse_porfimer_default_is_bellnier() {
         assert_eq!(
-            Photosensitizer::from_cli_spec("porfimer").unwrap(),
+            "porfimer".parse::<Photosensitizer>().unwrap(),
             Photosensitizer::Porfimer { t_half_h: 504.0 }
         );
     }
 
     #[test]
-    fn from_cli_spec_porfimer_with_value() {
+    fn parse_porfimer_with_value() {
         assert_eq!(
-            Photosensitizer::from_cli_spec("porfimer=336").unwrap(),
+            "porfimer=336".parse::<Photosensitizer>().unwrap(),
             Photosensitizer::Porfimer { t_half_h: 336.0 }
         );
     }
 
     #[test]
-    fn from_cli_spec_trims_whitespace() {
+    fn parse_trims_whitespace() {
         assert_eq!(
-            Photosensitizer::from_cli_spec("  porfimer = 504  ").unwrap(),
+            "  porfimer = 504  ".parse::<Photosensitizer>().unwrap(),
             Photosensitizer::Porfimer { t_half_h: 504.0 }
         );
     }
 
     #[test]
-    fn from_cli_spec_case_insensitive() {
+    fn parse_case_insensitive() {
         assert_eq!(
-            Photosensitizer::from_cli_spec("Uniform").unwrap(),
+            "Uniform".parse::<Photosensitizer>().unwrap(),
             Photosensitizer::Uniform(1.0)
         );
         assert_eq!(
-            Photosensitizer::from_cli_spec("PORFIMER=504").unwrap(),
+            "PORFIMER=504".parse::<Photosensitizer>().unwrap(),
             Photosensitizer::Porfimer { t_half_h: 504.0 }
         );
         assert_eq!(
-            Photosensitizer::from_cli_spec("PorFimEr").unwrap(),
+            "PorFimEr".parse::<Photosensitizer>().unwrap(),
             Photosensitizer::Porfimer { t_half_h: 504.0 }
         );
     }
 
     #[test]
-    fn from_cli_spec_unknown_variant_errors() {
-        let err = Photosensitizer::from_cli_spec("photochlor").unwrap_err();
+    fn parse_unknown_variant_errors() {
+        let err = "photochlor".parse::<Photosensitizer>().unwrap_err();
         assert!(err.contains("photochlor"));
         assert!(err.contains("uniform"));
         assert!(err.contains("porfimer"));
     }
 
     #[test]
-    fn from_cli_spec_unparseable_number_errors() {
-        let err = Photosensitizer::from_cli_spec("porfimer=abc").unwrap_err();
+    fn parse_unparseable_number_errors() {
+        let err = "porfimer=abc".parse::<Photosensitizer>().unwrap_err();
         assert!(err.contains("porfimer=N"));
         assert!(err.contains("abc"));
     }
 
     #[test]
-    fn from_cli_spec_negative_t_half_h_rejected() {
-        let err = Photosensitizer::from_cli_spec("porfimer=-1").unwrap_err();
+    fn parse_negative_t_half_h_rejected() {
+        let err = "porfimer=-1".parse::<Photosensitizer>().unwrap_err();
         assert!(err.contains("t_half_h"));
     }
 
     #[test]
-    fn from_cli_spec_zero_t_half_h_rejected() {
-        let err = Photosensitizer::from_cli_spec("porfimer=0").unwrap_err();
+    fn parse_zero_t_half_h_rejected() {
+        let err = "porfimer=0".parse::<Photosensitizer>().unwrap_err();
         assert!(err.contains("t_half_h"));
     }
 
     #[test]
-    fn from_cli_spec_negative_uniform_rejected() {
-        let err = Photosensitizer::from_cli_spec("uniform=-0.5").unwrap_err();
+    fn parse_negative_uniform_rejected() {
+        let err = "uniform=-0.5".parse::<Photosensitizer>().unwrap_err();
         assert!(err.contains("must be >= 0"));
     }
 
     #[test]
-    fn from_cli_spec_nan_rejected() {
-        let err = Photosensitizer::from_cli_spec("uniform=NaN").unwrap_err();
+    fn parse_nan_rejected() {
+        let err = "uniform=NaN".parse::<Photosensitizer>().unwrap_err();
         assert!(err.contains("must be finite"));
     }
 
     #[test]
-    fn display_round_trips_through_from_cli_spec() {
-        // Display's contract is round-trip parseability via from_cli_spec.
+    fn display_round_trips_through_parse() {
+        // Display's contract is round-trip parseability via FromStr.
+        // Includes Uniform(0.0) as the boundary case where validation
+        // accepts zero but a regression in either direction (parse or
+        // Display) would silently break the contract.
         for ps in [
+            Photosensitizer::Uniform(0.0),
             Photosensitizer::Uniform(1.0),
             Photosensitizer::Uniform(0.5),
             Photosensitizer::Porfimer { t_half_h: 504.0 },
             Photosensitizer::Porfimer { t_half_h: 336.5 },
         ] {
             let rendered = format!("{ps}");
-            let reparsed = Photosensitizer::from_cli_spec(&rendered)
+            let reparsed: Photosensitizer = rendered
+                .parse()
                 .unwrap_or_else(|e| panic!("round-trip failed for {ps:?}: {e}"));
             assert_eq!(reparsed, ps, "round-trip mismatch via {rendered:?}");
         }
@@ -510,10 +525,11 @@ mod tests {
     #[test]
     fn validate_dli_h_rejects_negative() {
         let err = validate_dli_h(-1.0).unwrap_err();
-        // Error message is library-friendly (`dli_h`), not CLI-coupled
-        // (`--dli-h`); callers are free to prefix with their flag name.
-        assert!(err.contains("dli_h"));
-        assert!(err.contains(">= 0"));
+        // Library returns only the constraint ("must be >= 0, got -1");
+        // no field/flag name embedded. Callers prefix with their own
+        // context, e.g. sim-spatial wraps as `error: --dli-h: <msg>`.
+        assert!(err.contains("must be >= 0"));
+        assert!(err.contains("-1"));
     }
 
     #[test]

--- a/simulations/sim-spatial/README.md
+++ b/simulations/sim-spatial/README.md
@@ -31,7 +31,7 @@ Runtime: several minutes (500x500 grid x 4 treatments x 180 steps, single-thread
 | `--seed` | 42 | Random seed (same seed = same tumor topology) |
 | `--output-dir` | `output/spatial` | Directory for output files |
 | `--n-steps` | 180 | Number of biochemistry timesteps per cell |
-| `--photosensitizer` | `uniform` | Photosensitizer PK model. Spec format: `uniform` (= `uniform=1.0`, default), `uniform=N` (constant fraction), `porfimer` (= `porfimer=504`, Bellnier 2006 t½ in hours), or `porfimer=N` (custom t½). Validated at parse time. |
+| `--photosensitizer` | `uniform=1` | Photosensitizer PK model. Spec format (case-insensitive): `uniform` (= `uniform=1`, the default), `uniform=N` (constant fraction), `porfimer` (= `porfimer=504`, Bellnier 2006 t½ in hours), or `porfimer=N` (custom t½). Parsed via `FromStr` and validated by clap at parse time; `Photosensitizer::Default` Display renders as `uniform=1`, which is what `--help` shows. |
 | `--dli-h` | 0.0 | Drug-light interval in hours from photosensitizer **post-distribution peak** to light delivery. **Not** the clinical DLI from injection — see `ferroptosis_core::photosensitizer_pk` for the distinction. |
 
 Biochemistry and physics parameters are hardcoded via `Params::default()` and `SpatialParams::default()`. See `simulations/calibration/parameter_provenance.md` for literature sources.

--- a/simulations/sim-spatial/src/main.rs
+++ b/simulations/sim-spatial/src/main.rs
@@ -49,8 +49,12 @@ struct Args {
     /// rather than the typical [0, 1] drug-presence range, intentional
     /// forward-compat hook), `porfimer` (= `porfimer=504`, Bellnier 2006
     /// t½ in hours), or `porfimer=N` (custom t½ in hours).
-    #[arg(long, default_value = "uniform")]
-    photosensitizer: String,
+    ///
+    /// Parsed via `Photosensitizer`'s `FromStr` impl, so clap validates
+    /// the spec at flag-parse time and reports errors via clap's standard
+    /// formatter (no manual `eprintln! + exit(2)` dance in `main()`).
+    #[arg(long, default_value_t = Photosensitizer::default())]
+    photosensitizer: Photosensitizer,
 
     /// Drug-light interval in hours: time from photosensitizer
     /// post-distribution peak to light delivery. NOT the clinical DLI
@@ -176,13 +180,10 @@ fn run_spatial(
 fn main() {
     let args = Args::parse();
 
-    let photosensitizer = match Photosensitizer::from_cli_spec(&args.photosensitizer) {
-        Ok(ps) => ps,
-        Err(e) => {
-            eprintln!("error: --photosensitizer {:?}: {}", args.photosensitizer, e);
-            std::process::exit(2);
-        }
-    };
+    // `--photosensitizer` is parsed and validated by clap via the
+    // `Photosensitizer` `FromStr` impl, so by the time we reach here
+    // `args.photosensitizer` is a valid enum value. Only `--dli-h`
+    // (an `f64`) needs explicit validation — clap accepts NaN/inf/neg.
     if let Err(e) = validate_dli_h(args.dli_h) {
         eprintln!("error: --dli-h: {e}");
         std::process::exit(2);
@@ -198,12 +199,15 @@ fn main() {
     );
     eprintln!("Cell size: {} µm", args.cell_size);
     eprintln!("Seed: {}", args.seed);
-    eprintln!("Photosensitizer: {photosensitizer}, DLI: {} h\n", args.dli_h);
+    eprintln!(
+        "Photosensitizer: {}, DLI: {} h\n",
+        args.photosensitizer, args.dli_h
+    );
 
     let params = Params::default();
     let spatial_params = SpatialParams {
         cell_size_um: args.cell_size,
-        photosensitizer,
+        photosensitizer: args.photosensitizer,
         t_drug_light_interval_h: args.dli_h,
         ..Default::default()
     };
@@ -310,18 +314,14 @@ mod tests {
     /// Spec / DLI parsers and their edge-case rejection logic live in
     /// `ferroptosis_core::photosensitizer_pk`; their unit tests live with
     /// them. The remaining test here covers the only binary-specific
-    /// concern: that clap's `default_value` attributes still map to
+    /// concern: that clap's `default_value_t` attributes still map to
     /// `SpatialParams::default()`. Without this, the parser-level
     /// invariant could pass while the clap defaults silently drifted.
     #[test]
     fn default_args_match_default_spatial_params() {
         let args = Args::parse_from(["sim-spatial"]);
-        let parsed_ps = Photosensitizer::from_cli_spec(&args.photosensitizer).unwrap();
         let default_sp = SpatialParams::default();
-        assert_eq!(parsed_ps, default_sp.photosensitizer);
+        assert_eq!(args.photosensitizer, default_sp.photosensitizer);
         assert_eq!(args.dli_h, default_sp.t_drug_light_interval_h);
-        // Also pin the canonical CLI string so a rename would be visible
-        // in stderr but not just in the parsed enum value.
-        assert_eq!(args.photosensitizer, "uniform");
     }
 }

--- a/simulations/sim-spatial/src/main.rs
+++ b/simulations/sim-spatial/src/main.rs
@@ -17,7 +17,7 @@ use ferroptosis_core::cell::{norm, Treatment};
 use ferroptosis_core::grid::{depth_kill_curve, death_heatmap, TumorGrid};
 use ferroptosis_core::io::{write_depth_curves_csv, write_heatmap_csv, write_json};
 use ferroptosis_core::params::{Params, SpatialParams};
-use ferroptosis_core::photosensitizer_pk::Photosensitizer;
+use ferroptosis_core::photosensitizer_pk::{validate_dli_h, Photosensitizer};
 use ferroptosis_core::physics::local_ros_multiplier;
 
 #[derive(Parser)]
@@ -60,63 +60,6 @@ struct Args {
     dli_h: f64,
 }
 
-/// Parse a `--photosensitizer` SPEC into a `Photosensitizer` value.
-///
-/// Accepted forms (case-insensitive on the variant name):
-/// - `uniform` → `Uniform(1.0)`
-/// - `uniform=N` → `Uniform(N)`
-/// - `porfimer` → `Porfimer { t_half_h: 504.0 }`
-/// - `porfimer=N` → `Porfimer { t_half_h: N }`
-///
-/// Errors on unknown variant, unparseable number, or any value that fails
-/// `Photosensitizer::validate()`.
-fn parse_photosensitizer_spec(s: &str) -> Result<Photosensitizer, String> {
-    let s = s.trim();
-    let (name, value) = match s.split_once('=') {
-        Some((n, v)) => (n.trim(), Some(v.trim())),
-        None => (s, None),
-    };
-    let ps = match name.to_ascii_lowercase().as_str() {
-        "uniform" => {
-            let c = match value {
-                Some(v) => v
-                    .parse::<f64>()
-                    .map_err(|e| format!("uniform=N: cannot parse N={v:?}: {e}"))?,
-                None => 1.0,
-            };
-            Photosensitizer::Uniform(c)
-        }
-        "porfimer" => {
-            let t_half_h = match value {
-                Some(v) => v
-                    .parse::<f64>()
-                    .map_err(|e| format!("porfimer=N: cannot parse N={v:?}: {e}"))?,
-                None => 504.0, // Bellnier 2006 terminal t½, hours.
-            };
-            Photosensitizer::Porfimer { t_half_h }
-        }
-        _ => {
-            return Err(format!(
-                "unknown photosensitizer {name:?}; expected one of: uniform, uniform=N, porfimer, porfimer=N (case-insensitive)"
-            ));
-        }
-    };
-    ps.validate()?;
-    Ok(ps)
-}
-
-/// Validate `--dli-h` at the same parse-time gate as the photosensitizer
-/// spec — reject NaN, negative, and infinite values rather than letting
-/// them propagate to silently non-physical PDT physics.
-fn validate_dli_h(dli_h: f64) -> Result<(), String> {
-    if !dli_h.is_finite() {
-        return Err(format!("--dli-h must be finite, got {dli_h}"));
-    }
-    if dli_h < 0.0 {
-        return Err(format!("--dli-h must be >= 0, got {dli_h}"));
-    }
-    Ok(())
-}
 
 fn run_spatial(
     grid: &mut TumorGrid,
@@ -233,7 +176,7 @@ fn run_spatial(
 fn main() {
     let args = Args::parse();
 
-    let photosensitizer = match parse_photosensitizer_spec(&args.photosensitizer) {
+    let photosensitizer = match Photosensitizer::from_cli_spec(&args.photosensitizer) {
         Ok(ps) => ps,
         Err(e) => {
             eprintln!("error: --photosensitizer {:?}: {}", args.photosensitizer, e);
@@ -364,159 +307,21 @@ fn main() {
 mod tests {
     use super::*;
 
-    #[test]
-    fn parse_uniform_default() {
-        let ps = parse_photosensitizer_spec("uniform").unwrap();
-        assert_eq!(ps, Photosensitizer::Uniform(1.0));
-    }
-
-    #[test]
-    fn parse_uniform_with_value() {
-        let ps = parse_photosensitizer_spec("uniform=0.5").unwrap();
-        assert_eq!(ps, Photosensitizer::Uniform(0.5));
-    }
-
-    #[test]
-    fn parse_porfimer_default_is_bellnier() {
-        let ps = parse_photosensitizer_spec("porfimer").unwrap();
-        assert_eq!(ps, Photosensitizer::Porfimer { t_half_h: 504.0 });
-    }
-
-    #[test]
-    fn parse_porfimer_with_value() {
-        let ps = parse_photosensitizer_spec("porfimer=336").unwrap();
-        assert_eq!(ps, Photosensitizer::Porfimer { t_half_h: 336.0 });
-    }
-
-    #[test]
-    fn parse_trims_whitespace() {
-        let ps = parse_photosensitizer_spec("  porfimer = 504  ").unwrap();
-        assert_eq!(ps, Photosensitizer::Porfimer { t_half_h: 504.0 });
-    }
-
-    #[test]
-    fn parse_unknown_variant_errors() {
-        let err = parse_photosensitizer_spec("photochlor").unwrap_err();
-        assert!(err.contains("photochlor"));
-        assert!(err.contains("uniform"));
-        assert!(err.contains("porfimer"));
-    }
-
-    #[test]
-    fn parse_unparseable_number_errors() {
-        let err = parse_photosensitizer_spec("porfimer=abc").unwrap_err();
-        assert!(err.contains("porfimer=N"));
-        assert!(err.contains("abc"));
-    }
-
-    #[test]
-    fn parse_negative_t_half_h_rejected_via_validate() {
-        let err = parse_photosensitizer_spec("porfimer=-1").unwrap_err();
-        // Photosensitizer::validate() rejects t_half_h <= 0
-        assert!(err.contains("t_half_h"));
-    }
-
-    #[test]
-    fn parse_zero_t_half_h_rejected_via_validate() {
-        let err = parse_photosensitizer_spec("porfimer=0").unwrap_err();
-        assert!(err.contains("t_half_h"));
-    }
-
-    #[test]
-    fn parse_negative_uniform_rejected_via_validate() {
-        let err = parse_photosensitizer_spec("uniform=-0.5").unwrap_err();
-        assert!(err.contains("must be >= 0"));
-    }
-
-    #[test]
-    fn parse_nan_rejected_via_validate() {
-        let err = parse_photosensitizer_spec("uniform=NaN").unwrap_err();
-        assert!(err.contains("must be finite"));
-    }
-
-    #[test]
-    fn parse_case_insensitive_variant_names() {
-        // Variant name matching is intentionally case-insensitive so users
-        // who hit shift get sensible behavior.
-        assert_eq!(
-            parse_photosensitizer_spec("Uniform").unwrap(),
-            Photosensitizer::Uniform(1.0)
-        );
-        assert_eq!(
-            parse_photosensitizer_spec("PORFIMER=504").unwrap(),
-            Photosensitizer::Porfimer { t_half_h: 504.0 }
-        );
-        assert_eq!(
-            parse_photosensitizer_spec("PorFimEr").unwrap(),
-            Photosensitizer::Porfimer { t_half_h: 504.0 }
-        );
-    }
-
-    // -- validate_dli_h --
-
-    #[test]
-    fn validate_dli_h_accepts_zero_and_positive() {
-        assert!(validate_dli_h(0.0).is_ok());
-        assert!(validate_dli_h(24.0).is_ok());
-        assert!(validate_dli_h(504.0).is_ok());
-        assert!(validate_dli_h(1e9).is_ok());
-    }
-
-    #[test]
-    fn validate_dli_h_rejects_negative() {
-        let err = validate_dli_h(-1.0).unwrap_err();
-        assert!(err.contains("--dli-h"));
-        assert!(err.contains(">= 0"));
-    }
-
-    #[test]
-    fn validate_dli_h_rejects_nan() {
-        let err = validate_dli_h(f64::NAN).unwrap_err();
-        assert!(err.contains("--dli-h"));
-        assert!(err.contains("finite"));
-    }
-
-    #[test]
-    fn validate_dli_h_rejects_infinity() {
-        assert!(validate_dli_h(f64::INFINITY).unwrap_err().contains("finite"));
-        assert!(validate_dli_h(f64::NEG_INFINITY)
-            .unwrap_err()
-            .contains("finite"));
-    }
-
+    /// Spec / DLI parsers and their edge-case rejection logic live in
+    /// `ferroptosis_core::photosensitizer_pk`; their unit tests live with
+    /// them. The remaining test here covers the only binary-specific
+    /// concern: that clap's `default_value` attributes still map to
+    /// `SpatialParams::default()`. Without this, the parser-level
+    /// invariant could pass while the clap defaults silently drifted.
     #[test]
     fn default_args_match_default_spatial_params() {
-        // Invokes clap with no user-supplied flags so the test catches
-        // accidental changes to the `default_value` attributes (e.g.
-        // someone bumping `--photosensitizer` default to `porfimer`).
-        // Without this, the parser-level invariant could pass while the
-        // clap defaults silently drifted from `SpatialParams::default()`.
         let args = Args::parse_from(["sim-spatial"]);
-        let parsed_ps = parse_photosensitizer_spec(&args.photosensitizer).unwrap();
+        let parsed_ps = Photosensitizer::from_cli_spec(&args.photosensitizer).unwrap();
         let default_sp = SpatialParams::default();
         assert_eq!(parsed_ps, default_sp.photosensitizer);
         assert_eq!(args.dli_h, default_sp.t_drug_light_interval_h);
-        // Defensively also check the clap default string itself, since
-        // a renaming of the canonical "uniform" form would be visible
-        // in stderr but not in the parsed enum value.
+        // Also pin the canonical CLI string so a rename would be visible
+        // in stderr but not just in the parsed enum value.
         assert_eq!(args.photosensitizer, "uniform");
-    }
-
-    #[test]
-    fn display_round_trips_through_parser() {
-        // Display's contract is round-trip parseability via
-        // `parse_photosensitizer_spec`. Verify both variants.
-        for ps in [
-            Photosensitizer::Uniform(1.0),
-            Photosensitizer::Uniform(0.5),
-            Photosensitizer::Porfimer { t_half_h: 504.0 },
-            Photosensitizer::Porfimer { t_half_h: 336.5 },
-        ] {
-            let rendered = format!("{ps}");
-            let reparsed = parse_photosensitizer_spec(&rendered).unwrap_or_else(|e| {
-                panic!("Display→parse round-trip failed for {ps:?} (rendered={rendered:?}): {e}")
-            });
-            assert_eq!(reparsed, ps, "round-trip mismatch via {rendered:?}");
-        }
     }
 }

--- a/simulations/sim-spatial/src/main.rs
+++ b/simulations/sim-spatial/src/main.rs
@@ -184,7 +184,7 @@ fn main() {
         }
     };
     if let Err(e) = validate_dli_h(args.dli_h) {
-        eprintln!("error: {e}");
+        eprintln!("error: --dli-h: {e}");
         std::process::exit(2);
     }
 


### PR DESCRIPTION
## Summary

Issue #205 originally proposed adding `--photosensitizer` / `--dli-h` to all "PDT-using binaries." **The audit caught a real problem:** `Treatment::PDT` references in those binaries are exhaustive `match` arms, not iteration sites. Only `sim-spatial`'s `treatments` array actually contains `Treatment::PDT`. Every other binary (sim-tme, sim-combo, sim-combo-mech, sim-icd, sim-window, sim-invivo, sim-original, sim-tissue-pk, sim-tumor-pk) iterates `[Control, RSL3, SDT]` only — adding the flags would be dead code.

This PR ships the part of #205 that is genuinely useful: **extract the parser from `sim-spatial/src/main.rs` into `ferroptosis-core`**, where it lives with the type it parses.

## Changes

- **`ferroptosis-core`** — `Photosensitizer` now implements `FromStr` (Err = String); 12 parse tests + 1 round-trip test live alongside the type. New `validate_dli_h(f)` free function for the DLI scalar (NaN/negative/inf rejection). ferroptosis-core test count: 49 → 66.
- **`sim-spatial`** — `Args.photosensitizer` is `Photosensitizer` directly (not `String`); clap parses + validates via the `FromStr` impl with `default_value_t = Photosensitizer::default()`. Removed the manual `match { Ok/Err → eprintln + exit(2) }` dance. `--dli-h` is still validated explicitly because clap's f64 parser accepts NaN/inf. Test module: 18 → 1 (only the binary-specific clap-default invariant remains).
- **`ferroptosis-core/Cargo.toml`** — **0.3.0 → 0.4.0**.

### Cargo bump convention

This repo bumps the second `0.x` digit on every additive feature batch (vs. strict cargo semver where `0.x.y` would be patch and `0.x.0` reserved for breaking). Prior history follows this pattern: #200's `0.2 → 0.3` was also additive (added the `Photosensitizer` enum + `SpatialParams` fields). Continuing the convention with `0.3 → 0.4` keeps versions in sync with feature batches; downstream pinning `ferroptosis-core = "0.3"` would not auto-pick this up — currently harmless since no consumer pins, but worth noting.

## Why colocate the parser with the type

1. **API ergonomics.** `"porfimer=504".parse::<Photosensitizer>()` is idiomatic Rust; `clap` integration is free via `default_value_t = Photosensitizer::default()`; non-CLI consumers (config files, tests) get `.parse()` for free.
2. **Test colocation.** 12 parse tests + 1 round-trip test belong with the type they validate, not in a binary's test module.
3. **No `clap` coupling.** `FromStr` is `&str → Result<Self, String>` — pure std. Moving to ferroptosis-core does NOT pull in clap.

## What about #205's original scope?

The issue body claimed `sim-combo` / `sim-combo-mech` "still construct `SpatialParams` with `Photosensitizer::default()`." That was factually wrong — they don't construct `SpatialParams` at all. After audit, only sim-spatial actually iterates `Treatment::PDT`. Other binaries' PDT branches are dead code paths reached only when callers pass `Treatment::PDT`, which they never do.

`sim-combo` / `sim-combo-mech` could honor photosensitizer PK via a different architectural change: scale `Params::pdt_ros` by `photosensitizer.concentration_at(dli)` at the treatment-application site. That's worth its own design discussion, not a flag-port. **Not filed pre-emptively** — spawn an issue if/when demand surfaces.

## Self-review iterations

- **Commit 2 (`4b2c7f54`)** — fixed: docstring example used wrong fn name; allocation per parse via `to_ascii_lowercase`; CLI flag name leaking into library error strings.
- **Commit 3 (`1ac7e3e3`, this commit)** — fixed: `from_cli_spec` renamed via `impl FromStr` (unlocks clap auto-parsing — Args holds `Photosensitizer` directly now); round-trip test extended with `Uniform(0.0)` boundary; error message stutter (`--dli-h: dli_h must be ...` → `--dli-h: must be ...`).

## End-to-end behavior

```
$ sim-spatial                                          # default
Photosensitizer: uniform=1, DLI: 0 h

$ sim-spatial --photosensitizer porfimer --dli-h 504
Photosensitizer: porfimer=504, DLI: 504 h

$ sim-spatial --photosensitizer porfimer=0
error: invalid value 'porfimer=0' for '--photosensitizer <PHOTOSENSITIZER>': Photosensitizer::Porfimer.t_half_h must be > 0, got 0
For more information, try '--help'.

$ sim-spatial --photosensitizer photochlor
error: invalid value 'photochlor' for '--photosensitizer <PHOTOSENSITIZER>': unknown photosensitizer "photochlor"; expected one of: uniform, uniform=N, porfimer, porfimer=N (case-insensitive)

$ sim-spatial --photosensitizer porfimer --dli-h NaN
error: --dli-h: must be finite, got NaN
```

## Test plan

- [x] `cargo test --workspace --exclude ferroptosis-python` — ferroptosis-core 66, sim-spatial 1, all green
- [x] `pytest tests/ simulations/ferroptosis-python/test_bindings.py` — 91/91
- [x] sim-spatial 100×100 default snapshot — byte-identical (SHA-256 match against pre-#205 baseline)
- [x] All 4 invalid-input rejection paths confirmed empirically (porfimer=0, photochlor, --dli-h NaN, --dli-h=-100)
- [x] Round-trip via `parse(format!("{ps}")) == Ok(ps)` covers `Uniform(0.0)`, `Uniform(0.5)`, `Uniform(1.0)`, `Porfimer{504}`, `Porfimer{336.5}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)