### PR TITLE
calibrate.py 3D extractor polish: tests, isclose, duplicate-row warn

### DIFF
--- a/simulations/calibration/calibrate.py
+++ b/simulations/calibration/calibrate.py
@@ -12,7 +12,9 @@ Usage:
 import argparse
 import csv
 import json
+import math
 import sys
+import warnings
 from pathlib import Path
 
 import yaml
@@ -200,14 +202,23 @@ def _find_3d_condition(
     "immune_anti_pd1"), optional stromal_mode ("stromal_on"/None), optional
     ph_mode ("ph_on"/None). Returns None if no match.
     """
-    for c in conditions:
+    matches = []
+    for idx, c in enumerate(conditions):
         if c.get("treatment") != treatment:
             continue
         if o2_lambda_um is None:
             if c.get("o2_condition") != "uniform":
                 continue
         else:
-            if c.get("o2_lambda_um") != o2_lambda_um:
+            # Use math.isclose for the λ comparison so that future schemas
+            # emitting non-exact float sweeps (e.g., 119.5, 120.0, 120.5)
+            # don't silently miss matches due to float precision. Today's
+            # schema emits exact 120.0, so this is identical in practice
+            # but future-proofs the filter (issue #222 item 2).
+            row_lambda = c.get("o2_lambda_um")
+            if row_lambda is None:
+                continue
+            if not math.isclose(row_lambda, o2_lambda_um, abs_tol=1e-6):
                 continue
         if c.get("immune_mode") != immune_mode:
             continue
@@ -215,8 +226,24 @@ def _find_3d_condition(
             continue
         if c.get("ph_mode") != ph_mode:
             continue
-        return c
-    return None
+        matches.append((idx, c))
+
+    if not matches:
+        return None
+    if len(matches) > 1:
+        # Issue #222 item 3: today's 24-condition matrix has unique combos
+        # so this never fires, but a future inner re-sweep introducing
+        # duplicate rows would silently pick the first match. Surface it.
+        indices = [idx for idx, _ in matches]
+        warnings.warn(
+            f"_find_3d_condition matched {len(matches)} rows "
+            f"(indices {indices}) for treatment={treatment!r}, "
+            f"o2_lambda_um={o2_lambda_um}, immune_mode={immune_mode!r}, "
+            f"stromal_mode={stromal_mode!r}, ph_mode={ph_mode!r}; "
+            f"returning first match.",
+            stacklevel=2,
+        )
+    return matches[0][1]
 
 
 def extract_tme_3d_json(target: dict) -> float | None:

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -1,0 +1,254 @@
+"""
+Unit tests for `simulations/calibration/calibrate.py`'s 3D extractor.
+
+Locks the row-filter invariants of `_find_3d_condition` and the
+named-metric dispatch of `extract_tme_3d_json`. Fixtures build minimal
+`summary.json`-shaped dicts in-memory (no on-disk dependency) so the
+tests pin the contract: if sim-tme-3d's `ConditionResult` schema drifts
+and the extractor silently returns `None`, these tests fail loudly
+instead.
+
+Covers issue #222 item 1.
+
+Run: pytest tests/test_calibrate.py -v
+"""
+
+import json
+import sys
+import warnings
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CALIBRATION_DIR = REPO_ROOT / "simulations" / "calibration"
+sys.path.insert(0, str(CALIBRATION_DIR))
+
+import calibrate  # noqa: E402
+
+
+# ============================================================
+# Fixture: minimal summary.json-shaped dict
+# ============================================================
+
+def _condition(
+    *,
+    treatment,
+    o2_condition="uniform",
+    o2_lambda_um=None,
+    immune_mode="off",
+    stromal_mode=None,
+    ph_mode=None,
+    normoxic_kill_rate=0.0,
+    hypoxic_kill_rate=0.0,
+    immune_kills=None,
+    stromal_adjacent_kill_rate=None,
+):
+    """Build one `ConditionResult`-shaped dict.
+
+    Mirrors the fields of `simulations/sim-tme-3d/src/main.rs`'s
+    `ConditionResult` struct that the extractor actually reads. Other
+    fields (total_tumor, peak_damp, etc.) are omitted because the
+    extractor doesn't consult them — this keeps the fixture minimal and
+    makes the test failures point to schema fields that actually matter.
+    """
+    return {
+        "treatment": treatment,
+        "o2_condition": o2_condition,
+        "o2_lambda_um": o2_lambda_um,
+        "immune_mode": immune_mode,
+        "stromal_mode": stromal_mode,
+        "ph_mode": ph_mode,
+        "normoxic_kill_rate": normoxic_kill_rate,
+        "hypoxic_kill_rate": hypoxic_kill_rate,
+        "immune_kills": immune_kills,
+        "stromal_adjacent_kill_rate": stromal_adjacent_kill_rate,
+    }
+
+
+@pytest.fixture
+def summary_dict():
+    """A summary.json-shaped dict with rows for all three Q1/Q2/Q3 metrics."""
+    return {
+        "conditions": [
+            # Row 0: RSL3, λ=120, immune_off — for rsl3_o2_collapse_ratio
+            _condition(
+                treatment="RSL3",
+                o2_condition="gradient",
+                o2_lambda_um=120.0,
+                immune_mode="off",
+                normoxic_kill_rate=0.80,
+                hypoxic_kill_rate=0.20,
+            ),
+            # Row 1: SDT, λ=120, immune_on — numerator of immune_sdt_rsl3_ratio
+            _condition(
+                treatment="SDT",
+                o2_condition="gradient",
+                o2_lambda_um=120.0,
+                immune_mode="immune_on",
+                immune_kills=400,
+            ),
+            # Row 2: RSL3, λ=120, immune_on, no stromal — denominator of immune ratio
+            # AND no-stromal baseline for stromal_shielding_ratio
+            _condition(
+                treatment="RSL3",
+                o2_condition="gradient",
+                o2_lambda_um=120.0,
+                immune_mode="immune_on",
+                immune_kills=100,
+                stromal_adjacent_kill_rate=0.50,
+            ),
+            # Row 3: RSL3, λ=120, immune_on, stromal_on — numerator of stromal ratio
+            _condition(
+                treatment="RSL3",
+                o2_condition="gradient",
+                o2_lambda_um=120.0,
+                immune_mode="immune_on",
+                stromal_mode="stromal_on",
+                stromal_adjacent_kill_rate=0.10,
+            ),
+        ],
+        "note": "test fixture",
+    }
+
+
+def _write_summary(tmp_path, summary):
+    """Write the fixture dict to disk and return a target dict pointing at it."""
+    out_dir = tmp_path / "tme-3d"
+    out_dir.mkdir()
+    summary_path = out_dir / "summary.json"
+    summary_path.write_text(json.dumps(summary))
+    return summary_path
+
+
+def _target(metric, summary_path):
+    """Build a target dict in the shape `extract_tme_3d_json` expects."""
+    return {
+        "binary": "sim-tme-3d",
+        "output_file": str(summary_path),
+        "extraction": {"metric": metric},
+    }
+
+
+@pytest.fixture(autouse=True)
+def _patch_resolve(monkeypatch):
+    """Make `_resolve_output_path` honor an absolute path in output_file."""
+    def fake_resolve(target):
+        return Path(target["output_file"])
+    monkeypatch.setattr(calibrate, "_resolve_output_path", fake_resolve)
+
+
+# ============================================================
+# Metric 1: rsl3_o2_collapse_ratio (single-row, two-field derivation)
+# Pins: stromal_mode=None / ph_mode=None filter, immune_off filter,
+# hypoxic/normoxic derivation.
+# ============================================================
+
+class TestRsl3O2CollapseRatio:
+    def test_returns_hypoxic_over_normoxic(self, tmp_path, summary_dict):
+        path = _write_summary(tmp_path, summary_dict)
+        result = calibrate.extract_tme_3d_json(_target("rsl3_o2_collapse_ratio", path))
+        assert result == pytest.approx(0.20 / 0.80)
+
+    def test_skips_immune_on_rows(self, tmp_path, summary_dict):
+        # Remove the immune_off RSL3 row — only immune_on RSL3 left.
+        # Extractor must return None (not silently pick the immune_on row).
+        summary_dict["conditions"] = [
+            c for c in summary_dict["conditions"]
+            if not (c["treatment"] == "RSL3" and c["immune_mode"] == "off")
+        ]
+        path = _write_summary(tmp_path, summary_dict)
+        result = calibrate.extract_tme_3d_json(_target("rsl3_o2_collapse_ratio", path))
+        assert result is None
+
+    def test_skips_stromal_on_rows(self, tmp_path, summary_dict):
+        # Add a stromal_on RSL3 immune_off row and remove the no-stromal one.
+        # `_find_3d_condition` defaults stromal_mode=None — must not match.
+        summary_dict["conditions"] = [
+            c for c in summary_dict["conditions"]
+            if not (c["treatment"] == "RSL3" and c["immune_mode"] == "off")
+        ]
+        summary_dict["conditions"].append(_condition(
+            treatment="RSL3",
+            o2_condition="gradient",
+            o2_lambda_um=120.0,
+            immune_mode="off",
+            stromal_mode="stromal_on",
+            normoxic_kill_rate=0.80,
+            hypoxic_kill_rate=0.20,
+        ))
+        path = _write_summary(tmp_path, summary_dict)
+        result = calibrate.extract_tme_3d_json(_target("rsl3_o2_collapse_ratio", path))
+        assert result is None
+
+
+# ============================================================
+# Metric 2: immune_sdt_rsl3_ratio (two-row, single-field per row)
+# Pins: matched-context filter (both rows at immune_on, λ=120,
+# stromal=None, ph=None), divide-by-zero guard, missing-row handling.
+# ============================================================
+
+class TestImmuneSdtRsl3Ratio:
+    def test_returns_sdt_over_rsl3_immune_kills(self, tmp_path, summary_dict):
+        path = _write_summary(tmp_path, summary_dict)
+        result = calibrate.extract_tme_3d_json(_target("immune_sdt_rsl3_ratio", path))
+        assert result == pytest.approx(400.0 / 100.0)
+
+    def test_skips_when_rsl3_immune_kills_zero(self, tmp_path, summary_dict):
+        # Zero RSL3 immune kills must not raise ZeroDivisionError.
+        for c in summary_dict["conditions"]:
+            if c["treatment"] == "RSL3" and c["immune_mode"] == "immune_on":
+                c["immune_kills"] = 0
+        path = _write_summary(tmp_path, summary_dict)
+        result = calibrate.extract_tme_3d_json(_target("immune_sdt_rsl3_ratio", path))
+        assert result is None
+
+
+# ============================================================
+# Metric 3: stromal_shielding_ratio (two-row, stromal_mode filter)
+# Pins: stromal_mode=None vs "stromal_on" partitioning — the row-filter
+# invariant most likely to silently break if the schema changes.
+# ============================================================
+
+class TestStromalShieldingRatio:
+    def test_returns_stromal_on_over_no_stromal(self, tmp_path, summary_dict):
+        path = _write_summary(tmp_path, summary_dict)
+        result = calibrate.extract_tme_3d_json(_target("stromal_shielding_ratio", path))
+        assert result == pytest.approx(0.10 / 0.50)
+
+    def test_skips_when_no_stromal_baseline_missing(self, tmp_path, summary_dict):
+        # Drop the no-stromal RSL3 immune_on row. Without a denominator
+        # the metric must SKIP, not silently fall back to stromal_on.
+        summary_dict["conditions"] = [
+            c for c in summary_dict["conditions"]
+            if not (
+                c["treatment"] == "RSL3"
+                and c["immune_mode"] == "immune_on"
+                and c["stromal_mode"] is None
+            )
+        ]
+        path = _write_summary(tmp_path, summary_dict)
+        result = calibrate.extract_tme_3d_json(_target("stromal_shielding_ratio", path))
+        assert result is None
+
+
+# ============================================================
+# Issue #222 item 3: duplicate-row warning
+# ============================================================
+
+class TestDuplicateRowWarning:
+    def test_warns_on_duplicate_match(self, tmp_path, summary_dict):
+        # Inject a duplicate of the RSL3 immune_off row. The extractor
+        # must still return a value (first-match-wins) but warn loudly.
+        dup = dict(summary_dict["conditions"][0])
+        summary_dict["conditions"].append(dup)
+        path = _write_summary(tmp_path, summary_dict)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = calibrate.extract_tme_3d_json(
+                _target("rsl3_o2_collapse_ratio", path)
+            )
+        assert result == pytest.approx(0.20 / 0.80)
+        assert any("matched" in str(w.message) for w in caught), (
+            f"expected duplicate-row warning, got: {[str(w.message) for w in caught]}"
+        )


### PR DESCRIPTION
## Summary

Three non-blocking polish items from PR #221 review of the 3D calibration extractor.

### Item 1 — Tests (`tests/test_calibrate.py`, new)

Adds fixture-based pytest coverage for `_find_3d_condition` and `extract_tme_3d_json` in `simulations/calibration/calibrate.py`. The existing extractors have no tests either, but the 3D extractor's row-filter invariants are subtle enough to pin:

- `TestRsl3O2CollapseRatio` — single-row two-field metric; pins `stromal_mode=None` and `immune_mode="off"` filters.
- `TestImmuneSdtRsl3Ratio` — two-row matched-context metric; pins divide-by-zero guard.
- `TestStromalShieldingRatio` — two-row stromal_mode partitioning; pins the most schema-fragile invariant.
- `TestDuplicateRowWarning` — pins the new warning side-effect from Item 3.

Fixtures construct minimal `summary.json`-shaped dicts in-memory (mirroring `sim-tme-3d::ConditionResult`); no on-disk dependency. If sim-tme-3d's schema drifts and the extractor silently returns `None`, these tests fail loudly.

### Item 2 — `math.isclose` for `o2_lambda_um`

Replaces raw `!=` with `math.isclose(row_lambda, o2_lambda_um, abs_tol=1e-6)` only on the λ comparison. Today's schema emits exact `120.0` so this is a no-op in practice, but future-proofs the filter against non-exact float sweeps.

### Item 3 — Warn on duplicate-row matches

`_find_3d_condition` now collects all matches; if `len(matches) > 1`, emits a `warnings.warn` listing the matched row indices and returns the first. Today's 24-condition matrix has unique combos so this never fires.

## Test results

- `pytest tests/ -q` → **87 passed** (was 79; +8 new tests, all green).
- `python3 calibration/calibrate.py --evaluate` → script runs through evaluation: 1 PASS, 7 SKIP (no simulation outputs locally). A pre-existing `KeyError: 'tolerance'` in `generate_report` fires for SKIP rows on `main` too — not introduced by this PR, out of scope.

## Test plan

- [x] Item 1: 8 new tests in `tests/test_calibrate.py` collected and pass.
- [x] Item 2: `math.isclose` applied only to `o2_lambda_um`; no other comparisons changed.
- [x] Item 3: Duplicate-row warning emits with row indices; return type unchanged; covered by `TestDuplicateRowWarning`.
- [x] Existing 79 tests still pass.
- [x] Live `calibrate.py --evaluate` runs through evaluation loop unchanged.

Closes #222

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)