### PR TITLE
Lift TME config structs + DAMP threshold to ferroptosis-core (#220)

### DIFF
--- a/simulations/Cargo.lock
+++ b/simulations/Cargo.lock
@@ -217,7 +217,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferroptosis-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "csv",
  "ndarray",

--- a/simulations/calibration/calibration_report.md
+++ b/simulations/calibration/calibration_report.md
@@ -2,15 +2,15 @@
 
 Comparison of current simulation outputs against published calibration targets.
 
-**Results: 3 PASS, 5 STALE out of 8 targets.**
+**Results: 5 PASS, 3 STALE out of 8 targets.**
 
 | Target | Status | Observed | Target | Residual | Tolerance | Confidence |
 |--------|--------|----------|--------|----------|-----------|------------|
 | **persister_rsl3_death_rate** | STALE | 0.4248 | 0.425 | -0.0002 | 0.1 | medium |
-| **pdt_kill_at_9mm** | STALE | 0.0105 | 0.005 | +0.0055 | 0.015 | high |
+| **pdt_kill_at_9mm** | PASS | 0.0105 | 0.005 | +0.0055 | 0.015 | high |
 | **rsl3_window_closure_72h** | STALE | 0.0143 | < 0.1 | -0.0857 | 0.05 | medium |
 | **invivo_mufa_protection_factor** | STALE | 18.5516 | 18.6 | -0.0484 | 5.0 | low |
-| **sdt_penetration_1cm** | STALE | 0.8412 | > 0.84 | -0.0012 | 0.1 | high |
+| **sdt_penetration_1cm** | PASS | 0.8412 | > 0.84 | -0.0012 | 0.1 | high |
 | **3d_rsl3_o2_collapse_ratio** | PASS | 0.0160 | < 0.5 | -0.4840 | 0.5 | medium |
 | **3d_immune_sdt_dominates** | PASS | 4.0345 | > 3.0 | -1.0345 | 1.0 | medium |
 | **3d_stromal_boundary_shielding** | PASS | 0.4848 | < 0.7 | -0.2152 | 0.3 | medium |
@@ -19,14 +19,12 @@ Comparison of current simulation outputs against published calibration targets.
 
 - [~] **persister_rsl3_death_rate**: Persister (FSP1-low) cell death rate under RSL3 in 2D culture
   - Value within tolerance but output is stale: Output simulation_results.json is older than source code — results may be stale. Re-run the simulation.
-- [~] **pdt_kill_at_9mm**: PDT kill rate at 9mm tissue depth
-  - Value within tolerance but output is stale: Output depth_kill_curves.csv is older than source code — results may be stale. Re-run the simulation.
+- [+] **pdt_kill_at_9mm**: PDT kill rate at 9mm tissue depth
 - [~] **rsl3_window_closure_72h**: RSL3 death rate drops below 10% by 72 hours post-treatment
   - Value within tolerance but output is stale: Output vulnerability_window.csv is older than source code — results may be stale. Re-run the simulation.
 - [~] **invivo_mufa_protection_factor**: In-vivo MUFA provides substantial protection against RSL3 for persisters
   - Value within tolerance but output is stale: Output invivo_comparison.json is older than source code — results may be stale. Re-run the simulation.
-- [~] **sdt_penetration_1cm**: SDT maintains >84% kill rate through 1cm tissue depth
-  - Value within tolerance but output is stale: Output depth_kill_curves.csv is older than source code — results may be stale. Re-run the simulation.
+- [+] **sdt_penetration_1cm**: SDT maintains >84% kill rate through 1cm tissue depth
 - [+] **3d_rsl3_o2_collapse_ratio**: RSL3 at λ=120 µm: hypoxic-zone kill rate should be ≤ 50% of normoxic-zone kill rate (Q1 finding)
 - [+] **3d_immune_sdt_dominates**: At λ=120 immune-on: SDT immune-kills should be > 3× RSL3 immune-kills (Q2 finding — the manuscript-keystone 104:1 → 4:1 reduction in 3D)
 - [+] **3d_stromal_boundary_shielding**: At λ=120 immune-on RSL3: stromal-on boundary kill rate should be ≤ 70% of no-stromal boundary kill rate (Q3 finding — CAF shielding ≥ 30%)

--- a/simulations/ferroptosis-core/Cargo.toml
+++ b/simulations/ferroptosis-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferroptosis-core"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Embeddable ferroptosis biochemistry engine for cancer simulation"
 license = "MIT"

--- a/simulations/ferroptosis-core/src/immune_3d.rs
+++ b/simulations/ferroptosis-core/src/immune_3d.rs
@@ -83,6 +83,17 @@
 
 use crate::grid::TumorGrid3D;
 
+/// Minimum local-DAMP concentration above which a cell is eligible for
+/// immune-mediated kill. Cells with `local_damp < DAMP_KILL_THRESHOLD`
+/// are skipped — both as a performance optimization (don't roll RNG
+/// when activation × kill_rate would round to ~0 anyway) and as a
+/// floor against numerical noise in the diffused DAMP field.
+///
+/// Used by both sim-tme (2D) and sim-tme-3d (3D) so the kill-eligibility
+/// floor stays consistent across dimensionality. Previously hard-coded
+/// `0.01` in sim-tme:735 and as a binary-local const in sim-tme-3d.
+pub const DAMP_KILL_THRESHOLD: f64 = 0.01;
+
 /// Maximum Moore-neighbor count in 3D (3×3×3 cube − self).
 ///
 /// **Coupled to [`TumorGrid3D::neighbors`]**: if a future refactor of

--- a/simulations/ferroptosis-core/src/immune_3d.rs
+++ b/simulations/ferroptosis-core/src/immune_3d.rs
@@ -92,6 +92,11 @@ use crate::grid::TumorGrid3D;
 /// Used by both sim-tme (2D) and sim-tme-3d (3D) so the kill-eligibility
 /// floor stays consistent across dimensionality. Previously hard-coded
 /// `0.01` in sim-tme:735 and as a binary-local const in sim-tme-3d.
+///
+/// TODO(#224): this const is dimensionality-agnostic but lives in the
+/// `immune_3d` module because that's where it was introduced. Move to a
+/// shared `immune_common` (or rename `immune_3d` to `immune_spatial`)
+/// once the broader naming cleanup happens.
 pub const DAMP_KILL_THRESHOLD: f64 = 0.01;
 
 /// Maximum Moore-neighbor count in 3D (3×3×3 cube − self).
@@ -247,6 +252,11 @@ pub fn dc_activation(local_damp: f64, kd: f64) -> f64 {
 /// Per-cell immune kill probability per step.
 ///
 /// `probability = (activation × kill_rate × (1 − effective_brake)).min(0.99)`
+///
+/// TODO(#224): dimensionality-agnostic (takes scalars, no grid), now
+/// imported by sim-tme (2D) as well as sim-tme-3d. Module name `immune_3d`
+/// is misleading; relocate alongside `DAMP_KILL_THRESHOLD` per the
+/// follow-up issue.
 ///
 /// The `.min(0.99)` cap matches sim-tme: even at full activation with no
 /// PD-1 brake, kills are never guaranteed (preserves stochasticity over

--- a/simulations/ferroptosis-core/src/params.rs
+++ b/simulations/ferroptosis-core/src/params.rs
@@ -249,10 +249,11 @@ impl Default for ImmuneParams {
 /// DAMP-field model. Same biology, different math; both are valid.
 ///
 /// **2D vs 3D split**: `damp_diffusion_fraction` differs by geometry.
-/// 2D uses 0.08 (4-Moore neighbors, ≤ 1 / 4 stability bound); 3D uses
-/// 0.025 (26-Moore neighbors, ≤ 1 / 26 stability bound enforced by
-/// `assert!` in `immune_3d::diffuse_damp_3d_step`). Use [`for_2d()`] or
-/// [`for_3d()`] to pick the right default.
+/// 2D uses 0.08 (8-Moore neighbors via `TumorGrid::neighbors`, stability
+/// bound `< 1 / 8 = 0.125`); 3D uses 0.025 (26-Moore neighbors, stability
+/// bound `< 1 / 26 ≈ 0.0385` enforced by `assert!` in
+/// `immune_3d::diffuse_damp_3d_step`). Use [`for_2d()`] or [`for_3d()`]
+/// to pick the right default.
 ///
 /// **No `Default` impl on purpose**: callers MUST pick a geometry. Using
 /// the wrong default in 3D would panic at runtime via the diffuse-step
@@ -264,8 +265,11 @@ impl Default for ImmuneParams {
 pub struct SpatialImmuneConfig {
     /// DAMP released per unit LP at death.
     pub damp_per_lp: f64,
-    /// Fraction of DAMP shared with each Moore neighbor per step.
-    /// 2D: 0.08 (×4 Moore = 0.32 redistributed). 3D: 0.025 (×26 Moore = 0.65).
+    /// Fraction of DAMP shared with each Moore neighbor per step. The
+    /// total redistributed mass per source cell is `fraction * neighbor_count`
+    /// and must stay below 1 to keep the diffusion update mass-conserving.
+    /// 2D: 0.08 (×8 Moore = up to 0.64 redistributed; bound `< 1/8`).
+    /// 3D: 0.025 (×26 Moore = up to 0.65 redistributed; bound `< 1/26`).
     pub damp_diffusion_fraction: f64,
     /// Exponential decay per step (models immune clearance of DAMPs).
     pub damp_clearance_rate: f64,
@@ -280,7 +284,9 @@ pub struct SpatialImmuneConfig {
 }
 
 impl SpatialImmuneConfig {
-    /// 2D default (sim-tme): `damp_diffusion_fraction = 0.08` for 4-Moore.
+    /// 2D default (sim-tme): `damp_diffusion_fraction = 0.08`, safely
+    /// below the `1/8` stability bound for the 8-Moore neighborhood used
+    /// by `TumorGrid::neighbors`.
     pub fn for_2d() -> Self {
         SpatialImmuneConfig {
             damp_per_lp: 1.0,
@@ -423,6 +429,11 @@ mod tests {
         assert_eq!(c.immune_kill_rate, 0.02);
         assert_eq!(c.pd1_brake, 0.7);
         assert_eq!(c.anti_pd1_efficacy, 0.0);
+        // 2D stability invariant: sim-tme's DAMP diffusion calls
+        // `TumorGrid::neighbors` which returns up to 8 Moore neighbors.
+        // Each step subtracts `fraction * count` from the source cell, so
+        // `fraction * 8 < 1` is required to keep the update mass-conserving.
+        assert!(c.damp_diffusion_fraction * 8.0 < 1.0);
     }
 
     /// `SpatialImmuneConfig::for_3d()` must reproduce the literal values

--- a/simulations/ferroptosis-core/src/params.rs
+++ b/simulations/ferroptosis-core/src/params.rs
@@ -198,7 +198,16 @@ impl Default for SpatialParams {
     }
 }
 
-/// Immune cascade parameters for ICD modeling.
+/// Immune cascade parameters for ICD modeling. Used by sim-icd + sim-combo.
+///
+/// Models the full DC→T-cell cascade with separate `dc_maturation_rate`,
+/// `tcell_priming_rate`, `tcell_kill_rate` steps.
+///
+/// **See also [`SpatialImmuneConfig`]** for the spatial-DAMP-field variant
+/// used by sim-tme + sim-tme-3d (single absorbed `immune_kill_rate`
+/// plus `damp_diffusion_fraction` / `damp_clearance_rate`). Same biology,
+/// different math; both valid. If you add a field here, check whether
+/// the spatial variant needs the same change.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ImmuneParams {
     /// DAMP release proportional to LP at death.
@@ -244,6 +253,13 @@ impl Default for ImmuneParams {
 /// 0.025 (26-Moore neighbors, ≤ 1 / 26 stability bound enforced by
 /// `assert!` in `immune_3d::diffuse_damp_3d_step`). Use [`for_2d()`] or
 /// [`for_3d()`] to pick the right default.
+///
+/// **No `Default` impl on purpose**: callers MUST pick a geometry. Using
+/// the wrong default in 3D would panic at runtime via the diffuse-step
+/// stability `assert!`; making that a compile error via explicit
+/// constructors is preferable. Compare with [`StromalConfig`] /
+/// [`PhConfig`], which do impl `Default` because they're
+/// geometry-independent.
 #[derive(Clone, Copy, Debug)]
 pub struct SpatialImmuneConfig {
     /// DAMP released per unit LP at death.

--- a/simulations/ferroptosis-core/src/params.rs
+++ b/simulations/ferroptosis-core/src/params.rs
@@ -231,6 +231,143 @@ impl Default for ImmuneParams {
     }
 }
 
+/// Spatial immune-coupling params used by sim-tme (2D) and sim-tme-3d (3D).
+///
+/// Distinct from [`ImmuneParams`] — that struct models the full DC→T-cell
+/// cascade with separate maturation/priming/kill rates. This struct uses
+/// a single absorbed `immune_kill_rate` plus spatial fields
+/// (`damp_diffusion_fraction`, `damp_clearance_rate`) for the spatial
+/// DAMP-field model. Same biology, different math; both are valid.
+///
+/// **2D vs 3D split**: `damp_diffusion_fraction` differs by geometry.
+/// 2D uses 0.08 (4-Moore neighbors, ≤ 1 / 4 stability bound); 3D uses
+/// 0.025 (26-Moore neighbors, ≤ 1 / 26 stability bound enforced by
+/// `assert!` in `immune_3d::diffuse_damp_3d_step`). Use [`for_2d()`] or
+/// [`for_3d()`] to pick the right default.
+#[derive(Clone, Copy, Debug)]
+pub struct SpatialImmuneConfig {
+    /// DAMP released per unit LP at death.
+    pub damp_per_lp: f64,
+    /// Fraction of DAMP shared with each Moore neighbor per step.
+    /// 2D: 0.08 (×4 Moore = 0.32 redistributed). 3D: 0.025 (×26 Moore = 0.65).
+    pub damp_diffusion_fraction: f64,
+    /// Exponential decay per step (models immune clearance of DAMPs).
+    pub damp_clearance_rate: f64,
+    /// Michaelis-Menten Kd for DC activation by DAMP concentration.
+    pub dc_activation_kd: f64,
+    /// Per-step immune kill rate (absorbs DC maturation + T cell priming + kill).
+    pub immune_kill_rate: f64,
+    /// PD-1 brake: fraction of T-cell kill suppressed.
+    pub pd1_brake: f64,
+    /// Anti-PD-1 efficacy: fraction of PD-1 brake removed.
+    pub anti_pd1_efficacy: f64,
+}
+
+impl SpatialImmuneConfig {
+    /// 2D default (sim-tme): `damp_diffusion_fraction = 0.08` for 4-Moore.
+    pub fn for_2d() -> Self {
+        SpatialImmuneConfig {
+            damp_per_lp: 1.0,
+            damp_diffusion_fraction: 0.08,
+            damp_clearance_rate: 0.03,
+            dc_activation_kd: 50.0,
+            immune_kill_rate: 0.02,
+            pd1_brake: 0.7,
+            anti_pd1_efficacy: 0.0,
+        }
+    }
+
+    /// 3D default (sim-tme-3d): `damp_diffusion_fraction = 0.025` for
+    /// 26-Moore (matches `immune_3d::diffuse_damp_3d_step`'s
+    /// `assert!(0.025 * 26.0 < 1.0)` stability invariant).
+    pub fn for_3d() -> Self {
+        SpatialImmuneConfig {
+            damp_per_lp: 1.0,
+            damp_diffusion_fraction: 0.025,
+            damp_clearance_rate: 0.03,
+            dc_activation_kd: 50.0,
+            immune_kill_rate: 0.02,
+            pd1_brake: 0.7,
+            anti_pd1_efficacy: 0.0,
+        }
+    }
+
+    /// Return a copy with anti-PD-1 blockade applied (efficacy 0.8).
+    pub fn with_anti_pd1(&self) -> Self {
+        SpatialImmuneConfig {
+            anti_pd1_efficacy: 0.8,
+            ..*self
+        }
+    }
+
+    /// Net PD-1 brake after anti-PD-1 modulation: `pd1_brake * (1 - anti_pd1_efficacy)`.
+    pub fn effective_brake(&self) -> f64 {
+        self.pd1_brake * (1.0 - self.anti_pd1_efficacy)
+    }
+}
+
+/// CAF-mediated stromal protection params used by sim-tme + sim-tme-3d.
+///
+/// All ESTIMATED. Refs: PMID 34373744 (CAF metabolic reprogramming),
+/// PMID 31813804 (ACSL3-mediated oleic acid), PMID 30842648 (MUFA
+/// ferroptosis). Geometry-independent — no 2D/3D split (per-cell
+/// shielding measured equal at 50.0% (2D) and 51.5% (3D) in the
+/// PR #221 validation report).
+#[derive(Clone, Copy, Debug)]
+pub struct StromalConfig {
+    /// Per-step GSH boost for stromal-adjacent tumor cells.
+    pub gsh_boost_per_step: f64,
+    /// Maximum GSH from CAF supply (1.5× normal gsh_max of 12.0).
+    pub gsh_boost_cap: f64,
+    /// Per-step MUFA boost from ACSL3-mediated oleic acid uptake.
+    pub mufa_boost_per_step: f64,
+    /// Maximum MUFA from CAF supply.
+    pub mufa_boost_cap: f64,
+}
+
+impl Default for StromalConfig {
+    fn default() -> Self {
+        StromalConfig {
+            gsh_boost_per_step: 0.06,
+            gsh_boost_cap: 18.0,
+            mufa_boost_per_step: 0.003,
+            mufa_boost_cap: 0.25,
+        }
+    }
+}
+
+/// Tumor acidic pH gradient params (Warburg effect lactic acid + ion-trapping).
+///
+/// Used by sim-tme + sim-tme-3d. Linearized Henderson-Hasselbalch over
+/// pH 6.5-7.4; valid only in that narrow window. Refs: Stubbs 2000,
+/// Gatenby & Gillies 2004 (tumor pH); Harrison & Arosio 1996 (ferritin
+/// iron release). Geometry-independent (same chemistry in 2D and 3D).
+#[derive(Clone, Copy, Debug)]
+pub struct PhConfig {
+    /// pH at tumor edge (well-perfused).
+    pub ph_edge: f64,
+    /// pH at deep tumor core (Warburg lactic acid).
+    pub ph_core: f64,
+    /// pH penetration length (μm); matches O2 reference λ.
+    pub lambda_ph_um: f64,
+    /// Iron-pH sensitivity: ferritin releases Fe²⁺ at low pH.
+    pub iron_ph_sensitivity: f64,
+    /// Ion trapping sensitivity for weak-base drugs (RSL3).
+    pub ion_trap_sensitivity: f64,
+}
+
+impl Default for PhConfig {
+    fn default() -> Self {
+        PhConfig {
+            ph_edge: 7.4,
+            ph_core: 6.5,
+            lambda_ph_um: 120.0,
+            iron_ph_sensitivity: 1.5,
+            ion_trap_sensitivity: 0.4,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -255,5 +392,89 @@ mod tests {
         assert_eq!(p.photosensitizer, Photosensitizer::Uniform(1.0));
         assert_eq!(p.t_drug_light_interval_h, 0.0);
         assert_eq!(p.photosensitizer.concentration_at(p.t_drug_light_interval_h), 1.0);
+    }
+
+    /// `SpatialImmuneConfig::for_2d()` must reproduce the literal values
+    /// sim-tme used before the lift (#220). Regression-guards a silent
+    /// drift if anyone edits the constructor.
+    #[test]
+    fn spatial_immune_for_2d_matches_sim_tme_legacy_defaults() {
+        let c = SpatialImmuneConfig::for_2d();
+        assert_eq!(c.damp_per_lp, 1.0);
+        assert_eq!(c.damp_diffusion_fraction, 0.08);
+        assert_eq!(c.damp_clearance_rate, 0.03);
+        assert_eq!(c.dc_activation_kd, 50.0);
+        assert_eq!(c.immune_kill_rate, 0.02);
+        assert_eq!(c.pd1_brake, 0.7);
+        assert_eq!(c.anti_pd1_efficacy, 0.0);
+    }
+
+    /// `SpatialImmuneConfig::for_3d()` must reproduce the literal values
+    /// sim-tme-3d used before the lift, in particular the 3D-safe
+    /// `damp_diffusion_fraction = 0.025` (×26 Moore < 1 stability bound).
+    #[test]
+    fn spatial_immune_for_3d_matches_sim_tme_3d_legacy_defaults() {
+        let c = SpatialImmuneConfig::for_3d();
+        assert_eq!(c.damp_per_lp, 1.0);
+        assert_eq!(c.damp_diffusion_fraction, 0.025);
+        assert_eq!(c.damp_clearance_rate, 0.03);
+        assert_eq!(c.dc_activation_kd, 50.0);
+        assert_eq!(c.immune_kill_rate, 0.02);
+        assert_eq!(c.pd1_brake, 0.7);
+        assert_eq!(c.anti_pd1_efficacy, 0.0);
+        // Stability invariant matched by immune_3d::diffuse_damp_3d_step's
+        // `assert!`. If this ever fails, that diffusion step panics in
+        // release mode — the test exists to catch the drift first.
+        assert!(c.damp_diffusion_fraction * 26.0 < 1.0);
+    }
+
+    /// `with_anti_pd1()` sets `anti_pd1_efficacy = 0.8` and leaves the
+    /// rest unchanged. Matches sim-tme's `ImmuneConfig::with_anti_pd1`.
+    #[test]
+    fn spatial_immune_with_anti_pd1_changes_only_efficacy() {
+        let base = SpatialImmuneConfig::for_2d();
+        let blocked = base.with_anti_pd1();
+        assert_eq!(blocked.anti_pd1_efficacy, 0.8);
+        // Everything else must match.
+        assert_eq!(blocked.damp_per_lp, base.damp_per_lp);
+        assert_eq!(blocked.damp_diffusion_fraction, base.damp_diffusion_fraction);
+        assert_eq!(blocked.damp_clearance_rate, base.damp_clearance_rate);
+        assert_eq!(blocked.dc_activation_kd, base.dc_activation_kd);
+        assert_eq!(blocked.immune_kill_rate, base.immune_kill_rate);
+        assert_eq!(blocked.pd1_brake, base.pd1_brake);
+    }
+
+    /// `effective_brake` = `pd1_brake * (1 - anti_pd1_efficacy)`. With
+    /// no anti-PD-1: full 0.7 brake. With anti-PD-1 (0.8 efficacy):
+    /// 0.7 × 0.2 = 0.14.
+    #[test]
+    fn spatial_immune_effective_brake_math() {
+        let base = SpatialImmuneConfig::for_2d();
+        assert!((base.effective_brake() - 0.7).abs() < 1e-12);
+        let blocked = base.with_anti_pd1();
+        assert!((blocked.effective_brake() - 0.14).abs() < 1e-12);
+    }
+
+    /// `StromalConfig::default()` reproduces the literal values that
+    /// sim-tme + sim-tme-3d used before the lift.
+    #[test]
+    fn stromal_default_matches_legacy() {
+        let c = StromalConfig::default();
+        assert_eq!(c.gsh_boost_per_step, 0.06);
+        assert_eq!(c.gsh_boost_cap, 18.0);
+        assert_eq!(c.mufa_boost_per_step, 0.003);
+        assert_eq!(c.mufa_boost_cap, 0.25);
+    }
+
+    /// `PhConfig::default()` reproduces the literal values that
+    /// sim-tme + sim-tme-3d used before the lift.
+    #[test]
+    fn ph_default_matches_legacy() {
+        let c = PhConfig::default();
+        assert_eq!(c.ph_edge, 7.4);
+        assert_eq!(c.ph_core, 6.5);
+        assert_eq!(c.lambda_ph_um, 120.0);
+        assert_eq!(c.iron_ph_sensitivity, 1.5);
+        assert_eq!(c.ion_trap_sensitivity, 0.4);
     }
 }

--- a/simulations/sim-tme-3d/src/main.rs
+++ b/simulations/sim-tme-3d/src/main.rs
@@ -384,7 +384,11 @@ fn run_one_condition_with_config(condition: &Condition, run_cfg: RunConfig) -> C
                     CellState::from_cell_with_ros(&gc.cell, condition.treatment, &params, exo_ros_peak);
                 gc.extra_iron = 0.0;
                 gc.newly_dead = false;
-                gc.lp_at_death = 0.0;
+                // Init to NaN so any code path that reads `lp_at_death`
+                // before writing it (grace-end write or end-of-sim
+                // catch-all) produces NaN downstream — calibration trips
+                // instead of silently using a stale value (#225 review).
+                gc.lp_at_death = f64::NAN;
             }
         }
     }
@@ -802,6 +806,19 @@ fn generate_conditions() -> Vec<Condition> {
 // ============================================================
 
 fn main() {
+    // Guard against silent drift between this binary's metadata const and
+    // the library's runtime value: if a future PR tunes
+    // `SpatialImmuneConfig::for_3d().damp_diffusion_fraction` without also
+    // touching `DAMP_DIFFUSION_FRACTION_3D`, `summary.json` would report a
+    // stale value while the simulation actually used the new one. This
+    // debug_assert catches that in tests/dev runs without affecting release
+    // bit-identical output.
+    debug_assert_eq!(
+        DAMP_DIFFUSION_FRACTION_3D,
+        SpatialImmuneConfig::for_3d().damp_diffusion_fraction,
+        "DAMP_DIFFUSION_FRACTION_3D metadata const out of sync with SpatialImmuneConfig::for_3d()",
+    );
+
     // Use the library's TUMOR_RADIUS_FRACTION constant instead of the bare
     // 0.45 literal — keeps `tumor_radius_um` in lockstep with whatever
     // value `TumorGrid3D::generate` actually uses (reviewer-flagged drift

--- a/simulations/sim-tme-3d/src/main.rs
+++ b/simulations/sim-tme-3d/src/main.rs
@@ -52,10 +52,12 @@ use ferroptosis_core::biochem::{sim_cell_step, CellState};
 use ferroptosis_core::cell::Treatment;
 use ferroptosis_core::grid::{TumorGrid3D, TUMOR_RADIUS_FRACTION};
 use ferroptosis_core::immune_3d::{
-    dc_activation, diffuse_damp_3d_step, immune_kill_probability,
+    dc_activation, diffuse_damp_3d_step, immune_kill_probability, DAMP_KILL_THRESHOLD,
 };
 use ferroptosis_core::oxygen::radial_o2_field;
-use ferroptosis_core::params::{Params, SpatialParams};
+use ferroptosis_core::params::{
+    Params, PhConfig, SpatialImmuneConfig, SpatialParams, StromalConfig,
+};
 use ferroptosis_core::ph::{ion_trap_factor_from_ph, iron_multiplier_from_ph, radial_ph_field};
 use ferroptosis_core::physics::local_ros_multiplier_3d;
 use ferroptosis_core::stromal::stromal_adjacency_mask;
@@ -83,10 +85,12 @@ const O2_LAMBDAS: &[f64] = &[80.0, 100.0, 120.0];
 /// Zone-analysis reference λ — matches sim-tme.
 const ZONE_REF_LAMBDA: f64 = 120.0;
 
-/// DAMP diffusion fraction. **3D-safe value**: sim-tme's 2D default
-/// (0.08) is unsafe in 3D — `immune_3d::diffuse_damp_3d_step`'s
-/// stability `assert!` would panic. Use 0.025 to match 2D's per-step
-/// total diffusion (~64%).
+/// DAMP diffusion fraction for 3D, retained as a const for legacy code
+/// paths that emit the value into output metadata (see `RunMetadata` /
+/// `summary.json`). Identical to `SpatialImmuneConfig::for_3d()
+/// .damp_diffusion_fraction`. **Not** the source of truth for the
+/// runtime value — that's the library const propagated through
+/// `SpatialImmuneConfig`.
 const DAMP_DIFFUSION_FRACTION_3D: f64 = 0.025;
 
 /// Step at which immune activity begins (matches sim-tme).
@@ -98,97 +102,9 @@ const IMMUNE_START_STEP: u32 = 60;
 /// in 3D (10% × 26 = 260% per source-cell loss, vs 2D's 80%).
 const IRON_DIFFUSE_FRACTION_3D: f64 = 0.1 * 8.0 / 26.0;
 
-/// Minimum local DAMP concentration to consider for immune-kill rolls.
-/// Cells below this short-circuit the activation+kill path (matches
-/// sim-tme/src/main.rs:735's `if local_damp < 0.01 { continue; }`).
-/// Acts as a numerical floor; without it, `dc_activation` for damp ≈ 0
-/// would still produce vanishing-small kill probabilities and waste
-/// per-cell-per-step RNG initialization.
-const DAMP_KILL_THRESHOLD: f64 = 0.01;
-
-// ============================================================
-// Config structs (duplicated from sim-tme for v1 — lift to
-// ferroptosis-core::params is a follow-up cleanup PR per the
-// consolidated checklist on issue #195).
-// ============================================================
-
-/// Parameters for the spatial immune model. Mirror of
-/// `sim-tme::ImmuneConfig` — the duplication is documented technical
-/// debt; see issue #195 follow-up tracking.
-#[derive(Clone, Copy, Debug)]
-struct ImmuneConfig {
-    damp_per_lp: f64,
-    /// 3D-safe diffusion fraction (NOT sim-tme's 2D 0.08 — that
-    /// triggers the immune_3d stability `assert!`).
-    damp_diffusion_fraction: f64,
-    damp_clearance_rate: f64,
-    dc_activation_kd: f64,
-    immune_kill_rate: f64,
-    pd1_brake: f64,
-    anti_pd1_efficacy: f64,
-}
-
-impl ImmuneConfig {
-    fn default_no_pd1() -> Self {
-        ImmuneConfig {
-            damp_per_lp: 1.0,
-            damp_diffusion_fraction: DAMP_DIFFUSION_FRACTION_3D,
-            damp_clearance_rate: 0.03,
-            dc_activation_kd: 50.0,
-            immune_kill_rate: 0.02,
-            pd1_brake: 0.7,
-            anti_pd1_efficacy: 0.0,
-        }
-    }
-
-    fn effective_brake(&self) -> f64 {
-        self.pd1_brake * (1.0 - self.anti_pd1_efficacy)
-    }
-}
-
-/// CAF-mediated stromal protection params. Mirror of
-/// `sim-tme::StromalConfig`.
-#[derive(Clone, Copy, Debug)]
-struct StromalConfig {
-    gsh_boost_per_step: f64,
-    gsh_boost_cap: f64,
-    mufa_boost_per_step: f64,
-    mufa_boost_cap: f64,
-}
-
-impl StromalConfig {
-    fn default() -> Self {
-        StromalConfig {
-            gsh_boost_per_step: 0.06,
-            gsh_boost_cap: 18.0,
-            mufa_boost_per_step: 0.003,
-            mufa_boost_cap: 0.25,
-        }
-    }
-}
-
-/// pH gradient + iron / ion-trap sensitivity params. Mirror of
-/// `sim-tme::PhConfig`.
-#[derive(Clone, Copy, Debug)]
-struct PhConfig {
-    ph_edge: f64,
-    ph_core: f64,
-    lambda_ph_um: f64,
-    iron_ph_sensitivity: f64,
-    ion_trap_sensitivity: f64,
-}
-
-impl PhConfig {
-    fn default() -> Self {
-        PhConfig {
-            ph_edge: 7.4,
-            ph_core: 6.5,
-            lambda_ph_um: 120.0,
-            iron_ph_sensitivity: 1.5,
-            ion_trap_sensitivity: 0.4,
-        }
-    }
-}
+// `DAMP_KILL_THRESHOLD`, `SpatialImmuneConfig`, `StromalConfig`,
+// `PhConfig` are imported from `ferroptosis-core` (#220). Previously
+// these were binary-local copies duplicated with sim-tme.
 
 // ============================================================
 // Output records
@@ -489,7 +405,7 @@ fn run_one_condition_with_config(condition: &Condition, run_cfg: RunConfig) -> C
     }
 
     // --- Main 180-step loop ---
-    let immune_cfg = ImmuneConfig::default_no_pd1();
+    let immune_cfg = SpatialImmuneConfig::for_3d();
     let mut damp_field = vec![0.0_f64; n_cells];
     let mut damp_scratch = vec![0.0_f64; n_cells];
     let mut ferroptosis_kills = 0usize;
@@ -554,8 +470,11 @@ fn run_one_condition_with_config(condition: &Condition, run_cfg: RunConfig) -> C
                         // 26-Moore neighbors (grid.rs:586). Not vestigial —
                         // load-bearing for iron-driven Fenton bystander effects.
                         gc.newly_dead = true;
-                        gc.lp_at_death = gc.state.lp;
                         ferroptosis_kills += 1;
+                        // `lp_at_death` is set later, at grace-end, just before
+                        // being read for the DAMP-field write. The moment-of-death
+                        // write that used to live here was dead (always overwritten
+                        // before read); removed in #220.
                     }
 
                     // Stromal CAF protection for alive cells — apply only when

--- a/simulations/sim-tme/src/main.rs
+++ b/simulations/sim-tme/src/main.rs
@@ -175,7 +175,11 @@ fn run_spatial(
             gc.state = CellState::from_cell_with_ros(&gc.cell, tx, params, exo_ros_peak);
             gc.extra_iron = 0.0;
             gc.newly_dead = false;
-            gc.lp_at_death = 0.0;
+            // Init to NaN so any code path that reads `lp_at_death` before
+            // writing it (the grace-end write or the end-of-sim catch-all)
+            // produces NaN downstream — calibration will trip instead of
+            // silently using a stale value (#225 review).
+            gc.lp_at_death = f64::NAN;
         }
     }
 
@@ -280,7 +284,11 @@ fn run_spatial_cycling(
             gc.state = CellState::from_cell_with_ros(&gc.cell, tx, params, exo_ros_peak);
             gc.extra_iron = 0.0;
             gc.newly_dead = false;
-            gc.lp_at_death = 0.0;
+            // Init to NaN so any code path that reads `lp_at_death` before
+            // writing it (the grace-end write or the end-of-sim catch-all)
+            // produces NaN downstream — calibration will trip instead of
+            // silently using a stale value (#225 review).
+            gc.lp_at_death = f64::NAN;
         }
     }
 
@@ -351,7 +359,8 @@ fn run_spatial_cycling(
 //
 // `SpatialImmuneConfig` lifted to `ferroptosis-core::params` (#220).
 // Use `SpatialImmuneConfig::for_2d()` for 2D defaults
-// (damp_diffusion_fraction = 0.08, ×4 Moore stability).
+// (damp_diffusion_fraction = 0.08, < 1/8 stability bound for the
+// 8-Moore neighborhood returned by `TumorGrid::neighbors`).
 
 // ============================================================
 // Stromal protection (Feature C)
@@ -488,7 +497,11 @@ fn run_spatial_with_immune(
             gc.state = CellState::from_cell_with_ros(&gc.cell, tx, params, exo_ros_peak);
             gc.extra_iron = 0.0;
             gc.newly_dead = false;
-            gc.lp_at_death = 0.0;
+            // Init to NaN so any code path that reads `lp_at_death` before
+            // writing it (the grace-end write or the end-of-sim catch-all)
+            // produces NaN downstream — calibration will trip instead of
+            // silently using a stale value (#225 review).
+            gc.lp_at_death = f64::NAN;
         }
     }
 

--- a/simulations/sim-tme/src/main.rs
+++ b/simulations/sim-tme/src/main.rs
@@ -39,8 +39,9 @@ use serde::Serialize;
 use ferroptosis_core::biochem::{sim_cell_step, CellState};
 use ferroptosis_core::cell::{norm, Treatment};
 use ferroptosis_core::grid::{depth_kill_curve, death_heatmap, TumorGrid};
+use ferroptosis_core::immune_3d::{immune_kill_probability, DAMP_KILL_THRESHOLD};
 use ferroptosis_core::io::{write_depth_curves_csv, write_heatmap_csv, write_json};
-use ferroptosis_core::params::{Params, SpatialParams};
+use ferroptosis_core::params::{Params, PhConfig, SpatialImmuneConfig, SpatialParams, StromalConfig};
 use ferroptosis_core::physics::local_ros_multiplier;
 
 const GRID_SIZE: usize = 500;
@@ -347,86 +348,18 @@ fn run_spatial_cycling(
 // ============================================================
 // Spatial immune coupling (Feature B)
 // ============================================================
-
-/// Parameters for the spatial immune model.
-struct ImmuneConfig {
-    /// DAMP release per unit LP at death (from ImmuneParams default).
-    damp_per_lp: f64,
-    /// Fraction of DAMP shared with each Moore neighbor per step.
-    damp_diffusion_fraction: f64,
-    /// Exponential decay rate per step (models immune clearance of DAMPs).
-    damp_clearance_rate: f64,
-    /// Michaelis-Menten Kd for DC activation by DAMP concentration.
-    dc_activation_kd: f64,
-    /// Per-step immune kill rate (absorbs DC maturation + T cell priming + kill).
-    immune_kill_rate: f64,
-    /// PD-1 suppression fraction (0.0 = no brake, 1.0 = full suppression).
-    pd1_brake: f64,
-    /// Anti-PD-1 efficacy (fraction of brake removed).
-    anti_pd1_efficacy: f64,
-    // LP overshoot is now emergent from ferroptosis-core post-death dynamics
-    // (post_death_steps in Params). Option C multiplier removed (issue #85).
-}
-
-impl ImmuneConfig {
-    fn default_no_pd1() -> Self {
-        ImmuneConfig {
-            damp_per_lp: 1.0,
-            damp_diffusion_fraction: 0.08,
-            damp_clearance_rate: 0.03,
-            dc_activation_kd: 50.0,
-            immune_kill_rate: 0.02,
-            pd1_brake: 0.7,
-            anti_pd1_efficacy: 0.0,
-        }
-    }
-
-    fn with_anti_pd1(&self) -> Self {
-        ImmuneConfig {
-            anti_pd1_efficacy: 0.8,
-            ..*self
-        }
-    }
-
-    fn effective_brake(&self) -> f64 {
-        self.pd1_brake * (1.0 - self.anti_pd1_efficacy)
-    }
-}
+//
+// `SpatialImmuneConfig` lifted to `ferroptosis-core::params` (#220).
+// Use `SpatialImmuneConfig::for_2d()` for 2D defaults
+// (damp_diffusion_fraction = 0.08, ×4 Moore stability).
 
 // ============================================================
 // Stromal protection (Feature C)
 // ============================================================
-
-/// Parameters for CAF-mediated protection of stromal-adjacent tumor cells.
-/// Biology: cancer-associated fibroblasts (CAFs) supply cysteine and oleic
-/// acid to adjacent tumor cells, boosting GSH antioxidant capacity and MUFA
-/// membrane protection. All parameters are ESTIMATED — no textbook coverage
-/// exists for CAF biology. Refs: PMID 34373744 (CAF metabolic reprogramming),
-/// PMID 31813804 (ACSL3-mediated oleic acid), PMID 30842648 (MUFA ferroptosis).
-struct StromalConfig {
-    /// Per-step GSH boost for stromal-adjacent tumor cells.
-    /// GGT1-mediated cysteine supply: CAFs cleave extracellular GSH, tumor
-    /// cells reimport cysteine via SLC7A11. ~2.5× endogenous NRF2 rate (0.025).
-    gsh_boost_per_step: f64,
-    /// Maximum GSH from CAF supply (1.5× normal gsh_max of 12.0).
-    gsh_boost_cap: f64,
-    /// Per-step MUFA boost from ACSL3-mediated oleic acid uptake.
-    /// ~30% of in-vivo SCD1 rate; CAF supply is supplementary.
-    mufa_boost_per_step: f64,
-    /// Maximum MUFA from CAF supply (50% of in-vivo SCD1 max).
-    mufa_boost_cap: f64,
-}
-
-impl StromalConfig {
-    fn default() -> Self {
-        StromalConfig {
-            gsh_boost_per_step: 0.06,
-            gsh_boost_cap: 18.0,
-            mufa_boost_per_step: 0.003,
-            mufa_boost_cap: 0.25,
-        }
-    }
-}
+//
+// `StromalConfig` lifted to `ferroptosis-core::params` (#220).
+// Geometry-independent (per-cell shielding is 50.0% in 2D, 51.5% in 3D
+// per PR #221's Q3 finding).
 
 /// Compute a boolean mask: true for tumor cells with at least one stromal
 /// (is_tumor=false) Moore neighbor. These cells receive CAF-mediated protection.
@@ -469,49 +402,9 @@ fn stromal_adjacent_kill_rate(grid: &TumorGrid, mask: &[bool]) -> f64 {
 // ============================================================
 // pH gradient and ion trapping (Feature D)
 // ============================================================
-
-/// Parameters for tumor acidic pH gradient.
-/// Biology: glycolytic tumors produce lactic acid (Warburg effect), lowering
-/// extracellular pH to 6.5-6.8 in the core. Two competing effects on ferroptosis:
-/// 1. Iron release: low pH destabilizes ferritin → more Fenton ROS (pro-ferroptosis)
-/// 2. Drug ion trapping: weak-base drugs protonated at low pH → less intracellular
-///    drug (anti-ferroptosis). Governed by Henderson-Hasselbalch (Chemistry2e Sec.14.2).
-///
-/// All parameters ESTIMATED. Tumor pH ranges from primary literature (Stubbs 2000,
-/// Gatenby & Gillies 2004). Ferritin iron release from Harrison & Arosio 1996.
-/// Warburg effect not covered in any reference textbook (Biology2e describes lactic
-/// acid fermentation only in anaerobic contexts). RSL3 pKa is not well-characterized
-/// (chloroacetamide, not a classic weak base) — ion_trap_sensitivity is the most
-/// uncertain parameter in this model.
-struct PhConfig {
-    /// pH at tumor edge (well-perfused, normal arterial blood).
-    ph_edge: f64,
-    /// pH at deep tumor core (Warburg effect lactic acid accumulation).
-    ph_core: f64,
-    /// pH penetration length (μm). Matches O2 reference λ; both are perfusion-limited.
-    lambda_ph_um: f64,
-    /// Iron-pH sensitivity: ferritin releases stored Fe²⁺ at low pH.
-    /// iron_multiplier = 1.0 + sensitivity * (ph_edge - local_ph).
-    /// At pH 6.5: 1.0 + 1.5 * 0.9 = 2.35× iron.
-    iron_ph_sensitivity: f64,
-    /// Ion trapping sensitivity for weak-base drugs (RSL3 only).
-    /// drug_factor = 1.0 - sensitivity * (ph_edge - local_ph), clamped [0.3, 1.0].
-    /// At pH 6.5: 1.0 - 0.4 * 0.9 = 0.64 (36% drug lost).
-    /// Linearized Henderson-Hasselbalch; valid over narrow pH 6.5-7.4 range.
-    ion_trap_sensitivity: f64,
-}
-
-impl PhConfig {
-    fn default() -> Self {
-        PhConfig {
-            ph_edge: 7.4,
-            ph_core: 6.5,
-            lambda_ph_um: 120.0,
-            iron_ph_sensitivity: 1.5,
-            ion_trap_sensitivity: 0.4,
-        }
-    }
-}
+//
+// `PhConfig` lifted to `ferroptosis-core::params` (#220).
+// Geometry-independent (same chemistry in 2D and 3D, see PR #221 Q4).
 
 /// Compute steady-state pH field and apply iron modulation.
 /// pH decreases inward: pH(d) = ph_edge - delta * (1 - exp(-d/λ)).
@@ -564,7 +457,7 @@ fn run_spatial_with_immune(
     tx: Treatment,
     params: &Params,
     spatial_params: &SpatialParams,
-    immune: &ImmuneConfig,
+    immune: &SpatialImmuneConfig,
     stromal: Option<(&[bool], &StromalConfig)>,
     ph: Option<(&[(usize, usize, f64)], &PhConfig)>,
     seed: u64,
@@ -669,10 +562,14 @@ fn run_spatial_with_immune(
 
                 if died {
                     gc.newly_dead = true;
-                    gc.lp_at_death = gc.state.lp;
                     ferroptosis_kills += 1;
                     // DAMP release is deferred until the post-death grace
-                    // period ends (emergent LP overshoot, issue #85).
+                    // period ends (emergent LP overshoot, issue #85). At
+                    // that point `lp_at_death` is set to the grace-end LP
+                    // value just before being read for DAMP — see the
+                    // grace-end block above. The moment-of-death write
+                    // that used to live here was dead (always overwritten
+                    // before read); removed in #220.
                     // Iron diffusion still happens immediately via newly_dead.
                 }
 
@@ -732,13 +629,20 @@ fn run_spatial_with_immune(
                     }
 
                     let local_damp = damp_field[idx];
-                    if local_damp < 0.01 {
+                    if local_damp < DAMP_KILL_THRESHOLD {
                         continue;
                     }
 
+                    // NaN-preserving cap (lifted via #220). Previously inline as
+                    // `.min(0.99)`, which silently converted NaN inputs to 0.99
+                    // — a near-certain kill probability. `immune_kill_probability`
+                    // uses an explicit `if raw > 0.99` branch that preserves NaN.
                     let activation = local_damp / (local_damp + immune.dc_activation_kd);
-                    let kill_prob = (activation * immune.immune_kill_rate * (1.0 - effective_brake))
-                        .min(0.99);
+                    let kill_prob = immune_kill_probability(
+                        activation,
+                        immune.immune_kill_rate,
+                        effective_brake,
+                    );
 
                     let mut rng = StdRng::seed_from_u64(
                         seed.wrapping_add(900_000_000)
@@ -1104,9 +1008,9 @@ fn main() {
     let stromal_adj_count = stromal_mask.iter().filter(|&&b| b).count();
 
     // --- Immune coupling (Feature B) at λ=120μm ---
-    let immune_modes: Vec<(&str, ImmuneConfig)> = vec![
-        ("immune_on", ImmuneConfig::default_no_pd1()),
-        ("immune_anti_pd1", ImmuneConfig::default_no_pd1().with_anti_pd1()),
+    let immune_modes: Vec<(&str, SpatialImmuneConfig)> = vec![
+        ("immune_on", SpatialImmuneConfig::for_2d()),
+        ("immune_anti_pd1", SpatialImmuneConfig::for_2d().with_anti_pd1()),
     ];
 
     eprintln!("\n=== Spatial Immune Coupling (O2 gradient λ=120μm) ===");
@@ -1200,9 +1104,9 @@ fn main() {
         stromal_cfg.mufa_boost_per_step, stromal_cfg.mufa_boost_cap);
     eprintln!("All parameters ESTIMATED (no textbook coverage). Refs: PMID 34373744, 31813804.\n");
 
-    let stromal_immune_modes: Vec<(&str, ImmuneConfig)> = vec![
-        ("immune_on", ImmuneConfig::default_no_pd1()),
-        ("immune_anti_pd1", ImmuneConfig::default_no_pd1().with_anti_pd1()),
+    let stromal_immune_modes: Vec<(&str, SpatialImmuneConfig)> = vec![
+        ("immune_on", SpatialImmuneConfig::for_2d()),
+        ("immune_anti_pd1", SpatialImmuneConfig::for_2d().with_anti_pd1()),
     ];
 
     for (immune_label, immune_cfg) in &stromal_immune_modes {
@@ -1287,7 +1191,7 @@ fn main() {
 
     // --- pH gradient (Feature D) at λ=120μm with immune_on ---
     let ph_cfg = PhConfig::default();
-    let immune_for_ph = ImmuneConfig::default_no_pd1();
+    let immune_for_ph = SpatialImmuneConfig::for_2d();
 
     eprintln!("\n=== pH Gradient / Ion Trapping (O2 gradient λ=120μm, immune_on) ===");
     eprintln!("pH range: {:.1} (edge) → {:.1} (core), λ_pH={:.0}μm",


### PR DESCRIPTION
## Summary

Closes the lift-and-cleanup items from #220 that don't need their own design pass:
- 3 config structs (`SpatialImmuneConfig`, `StromalConfig`, `PhConfig`) lifted to `ferroptosis-core::params`
- `DAMP_KILL_THRESHOLD = 0.01` promoted to a library `pub const`
- sim-tme NaN bug fixed via `immune_kill_probability` call (replaces inline `.min(0.99)`)
- Dead `lp_at_death = gc.state.lp` writes inside `if died` removed in both binaries
- 6 new param regression-guard tests added

Three items deferred to follow-up #224 (each needs its own design + PR).

## Acceptance criteria (#220)

| Item | Status |
|---|---|
| Configs moved to `ferroptosis-core::params` | ✅ `SpatialImmuneConfig` (with `for_2d`/`for_3d`/`with_anti_pd1`/`effective_brake`), `StromalConfig` (Default), `PhConfig` (Default) |
| sim-tme + sim-tme-3d import lifted structs | ✅ Both binaries delete local copies, import from library |
| sim-spatial output bit-identical | ✅ All 6 sim-spatial output SHA-256 hashes match baseline |
| Cross-geometry test math switched from inline to library | ⏭ Deferred to #224 — requires lifting 2D helpers (stromal_adjacency_mask 2D, depth-from-edge, pH) that don't exist in library yet |
| Dead `lp_at_death` write removed (both binaries) | ✅ sim-tme:565 + sim-tme-3d:473 — confirmed dead (overwritten before read at the grace-end DAMP write) |
| `schema_version` field + comparison-script asserts | ⏭ Deferred to #224 — independent change with its own design |

Plus the parity items the issue called out:
- ✅ `f64::min` NaN bug in sim-tme's inline kill-prob → replaced with library `immune_kill_probability` call
- ✅ `0.01` magic threshold → promoted to library `DAMP_KILL_THRESHOLD` const
- ⏭ sim-tme DAMP-gating bug: turned out **not applicable** — sim-tme has separate `run_spatial` (no DAMP) vs `run_spatial_with_immune` (with DAMP), so DAMP writes are inherently gated by which function gets called for the condition. No bug to fix.

## Verification

**Output bit-identical (the load-bearing check per #220):**

```
$ cargo run --release -p sim-spatial
$ shasum -a 256 output/spatial/*
ace766b... spatial_summary.json       ← identical to pre-refactor
e45241d... depth_kill_curves.csv     ← identical
1365e8f... spatial_death_control.csv ← identical
3c61509... spatial_death_pdt.csv     ← identical
bf20059... spatial_death_rsl3.csv    ← identical
beb5de3... spatial_death_sdt.csv     ← identical

$ cargo run --release -p sim-tme-3d
$ shasum -a 256 output/tme-3d/summary.json
a6ad210b... ← identical to pre-refactor
```

**Calibration unchanged:**

```
$ python3 simulations/calibration/calibrate.py --evaluate
[PASS] 3d_rsl3_o2_collapse_ratio: observed=0.0160, target=0.5
[PASS] 3d_immune_sdt_dominates: observed=4.0345, target=3.0
[PASS] 3d_stromal_boundary_shielding: observed=0.4848, target=0.7
```

**Tests:**

```
$ cargo test --workspace --release
ferroptosis-core: 166 passed (was 160; +6 new param regression-guard tests)
sim-tme-3d: 8 passed
sim-spatial: 1 passed
```

The 6 new param tests assert each lifted constructor produces the exact pre-lift literal values, including:
- `for_3d().damp_diffusion_fraction * 26.0 < 1.0` (matches the `immune_3d::diffuse_damp_3d_step` stability `assert!`)
- `with_anti_pd1()` sets only `anti_pd1_efficacy` to 0.8 — leaves all other fields unchanged
- `effective_brake()` math: 0.7 base, 0.14 with anti-PD-1

## Naming-collision resolution

`ferroptosis-core::params::ImmuneParams` already exists, used by sim-icd + sim-combo. It models the **full DC→T-cell cascade** (`dc_maturation_rate`, `tcell_priming_rate`, `tcell_kill_rate`). sim-tme's `ImmuneConfig` models the **single absorbed `immune_kill_rate`** + spatial diffusion fields. Different math, same biology — both valid abstractions.

Resolved by **renaming the lifted struct to `SpatialImmuneConfig`** so both live in `params.rs` without collision. Documented in the new struct's doc comment.

## Library version bump

`ferroptosis-core` 0.11.0 → 0.12.0 (new public API: 3 structs + 1 const, all additive — no breaking changes).

## Net code change

```
ferroptosis-core: +232 lines  (3 structs + 6 tests + 1 const)
sim-tme:         -123 lines  (delete 3 local struct defs)
sim-tme-3d:      -71  lines  (delete 3 local struct defs)
```

Binary-side delta: **-194 lines of duplicated config code.**

## Test plan

- [x] sim-spatial output bit-identical (SHA-256)
- [x] sim-tme-3d output bit-identical (SHA-256)
- [x] All 3 3D calibration targets PASS
- [x] cargo test --workspace clean (166 ferroptosis-core + 8 sim-tme-3d + 1 sim-spatial + 0 others)
- [x] cargo build --release --workspace --exclude ferroptosis-python (excluded because PyO3 needs maturin)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)