### PR TITLE
docs(ferroptosis-core): fix stale [0,1] range on local_ros_multiplier (#214)

### DIFF
--- a/simulations/ferroptosis-core/src/physics.rs
+++ b/simulations/ferroptosis-core/src/physics.rs
@@ -117,10 +117,28 @@ pub fn rsl3_concentration(_z_um: f64) -> f64 {
 }
 
 /// Compute the ROS dose multiplier for a cell at a given row in the grid.
-/// Energy is applied from the top (row 0 = tissue surface).
+/// Energy is applied from the top (row 0 = tissue surface): per-cell depth
+/// is `z = row × cell_size_um`, which is then dispatched to the same
+/// depth-attenuation functions used by the 3D path
+/// ([`local_ros_multiplier_3d`]).
 ///
-/// Returns a multiplier in [0, 1] that scales the base exogenous ROS.
-/// For Control, always returns 0.
+/// **2D ≡ 3D at matched depth:** for any treatment and parameter set, if
+/// the 3D caller passes `depth = row × cell_size_um` (the same value this
+/// function computes internally), [`local_ros_multiplier_3d`] returns the
+/// same multiplier. This is a **mathematical** invariant on the
+/// dispatcher (same depth-function applied to same f64), not a claim of
+/// physical equivalence between the two geometries. Locked down by
+/// `local_ros_multiplier_2d_3d_match_at_same_depth` below.
+///
+/// Returns a multiplier in `[0, ∞)` for `Treatment::RSL3`, `SDT`, and
+/// `PDT`; exactly `0.0` for `Treatment::Control`. For the PDT path, the
+/// underlying [`pdt_intensity_at_depth`] stays in `[0, 1]` for valid
+/// `Photosensitizer::Uniform(c)` with `c ≤ 1.0` or any valid
+/// `Photosensitizer::Porfimer` with `phi_so2_relative ≤ 1`;
+/// `Uniform(c)` with `c > 1.0` and `phi_so2_relative > 1` are
+/// intentionally permitted (forward-compat hooks for enrichment /
+/// sensitizer-engineered variants) and can produce multipliers above
+/// 1.0.
 pub fn local_ros_multiplier(
     row: usize,
     cell_size_um: f64,


### PR DESCRIPTION
## Summary

Re-proposed after revert in #232 — opening for explicit per-PR review this time. Original change content unchanged from `87c98b10`.

Doc-only fix in `simulations/ferroptosis-core/src/physics.rs`: `local_ros_multiplier`'s rustdoc claimed it returns a value in `[0, 1]`, but the same escape hatches that #200/#208 added for the 3D dispatcher apply to the 2D path:

- `Photosensitizer::Uniform(c)` allows `c > 1.0` (enrichment hook)
- `Porfimer { phi_so2_relative > 1.0 }` allows engineered variants with higher yield than porfimer baseline

Both can push `local_ros_multiplier` for `Treatment::PDT` above 1.0. The 3D analog `local_ros_multiplier_3d` already documents the correct range; the 2D version was the only stale one. This PR brings it in line:

- Range documented as `[0, ∞)` for `RSL3` / `SDT` / `PDT`, and `0.0` for `Control`
- Carries the same enrichment-hook caveat that `pdt_intensity_at_depth` already documents
- Wording is parallel to `local_ros_multiplier_3d`'s docstring

No behavior change. Only the dispatcher's range claim was inaccurate — the behavior has always been correct and is correctly documented on the underlying `pdt_intensity_at_depth`.

## Test plan

- [ ] CI green
- [ ] `cargo test --release -p ferroptosis-core --lib` → 166 tests pass (no doctest changes)
- [ ] `cargo doc -p ferroptosis-core --no-deps` produces no new warnings

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)