### PR TITLE
Add 3D energy physics for spheroid PDT/SDT (#186)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ The repo exists to compare therapeutic mechanisms, evidence depth, resistant-sta
 - pathway-target and resistant-state analysis
 - diagnostic-to-therapy chain extraction (6 chains, 129 articles mapped)
 - tissue-of-origin analysis layer (5 tissue categories, 62% coverage)
-- simulation work: ferroptosis biochemistry, drug penetration, calibration, photosensitizer PK (drug-light-interval scaling, saturating distribution phase, relative singlet-O₂ yield, FromStr-based clap CLI integration in sim-spatial)
+- simulation work: ferroptosis biochemistry, drug penetration, calibration, photosensitizer PK (drug-light-interval scaling, saturating distribution phase, relative singlet-O₂ yield, FromStr-based clap CLI integration in sim-spatial), 3D spheroid scaffolding (TumorGrid3D #185, signed radial depth + 3D energy-physics dispatcher #186) for the #185–#197 spheroid-validation series
 - ferroptosis-core library packaging for external use
 - news source authentication pipeline (fetch, extract claims, verify, score, index)
 - broader strategy review of alternative therapies and biological bottlenecks
@@ -51,7 +51,7 @@ The repo exists to compare therapeutic mechanisms, evidence depth, resistant-sta
 - tissue-of-origin and weighted-evidence layers are active
 - diagnostic-therapy matching layer covers 6 chains across 4 modalities (radioligand, checkpoint, mRNA vaccine, oncolytic)
 - manuscript: 112 pages (book format), 11 chapters + 3 appendices, 20 figures, ~36,700 words
-- simulation suite: 10 binaries (incl. sim-tumor-pk) + ferroptosis-core library (MIT licensed, 11 modules including `photosensitizer_pk`; current unit-test count tracked in CI / `cargo test --workspace`) + Python bindings + 91 Python tests (pipeline smoke + figure traceability + invariant/integration + ferroptosis-python bindings)
+- simulation suite: 10 binaries (incl. sim-tumor-pk) + ferroptosis-core library (MIT licensed, 11 modules including `photosensitizer_pk`; v0.7.0 adds 3D radial-depth + 3D ROS-multiplier APIs alongside the 2D path #185–#186; current unit-test count tracked in CI / `cargo test --workspace`) + Python bindings + 91 Python tests (pipeline smoke + figure traceability + invariant/integration + ferroptosis-python bindings)
 - news authentication pipeline: 5 scripts (fetch, extract claims, verify against PubMed, score credibility, build claim-centric index) implementing the 3-tier source framework from analysis/news-source-criteria.md
 - simulation calibration: 5 targets documented, evaluate script operational
 - drug penetration module: 3 tissue types, exponential Krogh approximation

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If you have expertise in oncology, biochemistry, ferroptosis, immunology, comput
 
 - **4,830 full-text cancer research articles** across 19 mechanisms, 22 cancer types, 803 journals (2001-2026)
 - **Python pipeline** for corpus fetching, tagging (7 tag layers), indexing, analysis, and figure generation
-- **10 Rust simulation binaries** modeling ferroptosis biochemistry: single-cell Monte Carlo, spatial tumors with PDT/SDT depth physics + photosensitizer PK (drug-light-interval scaling, saturating distribution phase, relative singlet-O₂ yield), drug penetration, drug combinations, tumor microenvironment (oxygen gradients, spatial immune zones, DAMP-mediated T cell activation), vulnerability windows, ICD immune cascades, tumor PK
+- **10 Rust simulation binaries** modeling ferroptosis biochemistry: single-cell Monte Carlo, spatial tumors with PDT/SDT depth physics (2D row-based and 3D radial-depth dispatchers — 3D spheroid scaffolding for the upcoming spheroid-validation series) + photosensitizer PK (drug-light-interval scaling, saturating distribution phase, relative singlet-O₂ yield), drug penetration, drug combinations, tumor microenvironment (oxygen gradients, spatial immune zones, DAMP-mediated T cell activation), vulnerability windows, ICD immune cascades, tumor PK
 - **ferroptosis-core library** (MIT, with Python bindings) — embeddable ferroptosis biochemistry engine; module list and current unit-test count in [`simulations/ferroptosis-core/README.md`](simulations/ferroptosis-core/README.md)
 - **Calibration infrastructure** linking simulation parameters to published experimental data
 - **112-page book-format manuscript** with 11 chapters, 3 appendices, and 20 figures (~36,700 words), cross-referenced against all analysis outputs

--- a/simulations/Cargo.lock
+++ b/simulations/Cargo.lock
@@ -217,7 +217,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferroptosis-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "csv",
  "ndarray",

--- a/simulations/README.md
+++ b/simulations/README.md
@@ -21,7 +21,7 @@ Each binary has its own README with parameters, output format, example commands,
 
 ## Shared library
 
-`ferroptosis-core` provides the biochemistry engine, cell types, physics models (Beer-Lambert PDT, acoustic SDT), spatial grid, immune cascade, drug transport (Krogh penetration), tumor PK (two-compartment), and photosensitizer PK (single-exponential kinetics with optional saturating distribution phase + relative singlet-O₂ yield) used by all binaries. See [ferroptosis-core/README.md](ferroptosis-core/README.md).
+`ferroptosis-core` provides the biochemistry engine, cell types, physics models (Beer-Lambert PDT, acoustic SDT; 2D row-based and 3D radial-depth dispatchers, #186), spatial grid (2D `TumorGrid` and 3D `TumorGrid3D` with per-cell `radial_depth_um` for spheroid energy physics; downstream spheroid binary lands with #194), immune cascade, drug transport (Krogh penetration), tumor PK (two-compartment), and photosensitizer PK (single-exponential kinetics with optional saturating distribution phase + relative singlet-O₂ yield) used by all binaries. See [ferroptosis-core/README.md](ferroptosis-core/README.md).
 
 ## Quick start
 

--- a/simulations/ferroptosis-core/Cargo.toml
+++ b/simulations/ferroptosis-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferroptosis-core"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Embeddable ferroptosis biochemistry engine for cancer simulation"
 license = "MIT"

--- a/simulations/ferroptosis-core/README.md
+++ b/simulations/ferroptosis-core/README.md
@@ -32,8 +32,8 @@ Run the included example: `cargo run -p ferroptosis-core --example basic_usage`
 | `params` | All rate constants: `Params` (biochemistry), `SpatialParams` (physics), `ImmuneParams` (immune cascade), `RecoveryRates` |
 | `biochem` | Core simulation engine: `sim_cell` (full 180-step loop), `sim_cell_step` (single timestep for spatial interleaving) |
 | `stats` | Wilson confidence intervals, parallel Monte Carlo execution via rayon |
-| `physics` | Depth-dependent energy deposition: Beer-Lambert (PDT), acoustic attenuation (SDT), uniform (RSL3) |
-| `grid` | 2D `TumorGrid` (8-Moore, circular) and 3D `TumorGrid3D` (26-Moore, spherical) with heterogeneous architecture, neighbor iteration, iron diffusion. 3D analytics (radial-depth curves, volumetric heatmaps) land with the binary that consumes them (#194). |
+| `physics` | Depth-dependent energy deposition: Beer-Lambert (PDT), acoustic attenuation (SDT), uniform (RSL3). 2D row-based (`local_ros_multiplier`) and 3D radial-depth (`local_ros_multiplier_3d`) dispatchers share the same per-treatment depth functions (#186). |
+| `grid` | 2D `TumorGrid` (8-Moore, circular) and 3D `TumorGrid3D` (26-Moore, spherical) with heterogeneous architecture, neighbor iteration, iron diffusion. `TumorGrid3D::radial_depth_um` provides per-cell signed depth from the spheroid surface for energy physics (#185, #186). 3D analytics (radial-depth curves, volumetric heatmaps) and the consuming binary land with #194. |
 | `immune` | ICD/DAMP immune cascade: ferroptotic death quality drives dendritic cell activation and T cell priming |
 | `io` | JSON and CSV output helpers |
 | `drug_transport` | Krogh cylinder drug penetration model |
@@ -68,6 +68,20 @@ exponential plasma decay with optional saturating distribution-phase
 hold and relative singlet-O₂ yield). All defaults preserve identity-
 preserving physics. `physics::pdt_intensity_at_depth` calls `yield_at`
 to compose drug presence + yield with depth-attenuated light.
+
+**3D spheroid energy physics (#186):**
+```rust
+let g = TumorGrid3D::generate(40, 40, 40, 20.0, 42);
+let depth_um = g.radial_depth_um(r, c, l);   // signed: + inside, − outside
+let m = local_ros_multiplier_3d(depth_um, Treatment::PDT, &spatial_params);
+```
+Negative depths (cells outside the spheroid) are clipped to the surface
+value. The 3D dispatcher reaches the same per-treatment depth functions
+the 2D path uses, so the matched-depth invariant `local_ros_multiplier(row,
+cell_size, ...) == local_ros_multiplier_3d(row × cell_size, ...)` holds
+bit-exact across all `Treatment` variants — the physical *geometries*
+differ (planar slab vs. spheroid + nearest-surface 1-D approximation),
+but the dispatcher math does not.
 
 **Parameter contexts:**
 - `Params::default()` — 2D culture baseline

--- a/simulations/ferroptosis-core/src/grid.rs
+++ b/simulations/ferroptosis-core/src/grid.rs
@@ -650,6 +650,14 @@ impl TumorGrid3D {
     /// within the grid (matching the no-bounds-check convention of
     /// [`get`](Self::get) and [`get_mut`](Self::get_mut)). Out-of-range
     /// indices give nonsense distances but won't panic.
+    ///
+    /// **Perf note (#194):** the four constants `center_{r,c,l}` and
+    /// `tumor_radius` depend only on grid dimensions and are recomputed
+    /// every call. `#[inline]` lets the compiler hoist them at a single
+    /// call site, but a per-cell sweep over ~10⁵–10⁶ cells in
+    /// sim-spatial-3d should precompute them once outside the loop (or
+    /// store them on the struct) to avoid `usize::min` + cast + multiply
+    /// per cell. Cheap to address when the consumer lands.
     #[inline]
     pub fn radial_depth_um(&self, r: usize, c: usize, l: usize) -> f64 {
         let center_r = self.rows as f64 / 2.0;
@@ -922,9 +930,15 @@ mod tests_3d {
     /// Radial depth at the geometric center equals tumor_radius × cell_size.
     /// For a 20×20×20 grid the center is at (10,10,10) and the cell at
     /// (10,10,10) lies offset by exactly (0,0,0) from the center, so depth
-    /// is `tumor_radius_lattice × cell_size_um = (20·0.45) × 20 = 180.0 µm`.
-    /// Hand-computed in pure-rational arithmetic so the assertion is
-    /// IEEE-exact.
+    /// is `tumor_radius_lattice × cell_size_um = (20·0.45) × 20`.
+    ///
+    /// `0.45` is *not* exact in IEEE 754 (its binary expansion is
+    /// repeating), but the f64 round-to-nearest result of `20.0 × 0.45`
+    /// happens to land on exactly `9.0` (the rounding error in `0.45`'s
+    /// nearest-double is well under half-ULP at 9.0), so the assertion
+    /// `(20·0.45) × 20 == 9.0 × 20.0 = 180.0` holds bit-exact. Strict
+    /// equality is safe here because of that rounding-friendly arithmetic,
+    /// not because it's provably exact rationally.
     #[test]
     fn radial_depth_at_center_is_max() {
         let g = TumorGrid3D::generate(20, 20, 20, 20.0, 42);
@@ -986,17 +1000,20 @@ mod tests_3d {
         }
     }
 
-    /// A cell sitting exactly on the spheroid boundary returns depth ≈ 0.
+    /// A cell sitting exactly on the spheroid boundary returns depth = 0.
     /// Defends the sign-convention contract: `depth = 0` at the surface,
-    /// positive inside, negative outside. Picks a grid where the
-    /// (r, c, l) offset from center hits an exact rational distance equal
-    /// to `tumor_radius_lattice`, so the assertion is precise.
+    /// positive inside, negative outside.
     ///
     /// For a `(20, 20, 20)` grid: center = (10, 10, 10), tumor_radius
-    /// = 20 × TUMOR_RADIUS_FRACTION = 9.0 lattice units. Cell (10, 10, 19)
-    /// is 9.0 lattice units offset from center along the `l` axis, so
-    /// `depth = (9.0 - 9.0) × cell_size = 0.0` exactly (subtracting
-    /// equal f64s yields a true zero, no libm involved).
+    /// = 20 × TUMOR_RADIUS_FRACTION. As noted in
+    /// `radial_depth_at_center_is_max`, `0.45` is not exact in IEEE 754
+    /// but `20.0 × 0.45` rounds to exactly `9.0`. Cell (10, 10, 19) is
+    /// 9.0 lattice units offset from center along the `l` axis;
+    /// `sqrt(81.0) = 9.0` is IEEE-required-correct (perfect square →
+    /// exact result), so `tumor_radius - dist = 9.0 - 9.0 = 0.0` exactly
+    /// and `0.0 × cell_size = 0.0` exactly. The assertion is bit-exact
+    /// because of these rounding-friendly inputs, not provable
+    /// rationally.
     #[test]
     fn radial_depth_at_sphere_surface_is_zero() {
         let g = TumorGrid3D::generate(20, 20, 20, 20.0, 42);

--- a/simulations/ferroptosis-core/src/grid.rs
+++ b/simulations/ferroptosis-core/src/grid.rs
@@ -602,6 +602,41 @@ impl TumorGrid3D {
         }
         census
     }
+
+    /// Signed radial depth from the spheroid surface in micrometers.
+    ///
+    /// `depth = (tumor_radius_lattice − distance_from_center) × cell_size_um`
+    ///
+    /// Sign convention: **positive inside the sphere, negative outside, zero
+    /// at the surface.** The deepest interior cell has the largest positive
+    /// value (the sphere center); cells far from the tumor (corners of the
+    /// bounding box) return negative values.
+    ///
+    /// **Geometry:** matches [`TumorGrid3D::generate`] — sphere center at
+    /// `(rows/2, cols/2, layers/2)`, lattice-centered coords (no voxel
+    /// offset), and `tumor_radius = min(rows, cols, layers) × 0.45`.
+    ///
+    /// **Intended use:** pair with [`crate::physics::local_ros_multiplier_3d`]
+    /// for spheroid PDT/SDT energy deposition — energy enters from the
+    /// (isotropic) sphere surface and attenuates inward, so penetration
+    /// depth maps to this signed radial coordinate clipped at zero.
+    ///
+    /// **Not yet bounds-checked:** caller is expected to pass `(r, c, l)`
+    /// within the grid (matching the no-bounds-check convention of
+    /// [`get`](Self::get) and [`get_mut`](Self::get_mut)). Out-of-range
+    /// indices give nonsense distances but won't panic.
+    #[inline]
+    pub fn radial_depth_um(&self, r: usize, c: usize, l: usize) -> f64 {
+        let center_r = self.rows as f64 / 2.0;
+        let center_c = self.cols as f64 / 2.0;
+        let center_l = self.layers as f64 / 2.0;
+        let tumor_radius = (self.rows.min(self.cols).min(self.layers) as f64) * 0.45;
+        let dr = r as f64 - center_r;
+        let dc = c as f64 - center_c;
+        let dl = l as f64 - center_l;
+        let dist = (dr * dr + dc * dc + dl * dl).sqrt();
+        (tumor_radius - dist) * self.cell_size_um
+    }
 }
 
 #[cfg(test)]
@@ -856,5 +891,72 @@ mod tests_3d {
         assert_eq!(census.oxphos_dead, 0);
         assert_eq!(census.persister_dead, 0);
         assert_eq!(census.persister_nrf2_dead, 0);
+    }
+
+    /// Radial depth at the geometric center equals tumor_radius × cell_size.
+    /// For a 20×20×20 grid the center is at (10,10,10) and the cell at
+    /// (10,10,10) lies offset by exactly (0,0,0) from the center, so depth
+    /// is `tumor_radius_lattice × cell_size_um = (20·0.45) × 20 = 180.0 µm`.
+    /// Hand-computed in pure-rational arithmetic so the assertion is
+    /// IEEE-exact.
+    #[test]
+    fn radial_depth_at_center_is_max() {
+        let g = TumorGrid3D::generate(20, 20, 20, 20.0, 42);
+        // center coord is rows/2 = 10.0; cell (10,10,10) has dr=dc=dl=0
+        // (since 10 - 10.0 = 0 exactly in f64).
+        assert_eq!(g.radial_depth_um(10, 10, 10), 9.0 * 20.0);
+    }
+
+    /// Cells well outside the spheroid (grid corners) return negative depth.
+    /// For a 20×20×20 grid with cell_size=20, the corner (0,0,0) is at
+    /// distance sqrt(3·10²) ≈ 17.32 lattice units from center; tumor
+    /// radius is 9.0 lattice units, so depth ≈ (9.0 - 17.32) × 20 ≈ -166 µm.
+    #[test]
+    fn radial_depth_outside_sphere_is_negative() {
+        let g = TumorGrid3D::generate(20, 20, 20, 20.0, 42);
+        let depth = g.radial_depth_um(0, 0, 0);
+        assert!(
+            depth < 0.0,
+            "corner cell should have negative radial depth, got {depth}"
+        );
+        // Sanity-bound the magnitude. Hand-derived: dist = sqrt(300), depth =
+        // (9 - sqrt(300)) * 20 ≈ -166.4 µm.
+        let expected = (9.0 - 300.0_f64.sqrt()) * 20.0;
+        assert!(
+            (depth - expected).abs() < 1e-9,
+            "depth = {depth}, expected {expected}"
+        );
+    }
+
+    /// Anisotropic grid: tumor radius is set by the *smallest* dimension,
+    /// so a (20, 20, 5) grid has `tumor_radius = 5·0.45 = 2.25` lattice
+    /// units. Verifies the radial geometry doesn't accidentally use the
+    /// wrong dimension (e.g. rows when it should be min).
+    #[test]
+    fn radial_depth_anisotropic_grid() {
+        let g = TumorGrid3D::generate(20, 20, 5, 10.0, 42);
+        // Center of layer axis is layers/2 = 2.5, so cell at l=2 is 0.5
+        // off-center in the l direction. (10, 10, 2): dr=0, dc=0, dl=-0.5,
+        // dist=0.5, depth = (2.25 - 0.5) * 10 = 17.5 µm.
+        let depth = g.radial_depth_um(10, 10, 2);
+        assert_eq!(depth, (2.25 - 0.5) * 10.0);
+        // Far corner is outside the (very small) sphere.
+        let corner = g.radial_depth_um(0, 0, 0);
+        assert!(
+            corner < 0.0,
+            "corner should be outside spheroid, got {corner}"
+        );
+    }
+
+    /// Determinism check: same grid, same indices, same depth. Cheap
+    /// regression guard for any future refactor that introduces RNG or
+    /// caching into the depth path.
+    #[test]
+    fn radial_depth_is_deterministic() {
+        let g1 = TumorGrid3D::generate(10, 10, 10, 20.0, 42);
+        let g2 = TumorGrid3D::generate(10, 10, 10, 20.0, 42);
+        for &(r, c, l) in &[(0, 0, 0), (5, 5, 5), (9, 9, 9), (3, 7, 2)] {
+            assert_eq!(g1.radial_depth_um(r, c, l), g2.radial_depth_um(r, c, l));
+        }
     }
 }

--- a/simulations/ferroptosis-core/src/grid.rs
+++ b/simulations/ferroptosis-core/src/grid.rs
@@ -4,9 +4,11 @@
 //! diffusion. The 2D model ([`TumorGrid`], 8-Moore neighbors, circular
 //! tumor) is the established default used by `sim-spatial` and `sim-tme`.
 //! The 3D model ([`TumorGrid3D`], 26-Moore neighbors, spherical tumor)
-//! was added as foundational infrastructure for the spheroid-validation
-//! series (#185–#197); analytics (`depth_kill_curve`, `death_heatmap`
-//! analogs) land with the binary that actually uses them (#194).
+//! provides foundational infrastructure for the spheroid-validation series
+//! (#185–#197). #185 (struct) and #186 (signed radial depth + paired 3D
+//! energy-physics dispatcher in [`crate::physics`]) are landed; downstream
+//! analytics (`depth_kill_curve` / `death_heatmap` analogs) and the
+//! sim-spatial-3d binary land with #194.
 
 use ndarray::Array2;
 use rand::prelude::*;
@@ -14,6 +16,15 @@ use serde::Serialize;
 
 use crate::cell::{gen_cell, Cell, Phenotype};
 use crate::biochem::CellState;
+
+/// Fraction of the smallest grid dimension used for the tumor sphere/circle
+/// radius (in lattice cells). Shared by [`TumorGrid3D::generate`] and
+/// [`TumorGrid3D::radial_depth_um`] so geometry stays in sync — changing
+/// this value moves both the generated tumor and the depth-from-surface
+/// reference together. (The 2D [`TumorGrid::generate`] uses the same
+/// numeric value inline; if it ever needs to vary independently we can
+/// split the constants.)
+const TUMOR_RADIUS_FRACTION: f64 = 0.45;
 
 /// A single cell in the spatial grid.
 #[derive(Clone, Debug, Serialize)]
@@ -325,7 +336,9 @@ impl TumorGrid3D {
     ///
     /// Layout:
     /// - Spherical tumor centered in `(rows/2, cols/2, layers/2)` with
-    ///   radius = `min(rows, cols, layers) * 0.45`
+    ///   radius = `min(rows, cols, layers) * TUMOR_RADIUS_FRACTION`
+    ///   (currently 0.45; same constant used by
+    ///   [`TumorGrid3D::radial_depth_um`])
     /// - Core (inner 60% of tumor radius): Glycolytic 80%, OXPHOS 15%, Persister 5%
     /// - Periphery (outer 40%): OXPHOS 70%, Glycolytic 20%, Persister 8%, PersisterNrf2 2%
     /// - 10–20 persister cluster seeds scattered uniformly by volume
@@ -368,7 +381,7 @@ impl TumorGrid3D {
         let center_r = rows as f64 / 2.0;
         let center_c = cols as f64 / 2.0;
         let center_l = layers as f64 / 2.0;
-        let tumor_radius = (rows.min(cols).min(layers) as f64) * 0.45;
+        let tumor_radius = (rows.min(cols).min(layers) as f64) * TUMOR_RADIUS_FRACTION;
         let core_radius = tumor_radius * 0.6;
 
         // Generate persister cluster centers uniformly distributed by
@@ -614,12 +627,24 @@ impl TumorGrid3D {
     ///
     /// **Geometry:** matches [`TumorGrid3D::generate`] — sphere center at
     /// `(rows/2, cols/2, layers/2)`, lattice-centered coords (no voxel
-    /// offset), and `tumor_radius = min(rows, cols, layers) × 0.45`.
+    /// offset), and `tumor_radius = min(rows, cols, layers) × TUMOR_RADIUS_FRACTION`
+    /// (both `generate` and this method share the same constant, so the
+    /// generated geometry and the depth-from-surface reference can't drift).
     ///
     /// **Intended use:** pair with [`crate::physics::local_ros_multiplier_3d`]
-    /// for spheroid PDT/SDT energy deposition — energy enters from the
-    /// (isotropic) sphere surface and attenuates inward, so penetration
-    /// depth maps to this signed radial coordinate clipped at zero.
+    /// for spheroid PDT/SDT energy deposition.
+    ///
+    /// **Physical caveat — first-order nearest-surface approximation.** This
+    /// returns the *radial* depth from the spheroid surface, which models
+    /// energy entering from the nearest surface point and attenuating along
+    /// a 1-D radial path. That is the standard first-order approximation
+    /// used in spheroid PDT/SDT models, but it is **not** the exact fluence
+    /// profile for isotropic surface illumination: a full solution would
+    /// integrate chord-length contributions from every surface point and
+    /// account for diffuse back-scatter buildup near the boundary (which
+    /// can push near-surface fluence above `I₀`). For uncalibrated v1
+    /// modelling this is fine; calibration against experimental depth-kill
+    /// curves lands with sim-spatial-3d (#194).
     ///
     /// **Not yet bounds-checked:** caller is expected to pass `(r, c, l)`
     /// within the grid (matching the no-bounds-check convention of
@@ -630,7 +655,8 @@ impl TumorGrid3D {
         let center_r = self.rows as f64 / 2.0;
         let center_c = self.cols as f64 / 2.0;
         let center_l = self.layers as f64 / 2.0;
-        let tumor_radius = (self.rows.min(self.cols).min(self.layers) as f64) * 0.45;
+        let tumor_radius =
+            (self.rows.min(self.cols).min(self.layers) as f64) * TUMOR_RADIUS_FRACTION;
         let dr = r as f64 - center_r;
         let dc = c as f64 - center_c;
         let dl = l as f64 - center_l;
@@ -957,6 +983,62 @@ mod tests_3d {
         let g2 = TumorGrid3D::generate(10, 10, 10, 20.0, 42);
         for &(r, c, l) in &[(0, 0, 0), (5, 5, 5), (9, 9, 9), (3, 7, 2)] {
             assert_eq!(g1.radial_depth_um(r, c, l), g2.radial_depth_um(r, c, l));
+        }
+    }
+
+    /// A cell sitting exactly on the spheroid boundary returns depth ≈ 0.
+    /// Defends the sign-convention contract: `depth = 0` at the surface,
+    /// positive inside, negative outside. Picks a grid where the
+    /// (r, c, l) offset from center hits an exact rational distance equal
+    /// to `tumor_radius_lattice`, so the assertion is precise.
+    ///
+    /// For a `(20, 20, 20)` grid: center = (10, 10, 10), tumor_radius
+    /// = 20 × TUMOR_RADIUS_FRACTION = 9.0 lattice units. Cell (10, 10, 19)
+    /// is 9.0 lattice units offset from center along the `l` axis, so
+    /// `depth = (9.0 - 9.0) × cell_size = 0.0` exactly (subtracting
+    /// equal f64s yields a true zero, no libm involved).
+    #[test]
+    fn radial_depth_at_sphere_surface_is_zero() {
+        let g = TumorGrid3D::generate(20, 20, 20, 20.0, 42);
+        let on_surface = g.radial_depth_um(10, 10, 19);
+        assert_eq!(on_surface, 0.0);
+    }
+
+    /// Guards against silent geometry drift: the generated tumor and the
+    /// reference sphere used by `radial_depth_um` must use the same radius.
+    /// If a future refactor changed one side without the other (e.g. tweaks
+    /// `generate` to use a different fraction inline), this test catches it.
+    ///
+    /// Walks every cell in a small grid and asserts:
+    /// - `is_tumor == true`  →  `radial_depth_um >= 0` (cell is at or
+    ///   inside the depth-reference sphere)
+    /// - `is_tumor == false` →  `radial_depth_um < 0`  (cell is outside)
+    ///
+    /// Holds exactly *because* both code paths reference
+    /// `TUMOR_RADIUS_FRACTION` — the test breaks the moment they diverge.
+    #[test]
+    fn radial_depth_sign_agrees_with_generated_is_tumor() {
+        let g = TumorGrid3D::generate(10, 10, 10, 20.0, 42);
+        for r in 0..g.rows {
+            for c in 0..g.cols {
+                for l in 0..g.layers {
+                    let depth = g.radial_depth_um(r, c, l);
+                    let is_tumor = g.get(r, c, l).is_tumor;
+                    if is_tumor {
+                        assert!(
+                            depth >= 0.0,
+                            "tumor cell ({r},{c},{l}) has negative depth {depth}; \
+                             generate/radial_depth_um drifted"
+                        );
+                    } else {
+                        assert!(
+                            depth < 0.0,
+                            "stromal cell ({r},{c},{l}) has non-negative depth {depth}; \
+                             generate/radial_depth_um drifted"
+                        );
+                    }
+                }
+            }
         }
     }
 }

--- a/simulations/ferroptosis-core/src/physics.rs
+++ b/simulations/ferroptosis-core/src/physics.rs
@@ -1,7 +1,22 @@
 //! Energy deposition models for PDT, SDT, and RSL3.
 //!
-//! Physics of how treatment energy attenuates with tissue depth,
-//! converting to local ROS dose for each cell in the spatial model.
+//! Physics of how treatment energy attenuates with tissue depth, converting
+//! to local ROS dose. Two dispatchers share the same per-treatment
+//! depth-attenuation functions: [`local_ros_multiplier`] (2D, row-based,
+//! planar surface illumination from row 0) and [`local_ros_multiplier_3d`]
+//! (3D, raw radial depth, spheroid surface illumination — pair with
+//! [`crate::grid::TumorGrid3D::radial_depth_um`]).
+//!
+//! **Physical scope.** The PDT path uses the diffusion-approximation form
+//! `µ_eff = sqrt(3·µ_a·(µ_a+µ_s'))` (Jacques 2013), conventionally labelled
+//! "modified Beer-Lambert" in the biomedical-optics literature. The SDT
+//! path uses the empirical `dB/cm/MHz` linear-attenuation form for soft
+//! tissue (Cobbold 2007). Both are first-order **plane-wave** models
+//! applied along a radial path in 3D; chord-length integration from the
+//! full spheroid surface, diffuse back-scatter buildup, and curvature
+//! refraction are **not** modelled. Adequate for first-order spheroid
+//! comparison; calibration against experimental depth-kill curves is the
+//! charter of sim-spatial-3d (#194).
 
 use crate::cell::Treatment;
 use crate::params::SpatialParams;
@@ -133,17 +148,34 @@ pub fn local_ros_multiplier(
 /// **Why the signature differs from the 2D version:** the 2D model lays
 /// energy onto a planar surface (row 0), so `local_ros_multiplier` takes
 /// `(row, cell_size)` and computes `z = row × cell_size` internally. The
-/// 3D model treats energy as entering isotropically through the spheroid
-/// surface, so per-cell depth is **not** a simple coordinate × size — it
-/// depends on geometry. Computing depth lives in `TumorGrid3D`; this
-/// function takes the already-derived depth so physics stays decoupled
-/// from grid representation.
+/// 3D model treats energy as entering through the spheroid surface, so
+/// per-cell depth is **not** a simple coordinate × size — it depends on
+/// geometry. Computing depth lives in `TumorGrid3D`; this function takes
+/// the already-derived depth so physics stays decoupled from grid
+/// representation.
+///
+/// **Physical caveat — different geometry from 2D, same depth function.**
+/// The 2D path models a planar tissue slab illuminated from one edge.
+/// This 3D path models a spheroid with energy entering at the nearest
+/// surface point along a 1-D radial path — the standard first-order
+/// approximation. It does **not** integrate chord-length contributions
+/// from the full spheroid surface (under isotropic illumination, every
+/// surface point contributes; this approximation only credits the
+/// nearest) and it ignores diffuse back-scatter buildup that can push
+/// near-surface fluence above `I₀`. Net effect: the model tends to
+/// over-estimate fluence at deep cells under truly isotropic
+/// illumination. Adequate for first-order spheroid comparison;
+/// calibration against experimental depth-kill curves lands with
+/// sim-spatial-3d (#194).
 ///
 /// **2D ≡ 3D at matched depth:** for any treatment and parameter set, if
 /// the 3D caller passes `depth = row × cell_size_um` (the same value the
 /// 2D path would compute internally), this function returns the same
-/// multiplier as `local_ros_multiplier(row, cell_size_um, ...)`. Locked
-/// down by `pdt_2d_3d_match_at_same_depth_*` tests below.
+/// multiplier as `local_ros_multiplier(row, cell_size_um, ...)`. This is
+/// a **mathematical** invariant on the dispatcher (same depth-function
+/// applied to same f64), not a claim of physical equivalence between the
+/// two geometries. Locked down by
+/// `local_ros_multiplier_2d_3d_match_at_same_depth` below.
 ///
 /// Returns a multiplier in `[0, ∞)`. For `Control`, always returns 0.
 pub fn local_ros_multiplier_3d(radial_depth_um: f64, tx: Treatment, params: &SpatialParams) -> f64 {

--- a/simulations/ferroptosis-core/src/physics.rs
+++ b/simulations/ferroptosis-core/src/physics.rs
@@ -121,6 +121,44 @@ pub fn local_ros_multiplier(
     }
 }
 
+/// 3D analog of [`local_ros_multiplier`] for spheroid energy deposition.
+///
+/// Takes a **raw signed radial depth** in micrometers (positive inside the
+/// spheroid, negative outside) — typically produced by
+/// [`crate::grid::TumorGrid3D::radial_depth_um`]. Negative depths are
+/// clipped to zero (cells outside the spheroid are treated as if at the
+/// surface), then dispatched to the same depth-attenuation functions
+/// used by the 2D path.
+///
+/// **Why the signature differs from the 2D version:** the 2D model lays
+/// energy onto a planar surface (row 0), so `local_ros_multiplier` takes
+/// `(row, cell_size)` and computes `z = row × cell_size` internally. The
+/// 3D model treats energy as entering isotropically through the spheroid
+/// surface, so per-cell depth is **not** a simple coordinate × size — it
+/// depends on geometry. Computing depth lives in `TumorGrid3D`; this
+/// function takes the already-derived depth so physics stays decoupled
+/// from grid representation.
+///
+/// **2D ≡ 3D at matched depth:** for any treatment and parameter set, if
+/// the 3D caller passes `depth = row × cell_size_um` (the same value the
+/// 2D path would compute internally), this function returns the same
+/// multiplier as `local_ros_multiplier(row, cell_size_um, ...)`. Locked
+/// down by `pdt_2d_3d_match_at_same_depth_*` tests below.
+///
+/// Returns a multiplier in `[0, ∞)`. For `Control`, always returns 0.
+pub fn local_ros_multiplier_3d(radial_depth_um: f64, tx: Treatment, params: &SpatialParams) -> f64 {
+    // Outside-spheroid cells (negative depth) get the surface value.
+    // Physically: energy enters at the surface; we don't model
+    // attenuation through stromal tissue outside the tumor (yet).
+    let z_um = radial_depth_um.max(0.0);
+    match tx {
+        Treatment::SDT => sdt_intensity_at_depth(z_um, params),
+        Treatment::PDT => pdt_intensity_at_depth(z_um, params),
+        Treatment::RSL3 => rsl3_concentration(z_um),
+        Treatment::Control => 0.0,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -258,5 +296,106 @@ mod tests {
             intensity > 0.15,
             "SDT at 10cm should still be significant, got {intensity}"
         );
+    }
+
+    /// Matched-depth invariant: when the 3D caller passes the same depth
+    /// the 2D path computes internally (`row × cell_size_um`), the two
+    /// dispatchers must return bit-identical values for **every** treatment
+    /// variant. Locks down the contract that 3D physics is not a separate
+    /// implementation — it's the same depth-functions reached through a
+    /// different per-cell depth derivation.
+    ///
+    /// Iterates all four `Treatment` variants (including `Control` for the
+    /// trivial 0.0 case and `RSL3` for the depth-independent 1.0 case) so a
+    /// future refactor that introduced 3D-only physics quirks would fail
+    /// here.
+    #[test]
+    fn local_ros_multiplier_2d_3d_match_at_same_depth() {
+        let params = SpatialParams::default();
+        let cell_size_um = 20.0_f64;
+        // Probe several depths including row 0 (surface) and deeper.
+        for row in [0usize, 1, 5, 25, 100] {
+            // Compute the depth the 2D path uses internally, then pass the
+            // SAME f64 to the 3D path. Any other phrasing (e.g.
+            // `(row * cell_size_um) as f64` via mixed types) could
+            // introduce 1-ULP drift and weaken the invariant.
+            let z_um = row as f64 * cell_size_um;
+            for tx in [
+                Treatment::Control,
+                Treatment::RSL3,
+                Treatment::SDT,
+                Treatment::PDT,
+            ] {
+                let v2d = local_ros_multiplier(row, cell_size_um, tx, &params);
+                let v3d = local_ros_multiplier_3d(z_um, tx, &params);
+                assert_eq!(
+                    v2d, v3d,
+                    "2D and 3D dispatchers diverged at row={row}, tx={tx:?}, z={z_um}: \
+                     2D = {v2d}, 3D = {v3d}"
+                );
+            }
+        }
+    }
+
+    /// Negative radial depth (cells outside the spheroid) must be clipped
+    /// to zero — i.e. behave like surface intensity, not produce
+    /// `exp(positive)` blowup or `10^positive` amplification.
+    ///
+    /// IEEE-exact: `(-z).max(0.0) == 0.0` exactly, then `exp(0) == 1.0`
+    /// and `10^0 == 1.0` exactly, so the multiplier equals `I₀`. The
+    /// default `SpatialParams` has `pdt_i0 = sdt_i0 = 1.0` so the
+    /// surface multiplier is exactly 1.0 for PDT/SDT.
+    #[test]
+    fn local_ros_multiplier_3d_negative_depth_clips_to_surface() {
+        let params = SpatialParams::default();
+        for &z_negative in &[-1.0, -100.0, -10_000.0] {
+            for tx in [Treatment::SDT, Treatment::PDT] {
+                let at_surface = local_ros_multiplier_3d(0.0, tx, &params);
+                let at_negative = local_ros_multiplier_3d(z_negative, tx, &params);
+                assert_eq!(
+                    at_negative, at_surface,
+                    "negative depth z={z_negative} for {tx:?} should clip to surface value"
+                );
+            }
+            // RSL3 is depth-independent; Control is identically 0.
+            assert_eq!(
+                local_ros_multiplier_3d(z_negative, Treatment::RSL3, &params),
+                1.0
+            );
+            assert_eq!(
+                local_ros_multiplier_3d(z_negative, Treatment::Control, &params),
+                0.0
+            );
+        }
+    }
+
+    /// The photosensitizer PK path composes correctly when reached via the
+    /// 3D dispatcher. Sanity check that the 0.5-yield phi factor produces
+    /// exactly half the PDT multiplier the default Uniform(1.0) does, at
+    /// the same depth — same property `pdt_with_porfimer_phi_half_is_half`
+    /// asserts via the 2D-style direct call, but routed through
+    /// `local_ros_multiplier_3d` so a future split in the PDT path would
+    /// be caught.
+    #[test]
+    fn local_ros_multiplier_3d_composes_with_photosensitizer() {
+        use crate::photosensitizer_pk::Photosensitizer;
+
+        let baseline_params = SpatialParams::default();
+        let half_params = SpatialParams {
+            photosensitizer: Photosensitizer::Porfimer {
+                t_half_h: 504.0,
+                t_distribution_h: 0.0,
+                phi_so2_relative: 0.5,
+            },
+            t_drug_light_interval_h: 0.0,
+            ..Default::default()
+        };
+
+        let depth_um = 1000.0_f64; // 1 mm — well inside spheroid range
+        let baseline = local_ros_multiplier_3d(depth_um, Treatment::PDT, &baseline_params);
+        let half = local_ros_multiplier_3d(depth_um, Treatment::PDT, &half_params);
+
+        // 0.5 is IEEE-exact, so strict equality is safe.
+        assert_eq!(half, baseline * 0.5);
     }
 }


### PR DESCRIPTION
## Summary

Closes #186. Adds the physics primitives the 3D ferroptosis pipeline needs without touching the 2D path.

- `TumorGrid3D::radial_depth_um(r, c, l) -> f64` — signed depth from the spheroid surface (positive inside, negative outside, zero at surface). Geometry matches `TumorGrid3D::generate`.
- `physics::local_ros_multiplier_3d(depth_um, tx, params) -> f64` — 3D analog of `local_ros_multiplier`. Takes raw depth, clips negative values to zero, dispatches to the same depth-attenuation functions the 2D path uses (Beer-Lambert for PDT, acoustic for SDT, uniform for RSL3, zero for Control).
- Bumps `ferroptosis-core` 0.6.0 → 0.7.0 (additive feature batch).

## Design notes

The 2D and 3D signatures are intentionally asymmetric. 2D `local_ros_multiplier(row, cell_size, ...)` computes `z = row × cell_size` internally because energy enters from a flat surface (row 0). 3D `local_ros_multiplier_3d(depth_um, ...)` takes raw `z` because per-cell depth in a spheroid depends on geometry (distance to sphere surface), not just a single coordinate × size. Computing depth lives on `TumorGrid3D`; physics stays decoupled from grid representation. Documented on the function.

The **2D ≡ 3D matched-depth invariant** is locked down by `local_ros_multiplier_2d_3d_match_at_same_depth`: iterates all four `Treatment` variants over five depths and asserts bit-exact equality. Any future refactor that introduces 3D-only physics quirks would fail there.

## Acceptance criteria (#186)

- [x] `local_ros_multiplier()` works with 3D radial depth — via new `local_ros_multiplier_3d`, keeping the 2D function untouched (verified bit-identical via sim-spatial snapshot below).
- [x] PDT kill dropoff matches 2D behavior at equivalent depths — covered by `local_ros_multiplier_2d_3d_match_at_same_depth`.
- [x] SDT maintains deep-tissue penetration in 3D — same matched-depth test covers SDT.
- [x] Unit tests comparing 2D and 3D at matched depths — see above.

Per issue: directional energy delivery (ultrasound focal zone vs. isotropic-surface) is explicitly listed as **optional for v1** and is not addressed here.

## Verification

- 13 `grid::tests_3d` tests pass (4 new for `radial_depth_um`: at center, outside-sphere, anisotropic grid, determinism)
- 12 `physics::tests` tests pass (3 new: matched-depth invariant, negative-depth clipping, photosensitizer-composes-in-3D)
- 103 total `ferroptosis-core` tests pass
- `sim-spatial 100×100` snapshot bit-identical before vs. after:
  - `spatial_summary.json` SHA-256: `f7628f85fe86217142f078d2857caefb6c4ac400bf2837abf3c96c2808e13e66`
  - `depth_kill_curves.csv` SHA-256: `2eea07e1ef94ff5233f470c434183c4ad413593ed34d5dacef9fdbaa0059a72e`

## Test plan

- [x] `cargo test --workspace --release` passes locally
- [x] `cargo build --release --workspace --exclude ferroptosis-python` clean (Python crate excluded due to local pyo3 linker env; unaffected by these changes)
- [x] `sim-spatial 100×100` re-run produces bit-identical output to baseline
- [ ] CI green

## Follow-ups

- Partially unblocks #194 (sim-spatial-3d). The binary still needs analytics helpers (radial-depth curves, volumetric heatmaps) and the binary itself.
- Does not address #209 (pre-existing fmt drift + CI gate); new code in this PR is fmt-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)