### PR TITLE
Docs: surface 3D infrastructure (TumorGrid3D) in CLAUDE.md + simulations/README.md (#211)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ The repo exists to compare therapeutic mechanisms, evidence depth, resistant-sta
 - diagnostic-to-therapy chain extraction (6 chains, 129 articles mapped)
 - tissue-of-origin analysis layer (5 tissue categories, 62% coverage)
 - simulation work: ferroptosis biochemistry, drug penetration, calibration, photosensitizer PK (drug-light-interval scaling, saturating distribution phase, relative singlet-O₂ yield, FromStr-based clap CLI integration in sim-spatial)
+- 3D spheroid infrastructure: foundational `TumorGrid3D` merged (#185); consumer features (3D energy physics #186, O2 gradient #187, stromal #189, pH #190, performance #192) and consumer binary (#194) pending
 - ferroptosis-core library packaging for external use
 - news source authentication pipeline (fetch, extract claims, verify, score, index)
 - broader strategy review of alternative therapies and biological bottlenecks

--- a/simulations/README.md
+++ b/simulations/README.md
@@ -21,7 +21,7 @@ Each binary has its own README with parameters, output format, example commands,
 
 ## Shared library
 
-`ferroptosis-core` provides the biochemistry engine, cell types, physics models (Beer-Lambert PDT, acoustic SDT), spatial grid, immune cascade, drug transport (Krogh penetration), tumor PK (two-compartment), and photosensitizer PK (single-exponential kinetics with optional saturating distribution phase + relative singlet-O₂ yield) used by all binaries. See [ferroptosis-core/README.md](ferroptosis-core/README.md).
+`ferroptosis-core` provides the biochemistry engine, cell types, physics models (Beer-Lambert PDT, acoustic SDT), spatial grid (2D `TumorGrid` with 8-Moore neighbors and circular tumor; 3D `TumorGrid3D` with 26-Moore neighbors and spherical tumor, foundational scaffolding for the spheroid series #186–#197), immune cascade, drug transport (Krogh penetration), tumor PK (two-compartment), and photosensitizer PK (single-exponential kinetics with optional saturating distribution phase + relative singlet-O₂ yield) used by all binaries. See [ferroptosis-core/README.md](ferroptosis-core/README.md).
 
 ## Quick start
 


### PR DESCRIPTION
## Summary

Two-line doc update closing #211. PR #210 merged `TumorGrid3D` as foundational scaffolding for the spheroid series (#185–#197). The per-crate `ferroptosis-core/README.md` already mentioned it; the higher-level docs lagged.

- **`CLAUDE.md` "Current Workstreams":** new entry tracking 3D infrastructure with forward references to the unblocked consumer issues (#186, #187, #189, #190, #192, #194).
- **`simulations/README.md` "Shared library":** mentions both grid types explicitly (2D `TumorGrid` 8-Moore circular + 3D `TumorGrid3D` 26-Moore spherical) instead of the generic "spatial grid".

## Not changed (intentionally)

- **Top-level `README.md`** — does NOT mention 3D yet. There's no 3D binary running in any pipeline. Should be updated when #194 (sim-spatial-3d) lands and actually produces output.
- **`parameter_provenance.md`** — no new physics parameters from #185 (data structure only).

## Test plan

- [x] Docs-only diff (2 lines)
- [x] No code, test, or behavior change

Closes #211.