### PR TITLE
Workspace cargo fmt + CI fmt-check gate (#209)

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -32,3 +32,21 @@ jobs:
       - name: Run tests and compile all binaries
         working-directory: simulations
         run: cargo test --workspace
+
+  fmt:
+    # Block PRs that introduce cargo fmt drift in the simulations
+    # workspace. Runs in parallel with `test`; rustfmt-only — no build
+    # cache needed.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain with rustfmt
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        working-directory: simulations
+        run: cargo fmt --all --check

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -42,8 +42,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Install Rust toolchain with rustfmt
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install pinned Rust toolchain with rustfmt
+        # Pin to the workspace toolchain in `simulations/rust-toolchain.toml`
+        # rather than @stable. Cargo invocations from `simulations/`
+        # honor the pin and would otherwise auto-download the pinned
+        # channel *without* rustfmt, breaking the gate (PR #236 review).
+        # Bumping the workspace pin requires bumping this version too.
+        uses: dtolnay/rust-toolchain@1.92.0
         with:
           components: rustfmt
 

--- a/simulations/ferroptosis-core/examples/basic_usage.rs
+++ b/simulations/ferroptosis-core/examples/basic_usage.rs
@@ -28,7 +28,10 @@ fn main() {
 
     println!("ferroptosis-core v{}", env!("CARGO_PKG_VERSION"));
     println!("Parameters: default (2D culture)\n");
-    println!("{:<25} {:<10} {:<8} {:<10} {:<10} {:<10}", "Phenotype", "Treatment", "Dead?", "LP", "GSH", "GPX4");
+    println!(
+        "{:<25} {:<10} {:<8} {:<10} {:<10} {:<10}",
+        "Phenotype", "Treatment", "Dead?", "LP", "GSH", "GPX4"
+    );
     println!("{}", "-".repeat(73));
 
     for (pheno, pname) in &phenotypes {
@@ -39,7 +42,12 @@ fn main() {
             let (dead, lp, gsh, gpx4) = sim_cell(&cell, *tx, &params, &mut sim_rng);
             println!(
                 "{:<25} {:<10} {:<8} {:<10.3} {:<10.3} {:<10.3}",
-                pname, tname, if dead { "YES" } else { "no" }, lp, gsh, gpx4
+                pname,
+                tname,
+                if dead { "YES" } else { "no" },
+                lp,
+                gsh,
+                gpx4
             );
         }
     }
@@ -47,7 +55,10 @@ fn main() {
     // Demonstrate in-vivo parameters (MUFA protection) with a small population
     println!("\n--- In-vivo context (SCD1-driven MUFA protection) ---\n");
     let invivo_params = Params::invivo();
-    println!("MUFA steady-state protection: {:.2}", invivo_params.initial_mufa_protection);
+    println!(
+        "MUFA steady-state protection: {:.2}",
+        invivo_params.initial_mufa_protection
+    );
     let n = 500;
     let mut deaths_2d = 0;
     let mut deaths_vivo = 0;
@@ -55,11 +66,24 @@ fn main() {
         let mut rng = StdRng::seed_from_u64(i * 2);
         let cell = gen_cell(Phenotype::Persister, &mut rng);
         let mut sr = StdRng::seed_from_u64(i * 2 + 1);
-        if sim_cell(&cell, Treatment::RSL3, &params, &mut sr).0 { deaths_2d += 1; }
+        if sim_cell(&cell, Treatment::RSL3, &params, &mut sr).0 {
+            deaths_2d += 1;
+        }
         let mut sr = StdRng::seed_from_u64(i * 2 + 1);
-        if sim_cell(&cell, Treatment::RSL3, &invivo_params, &mut sr).0 { deaths_vivo += 1; }
+        if sim_cell(&cell, Treatment::RSL3, &invivo_params, &mut sr).0 {
+            deaths_vivo += 1;
+        }
     }
-    println!("Persister + RSL3 (2D):     {deaths_2d}/{n} dead ({:.0}%)", deaths_2d as f64 / n as f64 * 100.0);
-    println!("Persister + RSL3 (in-vivo): {deaths_vivo}/{n} dead ({:.0}%)", deaths_vivo as f64 / n as f64 * 100.0);
-    println!("MUFA protection factor: {:.1}x", deaths_2d as f64 / deaths_vivo.max(1) as f64);
+    println!(
+        "Persister + RSL3 (2D):     {deaths_2d}/{n} dead ({:.0}%)",
+        deaths_2d as f64 / n as f64 * 100.0
+    );
+    println!(
+        "Persister + RSL3 (in-vivo): {deaths_vivo}/{n} dead ({:.0}%)",
+        deaths_vivo as f64 / n as f64 * 100.0
+    );
+    println!(
+        "MUFA protection factor: {:.1}x",
+        deaths_2d as f64 / deaths_vivo.max(1) as f64
+    );
 }

--- a/simulations/ferroptosis-core/src/biochem.rs
+++ b/simulations/ferroptosis-core/src/biochem.rs
@@ -49,7 +49,12 @@ impl CellState {
 
     /// Initialize with a custom exogenous ROS peak (for spatial model where
     /// ROS dose depends on depth/position).
-    pub fn from_cell_with_ros(cell: &Cell, tx: Treatment, params: &Params, exo_ros_peak: f64) -> Self {
+    pub fn from_cell_with_ros(
+        cell: &Cell,
+        tx: Treatment,
+        params: &Params,
+        exo_ros_peak: f64,
+    ) -> Self {
         let mut gpx4 = cell.gpx4;
         if let Treatment::RSL3 = tx {
             gpx4 *= 1.0 - params.rsl3_gpx4_inhib;
@@ -154,7 +159,9 @@ pub fn sim_cell_step(
     let lp_generation = lp_direct + lp_propagation;
 
     // === REPAIR ===
-    let gpx4_repair = state.gpx4 * (state.gsh / (state.gsh + 1.0)) * params.gpx4_rate
+    let gpx4_repair = state.gpx4
+        * (state.gsh / (state.gsh + 1.0))
+        * params.gpx4_rate
         * (state.lp / (state.lp + 0.5));
     let fsp1_repair = state.fsp1 * params.fsp1_rate * (state.lp / (state.lp + 0.5));
     let total_repair = gpx4_repair + fsp1_repair;
@@ -300,7 +307,10 @@ mod tests {
         let mut sim_rng = StdRng::seed_from_u64(1);
         let (dead, lp, _, _) = sim_cell(&cell, Treatment::Control, &params, &mut sim_rng);
         assert!(!dead, "Glycolytic cell should survive Control");
-        assert!(lp < params.death_threshold, "LP should stay below threshold");
+        assert!(
+            lp < params.death_threshold,
+            "LP should stay below threshold"
+        );
     }
 
     #[test]
@@ -321,7 +331,11 @@ mod tests {
         let mut sim_rng = StdRng::seed_from_u64(1);
         let state = CellState::from_cell(&cell, Treatment::RSL3, &params, &mut sim_rng);
         let expected = cell.gpx4 * (1.0 - params.rsl3_gpx4_inhib);
-        assert!((state.gpx4 - expected).abs() < 1e-10, "RSL3 should reduce GPX4 by {}%", params.rsl3_gpx4_inhib * 100.0);
+        assert!(
+            (state.gpx4 - expected).abs() < 1e-10,
+            "RSL3 should reduce GPX4 by {}%",
+            params.rsl3_gpx4_inhib * 100.0
+        );
     }
 
     #[test]
@@ -336,11 +350,18 @@ mod tests {
             let mut rng = StdRng::seed_from_u64(i * 2);
             let cell = gen_cell(Phenotype::Persister, &mut rng);
             let mut sr = StdRng::seed_from_u64(i * 2 + 1);
-            if sim_cell(&cell, Treatment::RSL3, &params_2d, &mut sr).0 { deaths_2d += 1; }
+            if sim_cell(&cell, Treatment::RSL3, &params_2d, &mut sr).0 {
+                deaths_2d += 1;
+            }
             let mut sr = StdRng::seed_from_u64(i * 2 + 1);
-            if sim_cell(&cell, Treatment::RSL3, &params_vivo, &mut sr).0 { deaths_vivo += 1; }
+            if sim_cell(&cell, Treatment::RSL3, &params_vivo, &mut sr).0 {
+                deaths_vivo += 1;
+            }
         }
-        assert!(deaths_vivo < deaths_2d, "In-vivo MUFA should reduce RSL3 deaths: 2D={deaths_2d}, vivo={deaths_vivo}");
+        assert!(
+            deaths_vivo < deaths_2d,
+            "In-vivo MUFA should reduce RSL3 deaths: 2D={deaths_2d}, vivo={deaths_vivo}"
+        );
     }
 
     #[test]

--- a/simulations/ferroptosis-core/src/cell.rs
+++ b/simulations/ferroptosis-core/src/cell.rs
@@ -139,9 +139,7 @@ impl Default for RecoveryRates {
 /// Returns new parameter means (not a full Cell — caller generates stochastic cell from these).
 pub fn recovered_persister_means(days: f64, rates: &RecoveryRates) -> (f64, f64, f64, f64) {
     // Exponential recovery: fraction recovered = 1 - exp(-ln(2) * t / t_half)
-    let frac = |t_half: f64| -> f64 {
-        1.0 - (-(2.0_f64.ln()) * days / t_half).exp()
-    };
+    let frac = |t_half: f64| -> f64 { 1.0 - (-(2.0_f64.ln()) * days / t_half).exp() };
 
     // Persister baseline → Glycolytic normal targets
     let fsp1 = 0.15 + (1.0 - 0.15) * frac(rates.fsp1_half_recovery_days);

--- a/simulations/ferroptosis-core/src/drug_transport.rs
+++ b/simulations/ferroptosis-core/src/drug_transport.rs
@@ -221,7 +221,10 @@ mod tests {
         let tissue = epithelial_well_vascularized();
         let c = concentration_at_distance(0.0, &drug, &tissue);
         let expected = drug.vessel_wall_conc * tissue.vascular_permeability;
-        assert!((c - expected).abs() < 1e-10, "At r=0: expected {expected}, got {c}");
+        assert!(
+            (c - expected).abs() < 1e-10,
+            "At r=0: expected {expected}, got {c}"
+        );
     }
 
     #[test]
@@ -230,7 +233,10 @@ mod tests {
         let tissue = epithelial_well_vascularized();
         let c_near = concentration_at_distance(10.0, &drug, &tissue);
         let c_far = concentration_at_distance(100.0, &drug, &tissue);
-        assert!(c_far < c_near, "Concentration should decrease with distance");
+        assert!(
+            c_far < c_near,
+            "Concentration should decrease with distance"
+        );
     }
 
     #[test]
@@ -238,7 +244,10 @@ mod tests {
         let drug = rsl3_like();
         let tissue = epithelial_well_vascularized();
         let c = concentration_at_distance(1000.0, &drug, &tissue);
-        assert!(c < 0.01, "Concentration at 1mm should be negligible, got {c}");
+        assert!(
+            c < 0.01,
+            "Concentration at 1mm should be negligible, got {c}"
+        );
     }
 
     #[test]
@@ -256,7 +265,10 @@ mod tests {
             ..drug1.clone()
         };
         let ratio = penetration_length_um(&drug2) / penetration_length_um(&drug1);
-        assert!((ratio - 2.0).abs() < 0.01, "λ should scale as √D: ratio={ratio}");
+        assert!(
+            (ratio - 2.0).abs() < 0.01,
+            "λ should scale as √D: ratio={ratio}"
+        );
     }
 
     #[test]
@@ -289,9 +301,15 @@ mod tests {
         let tissue = epithelial_well_vascularized();
         let profile = concentration_profile(&drug, &tissue, 50);
         assert_eq!(profile.len(), 50);
-        assert!((profile[0].0 - 0.0).abs() < 1e-10, "First point should be at r=0");
+        assert!(
+            (profile[0].0 - 0.0).abs() < 1e-10,
+            "First point should be at r=0"
+        );
         let r_max = max_distance_um(&tissue);
-        assert!((profile[49].0 - r_max).abs() < 1e-10, "Last point should be at r_max");
+        assert!(
+            (profile[49].0 - r_max).abs() < 1e-10,
+            "Last point should be at r_max"
+        );
     }
 
     #[test]
@@ -304,6 +322,9 @@ mod tests {
             name: "no-clearance",
         };
         let lambda = penetration_length_um(&drug);
-        assert!(lambda.is_infinite(), "Zero clearance should give infinite penetration");
+        assert!(
+            lambda.is_infinite(),
+            "Zero clearance should give infinite penetration"
+        );
     }
 }

--- a/simulations/ferroptosis-core/src/grid.rs
+++ b/simulations/ferroptosis-core/src/grid.rs
@@ -14,8 +14,8 @@ use ndarray::Array2;
 use rand::prelude::*;
 use serde::Serialize;
 
-use crate::cell::{gen_cell, Cell, Phenotype};
 use crate::biochem::CellState;
+use crate::cell::{gen_cell, Cell, Phenotype};
 
 /// Fraction of the smallest grid dimension used for the tumor sphere/circle
 /// radius (in lattice cells). Shared by [`TumorGrid3D::generate`] and
@@ -362,13 +362,7 @@ impl TumorGrid3D {
     /// `200³` is ~1.4 GB. Callers should size against available RAM
     /// before invoking; `debug_assert!` guards against accidental
     /// allocations above ~1 G cells (≈ 170 GB, almost certainly a typo).
-    pub fn generate(
-        rows: usize,
-        cols: usize,
-        layers: usize,
-        cell_size_um: f64,
-        seed: u64,
-    ) -> Self {
+    pub fn generate(rows: usize, cols: usize, layers: usize, cell_size_um: f64, seed: u64) -> Self {
         // Memory guard — catches "rows = 1000" typos in tests and CI.
         // Active only in debug builds; release callers are expected to
         // size against their own hardware. 10^9 cells × 170 B ≈ 170 GB
@@ -545,12 +539,7 @@ impl TumorGrid3D {
     /// - Face cell (one coordinate at the boundary): 17 (2·3·3 − 1)
     /// - Face-edge cell (two coordinates at boundary): 11 (2·2·3 − 1)
     /// - Corner cell (all three at boundary): 7 (2³ − 1)
-    pub fn neighbors(
-        &self,
-        r: usize,
-        c: usize,
-        l: usize,
-    ) -> ([(usize, usize, usize); 26], usize) {
+    pub fn neighbors(&self, r: usize, c: usize, l: usize) -> ([(usize, usize, usize); 26], usize) {
         let mut result = [(0usize, 0usize, 0usize); 26];
         let mut count = 0;
         for dr in [-1_i64, 0, 1] {
@@ -811,7 +800,10 @@ mod tests_3d {
                 "neighbor ({nr},{nc},{nl}) extra_iron should equal iron_per_death × neighbor_fraction"
             );
         }
-        assert!(!g.get(r, c, l).newly_dead, "newly_dead flag should be cleared after diffusion");
+        assert!(
+            !g.get(r, c, l).newly_dead,
+            "newly_dead flag should be cleared after diffusion"
+        );
     }
 
     /// Generate is deterministic from seed: same seed → same per-cell
@@ -868,7 +860,7 @@ mod tests_3d {
         let mut g = TumorGrid3D::generate(10, 10, 10, 20.0, 42);
 
         let (r, c, l) = (0, 0, 0); // grid corner
-        // Force the corner to be a fresh tumor cell that just died.
+                                   // Force the corner to be a fresh tumor cell that just died.
         let gc = g.get_mut(r, c, l);
         gc.is_tumor = true;
         gc.state.dead = true;

--- a/simulations/ferroptosis-core/src/immune.rs
+++ b/simulations/ferroptosis-core/src/immune.rs
@@ -38,10 +38,7 @@ pub struct ImmuneResult {
 ///
 /// Ref: Krysko et al., Nat Rev Cancer 2012 (ICD markers)
 ///      Berezhnoy et al., PLoS Comput Biol 2020 (Boolean ICD model)
-pub fn calculate_damp_release(
-    dead_cell_lps: &[f64],
-    params: &ImmuneParams,
-) -> (f64, f64) {
+pub fn calculate_damp_release(dead_cell_lps: &[f64], params: &ImmuneParams) -> (f64, f64) {
     if dead_cell_lps.is_empty() {
         return (0.0, 0.0);
     }
@@ -73,7 +70,8 @@ pub fn immune_cascade(
     // DC activation: saturating response to DAMP *per dead cell* (quality of death).
     // Using per-cell average rather than total prevents the number of dead cells from
     // dominating the activation signal, allowing SDT vs RSL3 quality differences to show.
-    let dc_activation_fraction = damp_per_dead_cell / (damp_per_dead_cell + params.dc_activation_kd);
+    let dc_activation_fraction =
+        damp_per_dead_cell / (damp_per_dead_cell + params.dc_activation_kd);
 
     // Mature DCs: activation quality × maturation rate × number of antigen-presenting deaths
     let mature_dcs = dc_activation_fraction * params.dc_maturation_rate * n_dead as f64;

--- a/simulations/ferroptosis-core/src/io.rs
+++ b/simulations/ferroptosis-core/src/io.rs
@@ -42,12 +42,15 @@ pub fn write_depth_curves_csv(
 
 /// Write vulnerability window results as CSV.
 /// Format: timepoint_hours, treatment, death_rate, ci_low, ci_high
-pub fn write_window_csv(
-    path: &Path,
-    results: &[(f64, String, f64, f64, f64)],
-) -> io::Result<()> {
+pub fn write_window_csv(path: &Path, results: &[(f64, String, f64, f64, f64)]) -> io::Result<()> {
     let mut wtr = csv::Writer::from_path(path)?;
-    wtr.write_record(["timepoint_hours", "treatment", "death_rate", "ci_low", "ci_high"])?;
+    wtr.write_record([
+        "timepoint_hours",
+        "treatment",
+        "death_rate",
+        "ci_low",
+        "ci_high",
+    ])?;
     for (hours, tx, rate, ci_lo, ci_hi) in results {
         wtr.write_record(&[
             format!("{:.1}", hours),
@@ -63,7 +66,7 @@ pub fn write_window_csv(
 
 /// Write any Serialize value as pretty-printed JSON to a file.
 pub fn write_json<T: serde::Serialize>(path: &Path, data: &T) -> io::Result<()> {
-    let json = serde_json::to_string_pretty(data)
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    let json =
+        serde_json::to_string_pretty(data).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
     std::fs::write(path, json)
 }

--- a/simulations/ferroptosis-core/src/lib.rs
+++ b/simulations/ferroptosis-core/src/lib.rs
@@ -36,17 +36,17 @@
 
 pub mod cell;
 // Listed before `params` because `SpatialParams` holds a `Photosensitizer`.
-pub mod photosensitizer_pk;
-pub mod params;
 pub mod biochem;
-pub mod stats;
-pub mod physics;
+pub mod drug_transport;
 pub mod grid;
-pub mod oxygen;
-pub mod ph;
-pub mod stromal;
 pub mod immune;
 pub mod immune_3d;
 pub mod io;
-pub mod drug_transport;
+pub mod oxygen;
+pub mod params;
+pub mod ph;
+pub mod photosensitizer_pk;
+pub mod physics;
+pub mod stats;
+pub mod stromal;
 pub mod tumor_pk;

--- a/simulations/ferroptosis-core/src/params.rs
+++ b/simulations/ferroptosis-core/src/params.rs
@@ -186,9 +186,9 @@ impl Default for SpatialParams {
             cell_size_um: 20.0,
             iron_diffusion_coeff: 281.0,
             iron_release_per_death: 2.0,
-            pdt_mu_eff: 0.31,       // 1/mm, δ ≈ 3.2mm at 630nm
+            pdt_mu_eff: 0.31, // 1/mm, δ ≈ 3.2mm at 630nm
             pdt_i0: 1.0,
-            sdt_alpha: 0.7,          // dB/cm/MHz (soft tissue)
+            sdt_alpha: 0.7, // dB/cm/MHz (soft tissue)
             sdt_freq_mhz: 1.0,
             sdt_i0: 1.0,
             neighbor_iron_fraction: 0.1,
@@ -413,7 +413,11 @@ mod tests {
         let p: SpatialParams = serde_json::from_str(legacy).unwrap();
         assert_eq!(p.photosensitizer, Photosensitizer::Uniform(1.0));
         assert_eq!(p.t_drug_light_interval_h, 0.0);
-        assert_eq!(p.photosensitizer.concentration_at(p.t_drug_light_interval_h), 1.0);
+        assert_eq!(
+            p.photosensitizer
+                .concentration_at(p.t_drug_light_interval_h),
+            1.0
+        );
     }
 
     /// `SpatialImmuneConfig::for_2d()` must reproduce the literal values
@@ -464,7 +468,10 @@ mod tests {
         assert_eq!(blocked.anti_pd1_efficacy, 0.8);
         // Everything else must match.
         assert_eq!(blocked.damp_per_lp, base.damp_per_lp);
-        assert_eq!(blocked.damp_diffusion_fraction, base.damp_diffusion_fraction);
+        assert_eq!(
+            blocked.damp_diffusion_fraction,
+            base.damp_diffusion_fraction
+        );
         assert_eq!(blocked.damp_clearance_rate, base.damp_clearance_rate);
         assert_eq!(blocked.dc_activation_kd, base.dc_activation_kd);
         assert_eq!(blocked.immune_kill_rate, base.immune_kill_rate);

--- a/simulations/ferroptosis-core/src/photosensitizer_pk.rs
+++ b/simulations/ferroptosis-core/src/photosensitizer_pk.rs
@@ -144,7 +144,10 @@ impl fmt::Display for Photosensitizer {
                 // round-trips unambiguously through `FromStr`. f64's
                 // whole-number rendering keeps it tidy in the common
                 // case (`porfimer=504,0,1`).
-                write!(f, "porfimer={t_half_h},{t_distribution_h},{phi_so2_relative}")
+                write!(
+                    f,
+                    "porfimer={t_half_h},{t_distribution_h},{phi_so2_relative}"
+                )
             }
         }
     }
@@ -203,7 +206,8 @@ impl FromStr for Photosensitizer {
                     t_half_h = parse_f64_field("porfimer=t_half[,t_dist[,phi]]", "t_half", p)?;
                 }
                 if let Some(p) = parts.get(1) {
-                    t_distribution_h = parse_f64_field("porfimer=t_half[,t_dist[,phi]]", "t_dist", p)?;
+                    t_distribution_h =
+                        parse_f64_field("porfimer=t_half[,t_dist[,phi]]", "t_dist", p)?;
                 }
                 if let Some(p) = parts.get(2) {
                     phi_so2_relative = parse_f64_field("porfimer=t_half[,t_dist[,phi]]", "phi", p)?;
@@ -229,9 +233,7 @@ impl FromStr for Photosensitizer {
 /// message rather than the cryptic `parse::<f64>("")` error.
 fn parse_f64_field(spec_form: &str, field_name: &str, raw: &str) -> Result<f64, String> {
     if raw.is_empty() {
-        return Err(format!(
-            "{spec_form}: empty value for {field_name}"
-        ));
+        return Err(format!("{spec_form}: empty value for {field_name}"));
     }
     raw.parse::<f64>()
         .map_err(|e| format!("{spec_form}: cannot parse {field_name}={raw:?}: {e}"))
@@ -242,7 +244,9 @@ fn parse_f64_field(spec_form: &str, field_name: &str, raw: &str) -> Result<f64, 
 /// would divide by zero).
 fn check_finite_strict_positive(field: &str, value: f64) -> Result<(), String> {
     if !value.is_finite() {
-        return Err(format!("Photosensitizer::{field} must be finite, got {value}"));
+        return Err(format!(
+            "Photosensitizer::{field} must be finite, got {value}"
+        ));
     }
     if value <= 0.0 {
         return Err(format!("Photosensitizer::{field} must be > 0, got {value}"));
@@ -256,10 +260,14 @@ fn check_finite_strict_positive(field: &str, value: f64) -> Result<(), String> {
 /// a defensible thought-experiment use).
 fn check_finite_nonneg(field: &str, value: f64) -> Result<(), String> {
     if !value.is_finite() {
-        return Err(format!("Photosensitizer::{field} must be finite, got {value}"));
+        return Err(format!(
+            "Photosensitizer::{field} must be finite, got {value}"
+        ));
     }
     if value < 0.0 {
-        return Err(format!("Photosensitizer::{field} must be >= 0, got {value}"));
+        return Err(format!(
+            "Photosensitizer::{field} must be >= 0, got {value}"
+        ));
     }
     Ok(())
 }
@@ -409,7 +417,11 @@ mod tests {
 
     #[test]
     fn porfimer_at_one_halflife_is_half() {
-        let p = Photosensitizer::Porfimer { t_half_h: 504.0, t_distribution_h: 0.0, phi_so2_relative: 1.0 };
+        let p = Photosensitizer::Porfimer {
+            t_half_h: 504.0,
+            t_distribution_h: 0.0,
+            phi_so2_relative: 1.0,
+        };
         // `exp(-ln(2))` lands on 0.5 on most libm implementations but is
         // not guaranteed bit-exact across platforms (intermediate rounding
         // in `ln(2)/504 * 504` may not round-trip). Compare with a tight
@@ -424,13 +436,21 @@ mod tests {
     #[test]
     fn porfimer_at_zero_is_one() {
         // `exp(0.0) == 1.0` is required by IEEE 754 — strict equality is safe here.
-        let p = Photosensitizer::Porfimer { t_half_h: 504.0, t_distribution_h: 0.0, phi_so2_relative: 1.0 };
+        let p = Photosensitizer::Porfimer {
+            t_half_h: 504.0,
+            t_distribution_h: 0.0,
+            phi_so2_relative: 1.0,
+        };
         assert_eq!(p.concentration_at(0.0), 1.0);
     }
 
     #[test]
     fn porfimer_decays_monotonically() {
-        let p = Photosensitizer::Porfimer { t_half_h: 504.0, t_distribution_h: 0.0, phi_so2_relative: 1.0 };
+        let p = Photosensitizer::Porfimer {
+            t_half_h: 504.0,
+            t_distribution_h: 0.0,
+            phi_so2_relative: 1.0,
+        };
         let c0 = p.concentration_at(0.0);
         let c1 = p.concentration_at(24.0);
         let c2 = p.concentration_at(168.0);
@@ -503,7 +523,11 @@ mod tests {
 
     #[test]
     fn serde_roundtrip_porfimer() {
-        let p = Photosensitizer::Porfimer { t_half_h: 504.0, t_distribution_h: 0.0, phi_so2_relative: 1.0 };
+        let p = Photosensitizer::Porfimer {
+            t_half_h: 504.0,
+            t_distribution_h: 0.0,
+            phi_so2_relative: 1.0,
+        };
         let json = serde_json::to_string(&p).unwrap();
         let q: Photosensitizer = serde_json::from_str(&json).unwrap();
         assert_eq!(p, q);
@@ -568,22 +592,38 @@ mod tests {
 
     #[test]
     fn validate_porfimer_accepts_valid() {
-        assert!(Photosensitizer::Porfimer { t_half_h: 504.0, t_distribution_h: 0.0, phi_so2_relative: 1.0 }
-            .validate()
-            .is_ok());
-        assert!(Photosensitizer::Porfimer { t_half_h: 0.001, t_distribution_h: 0.0, phi_so2_relative: 1.0 }
-            .validate()
-            .is_ok());
+        assert!(Photosensitizer::Porfimer {
+            t_half_h: 504.0,
+            t_distribution_h: 0.0,
+            phi_so2_relative: 1.0
+        }
+        .validate()
+        .is_ok());
+        assert!(Photosensitizer::Porfimer {
+            t_half_h: 0.001,
+            t_distribution_h: 0.0,
+            phi_so2_relative: 1.0
+        }
+        .validate()
+        .is_ok());
     }
 
     #[test]
     fn validate_porfimer_rejects_invalid() {
-        assert!(Photosensitizer::Porfimer { t_half_h: 0.0, t_distribution_h: 0.0, phi_so2_relative: 1.0 }
-            .validate()
-            .is_err());
-        assert!(Photosensitizer::Porfimer { t_half_h: -100.0, t_distribution_h: 0.0, phi_so2_relative: 1.0 }
-            .validate()
-            .is_err());
+        assert!(Photosensitizer::Porfimer {
+            t_half_h: 0.0,
+            t_distribution_h: 0.0,
+            phi_so2_relative: 1.0
+        }
+        .validate()
+        .is_err());
+        assert!(Photosensitizer::Porfimer {
+            t_half_h: -100.0,
+            t_distribution_h: 0.0,
+            phi_so2_relative: 1.0
+        }
+        .validate()
+        .is_err());
         assert!(Photosensitizer::Porfimer {
             t_half_h: f64::NAN,
             t_distribution_h: 0.0,
@@ -604,7 +644,11 @@ mod tests {
     fn negative_dli_saturates_to_peak() {
         // Negative DLI is non-physical (illumination before drug peak);
         // saturate to t=0 to keep outputs in [0, 1] for valid params.
-        let p = Photosensitizer::Porfimer { t_half_h: 504.0, t_distribution_h: 0.0, phi_so2_relative: 1.0 };
+        let p = Photosensitizer::Porfimer {
+            t_half_h: 504.0,
+            t_distribution_h: 0.0,
+            phi_so2_relative: 1.0,
+        };
         assert_eq!(p.concentration_at(-1.0), 1.0);
         assert_eq!(p.concentration_at(-1e6), 1.0);
         assert_eq!(p.concentration_at(f64::NEG_INFINITY), 1.0);
@@ -614,7 +658,11 @@ mod tests {
     fn nan_dli_saturates_to_peak() {
         // f64::max treats NaN as smaller than any value, so NaN.max(0.0)
         // returns 0.0 and concentration_at(NaN) is deterministic.
-        let p = Photosensitizer::Porfimer { t_half_h: 504.0, t_distribution_h: 0.0, phi_so2_relative: 1.0 };
+        let p = Photosensitizer::Porfimer {
+            t_half_h: 504.0,
+            t_distribution_h: 0.0,
+            phi_so2_relative: 1.0,
+        };
         assert_eq!(p.concentration_at(f64::NAN), 1.0);
     }
 
@@ -640,7 +688,11 @@ mod tests {
     fn parse_porfimer_default_is_bellnier() {
         assert_eq!(
             "porfimer".parse::<Photosensitizer>().unwrap(),
-            Photosensitizer::Porfimer { t_half_h: 504.0, t_distribution_h: 0.0, phi_so2_relative: 1.0 }
+            Photosensitizer::Porfimer {
+                t_half_h: 504.0,
+                t_distribution_h: 0.0,
+                phi_so2_relative: 1.0
+            }
         );
     }
 
@@ -648,7 +700,11 @@ mod tests {
     fn parse_porfimer_with_value() {
         assert_eq!(
             "porfimer=336".parse::<Photosensitizer>().unwrap(),
-            Photosensitizer::Porfimer { t_half_h: 336.0, t_distribution_h: 0.0, phi_so2_relative: 1.0 }
+            Photosensitizer::Porfimer {
+                t_half_h: 336.0,
+                t_distribution_h: 0.0,
+                phi_so2_relative: 1.0
+            }
         );
     }
 
@@ -656,7 +712,11 @@ mod tests {
     fn parse_trims_whitespace() {
         assert_eq!(
             "  porfimer = 504  ".parse::<Photosensitizer>().unwrap(),
-            Photosensitizer::Porfimer { t_half_h: 504.0, t_distribution_h: 0.0, phi_so2_relative: 1.0 }
+            Photosensitizer::Porfimer {
+                t_half_h: 504.0,
+                t_distribution_h: 0.0,
+                phi_so2_relative: 1.0
+            }
         );
     }
 
@@ -668,11 +728,19 @@ mod tests {
         );
         assert_eq!(
             "PORFIMER=504".parse::<Photosensitizer>().unwrap(),
-            Photosensitizer::Porfimer { t_half_h: 504.0, t_distribution_h: 0.0, phi_so2_relative: 1.0 }
+            Photosensitizer::Porfimer {
+                t_half_h: 504.0,
+                t_distribution_h: 0.0,
+                phi_so2_relative: 1.0
+            }
         );
         assert_eq!(
             "PorFimEr".parse::<Photosensitizer>().unwrap(),
-            Photosensitizer::Porfimer { t_half_h: 504.0, t_distribution_h: 0.0, phi_so2_relative: 1.0 }
+            Photosensitizer::Porfimer {
+                t_half_h: 504.0,
+                t_distribution_h: 0.0,
+                phi_so2_relative: 1.0
+            }
         );
     }
 
@@ -725,8 +793,16 @@ mod tests {
             Photosensitizer::Uniform(0.0),
             Photosensitizer::Uniform(1.0),
             Photosensitizer::Uniform(0.5),
-            Photosensitizer::Porfimer { t_half_h: 504.0, t_distribution_h: 0.0, phi_so2_relative: 1.0 },
-            Photosensitizer::Porfimer { t_half_h: 336.5, t_distribution_h: 0.0, phi_so2_relative: 1.0 },
+            Photosensitizer::Porfimer {
+                t_half_h: 504.0,
+                t_distribution_h: 0.0,
+                phi_so2_relative: 1.0,
+            },
+            Photosensitizer::Porfimer {
+                t_half_h: 336.5,
+                t_distribution_h: 0.0,
+                phi_so2_relative: 1.0,
+            },
         ] {
             let rendered = format!("{ps}");
             let reparsed: Photosensitizer = rendered
@@ -764,7 +840,9 @@ mod tests {
 
     #[test]
     fn validate_dli_h_rejects_infinity() {
-        assert!(validate_dli_h(f64::INFINITY).unwrap_err().contains("finite"));
+        assert!(validate_dli_h(f64::INFINITY)
+            .unwrap_err()
+            .contains("finite"));
         assert!(validate_dli_h(f64::NEG_INFINITY)
             .unwrap_err()
             .contains("finite"));

--- a/simulations/ferroptosis-core/src/physics.rs
+++ b/simulations/ferroptosis-core/src/physics.rs
@@ -308,7 +308,11 @@ mod tests {
         let baseline = pdt_intensity_at_depth(z_um, &baseline_params);
 
         let pk_params = SpatialParams {
-            photosensitizer: Photosensitizer::Porfimer { t_half_h: 504.0, t_distribution_h: 0.0, phi_so2_relative: 1.0 },
+            photosensitizer: Photosensitizer::Porfimer {
+                t_half_h: 504.0,
+                t_distribution_h: 0.0,
+                phi_so2_relative: 1.0,
+            },
             t_drug_light_interval_h: 504.0,
             ..Default::default()
         };

--- a/simulations/ferroptosis-core/src/stats.rs
+++ b/simulations/ferroptosis-core/src/stats.rs
@@ -1,11 +1,11 @@
 //! Statistics, results aggregation, and parallel execution.
 
-use rayon::prelude::*;
 use rand::prelude::*;
+use rayon::prelude::*;
 use serde::Serialize;
 
-use crate::cell::{gen_cell, Phenotype, Treatment};
 use crate::biochem::sim_cell;
+use crate::cell::{gen_cell, Phenotype, Treatment};
 use crate::params::Params;
 
 /// Aggregated result for one condition (phenotype × treatment).

--- a/simulations/ferroptosis-core/src/tumor_pk.rs
+++ b/simulations/ferroptosis-core/src/tumor_pk.rs
@@ -189,9 +189,7 @@ pub enum PlasmaModel {
         k_el: f64,
     },
     /// Constant concentration (for 2D culture reference validation).
-    Constant {
-        concentration: f64,
-    },
+    Constant { concentration: f64 },
     /// External plasma time-course (e.g., PK-Sim export).
     /// Auto-normalized so peak = 1.0. Linear interpolation between points.
     /// Returns last concentration value at or past the last time point.
@@ -252,26 +250,41 @@ impl PlasmaModel {
             }
             let parts: Vec<&str> = line.split(',').collect();
             if parts.len() < 2 {
-                return Err(format!("Line {}: expected 'time,concentration', got '{}'", i + 1, line));
+                return Err(format!(
+                    "Line {}: expected 'time,concentration', got '{}'",
+                    i + 1,
+                    line
+                ));
             }
             // Skip header line
             let t: f64 = match parts[0].trim().parse() {
                 Ok(v) => v,
                 Err(_) => {
-                    if i == 0 { continue; } // likely header
+                    if i == 0 {
+                        continue;
+                    } // likely header
                     return Err(format!("Line {}: invalid time '{}'", i + 1, parts[0]));
                 }
             };
             let c: f64 = match parts[1].trim().parse() {
                 Ok(v) => v,
-                Err(_) => return Err(format!("Line {}: invalid concentration '{}'", i + 1, parts[1])),
+                Err(_) => {
+                    return Err(format!(
+                        "Line {}: invalid concentration '{}'",
+                        i + 1,
+                        parts[1]
+                    ))
+                }
             };
             time_min.push(t);
             conc_raw.push(c);
         }
 
         if time_min.len() < 2 {
-            return Err(format!("CSV must have at least 2 data points, got {}", time_min.len()));
+            return Err(format!(
+                "CSV must have at least 2 data points, got {}",
+                time_min.len()
+            ));
         }
 
         // Validate monotonically increasing time
@@ -279,7 +292,10 @@ impl PlasmaModel {
             if time_min[i] <= time_min[i - 1] {
                 return Err(format!(
                     "Time must be strictly increasing: t[{}]={} <= t[{}]={}",
-                    i, time_min[i], i - 1, time_min[i - 1]
+                    i,
+                    time_min[i],
+                    i - 1,
+                    time_min[i - 1]
                 ));
             }
         }
@@ -569,7 +585,13 @@ mod tests {
     #[test]
     fn concentrations_never_negative() {
         let plasma = rsl3_iv_bolus();
-        for tumor_fn in [breast_tumor, pancreatic_tumor, glioblastoma_tumor, melanoma_tumor, sarcoma_tumor] {
+        for tumor_fn in [
+            breast_tumor,
+            pancreatic_tumor,
+            glioblastoma_tumor,
+            melanoma_tumor,
+            sarcoma_tumor,
+        ] {
             let tumor = tumor_fn();
             let result = solve_tumor_pk(&plasma, &tumor, 180, 100);
             for (i, &c) in result.c_interstitial.iter().enumerate() {
@@ -591,7 +613,10 @@ mod tests {
         let peak100: f64 = r100.c_interstitial.iter().cloned().fold(0.0, f64::max);
         let peak200: f64 = r200.c_interstitial.iter().cloned().fold(0.0, f64::max);
         let diff = (peak100 - peak200).abs() / peak200;
-        assert!(diff < 0.01, "Convergence failed: {peak100} vs {peak200} ({diff:.4}%)");
+        assert!(
+            diff < 0.01,
+            "Convergence failed: {peak100} vs {peak200} ({diff:.4}%)"
+        );
     }
 
     #[test]
@@ -641,7 +666,10 @@ mod tests {
         let s100 = compute_spatial_temporal_schedule(&pk, 100.0, 224.0);
         let peak0: f64 = s0.iter().cloned().fold(0.0, f64::max);
         let peak100: f64 = s100.iter().cloned().fold(0.0, f64::max);
-        assert!(peak100 < peak0, "Concentration should decrease with distance");
+        assert!(
+            peak100 < peak0,
+            "Concentration should decrease with distance"
+        );
         let expected_ratio = (-100.0_f64 / 224.0).exp();
         let actual_ratio = peak100 / peak0;
         assert!(

--- a/simulations/ferroptosis-ffi/build.rs
+++ b/simulations/ferroptosis-ffi/build.rs
@@ -8,8 +8,7 @@ fn main() {
     // Ensure include directory exists
     std::fs::create_dir_all(crate_dir.join("include")).ok();
 
-    let config = cbindgen::Config::from_file(&config_path)
-        .unwrap_or_default();
+    let config = cbindgen::Config::from_file(&config_path).unwrap_or_default();
 
     let bindings = cbindgen::Builder::new()
         .with_crate(&crate_dir)

--- a/simulations/ferroptosis-ffi/src/lib.rs
+++ b/simulations/ferroptosis-ffi/src/lib.rs
@@ -235,8 +235,13 @@ pub extern "C" fn ferro_gen_cell(phenotype: i32, rng: *mut FerroRng) -> FerroCel
     if rng.is_null() {
         // Return zeroed cell on null RNG (defensive)
         return FerroCell {
-            iron: 0.0, gsh: 0.0, gpx4: 0.0, fsp1: 0.0,
-            basal_ros: 0.0, lipid_unsat: 0.0, nrf2: 0.0,
+            iron: 0.0,
+            gsh: 0.0,
+            gpx4: 0.0,
+            fsp1: 0.0,
+            basal_ros: 0.0,
+            lipid_unsat: 0.0,
+            nrf2: 0.0,
         };
     }
     let rng_ref = unsafe { &mut *(rng as *mut StdRng) };
@@ -262,7 +267,10 @@ pub extern "C" fn ferro_sim_cell(
 ) -> FerroResult {
     if cell.is_null() || params.is_null() || rng.is_null() {
         return FerroResult {
-            dead: false, final_lp: 0.0, final_gsh: 0.0, final_gpx4: 0.0,
+            dead: false,
+            final_lp: 0.0,
+            final_gsh: 0.0,
+            final_gpx4: 0.0,
         };
     }
 

--- a/simulations/ferroptosis-python/src/lib.rs
+++ b/simulations/ferroptosis-python/src/lib.rs
@@ -90,7 +90,10 @@ fn params_to_dict(py: Python<'_>, params: &Params) -> PyResult<Py<PyDict>> {
     dict.set_item("pdt_ros", params.pdt_ros)?;
     dict.set_item("rsl3_gpx4_inhib", params.rsl3_gpx4_inhib)?;
     dict.set_item("gsh_max", params.gsh_max)?;
-    dict.set_item("gpx4_nrf2_target_multiplier", params.gpx4_nrf2_target_multiplier)?;
+    dict.set_item(
+        "gpx4_nrf2_target_multiplier",
+        params.gpx4_nrf2_target_multiplier,
+    )?;
     dict.set_item("death_threshold", params.death_threshold)?;
     Ok(dict.into())
 }
@@ -110,13 +113,33 @@ fn validate_params(params: &Params) -> PyResult<()> {
         ("sdt_ros", params.sdt_ros, 0.0, 100.0),
         ("pdt_ros", params.pdt_ros, 0.0, 100.0),
         ("nrf2_gsh_rate", params.nrf2_gsh_rate, 0.0, 10.0),
-        ("gpx4_degradation_by_ros", params.gpx4_degradation_by_ros, 0.0, 1.0),
-        ("gpx4_nrf2_upregulation", params.gpx4_nrf2_upregulation, 0.0, 1.0),
-        ("gpx4_nrf2_target_multiplier", params.gpx4_nrf2_target_multiplier, 0.0, 100.0),
+        (
+            "gpx4_degradation_by_ros",
+            params.gpx4_degradation_by_ros,
+            0.0,
+            1.0,
+        ),
+        (
+            "gpx4_nrf2_upregulation",
+            params.gpx4_nrf2_upregulation,
+            0.0,
+            1.0,
+        ),
+        (
+            "gpx4_nrf2_target_multiplier",
+            params.gpx4_nrf2_target_multiplier,
+            0.0,
+            100.0,
+        ),
         ("scd_mufa_rate", params.scd_mufa_rate, 0.0, 1.0),
         ("scd_mufa_max", params.scd_mufa_max, 0.0, 1.0),
         ("scd_mufa_decay", params.scd_mufa_decay, 0.0, 1.0),
-        ("initial_mufa_protection", params.initial_mufa_protection, 0.0, 1.0),
+        (
+            "initial_mufa_protection",
+            params.initial_mufa_protection,
+            0.0,
+            1.0,
+        ),
     ];
     for (name, val, lo, hi) in checks {
         if *val < *lo || *val > *hi {

--- a/simulations/sim-combo-mech/src/main.rs
+++ b/simulations/sim-combo-mech/src/main.rs
@@ -265,24 +265,47 @@ fn main() {
 
     // Control (no drugs)
     let cr = run_condition(&[], &params, phenotype, N_CELLS, seed);
-    eprintln!("  Control: {:.1}% ({}/{})", cr.death_rate * 100.0, cr.n_dead, N_CELLS);
+    eprintln!(
+        "  Control: {:.1}% ({}/{})",
+        cr.death_rate * 100.0,
+        cr.n_dead,
+        N_CELLS
+    );
     single_rates.push(("Control".to_string(), cr.death_rate));
     single_results.push(SingleResult {
-        drug: "Control".to_string(), death_rate: cr.death_rate, ci_low: cr.ci_low,
-        ci_high: cr.ci_high, n_dead: cr.n_dead, n_cells: N_CELLS,
-        mean_gpx4_final: cr.pathway.mean_gpx4_final, mean_fsp1_final: cr.pathway.mean_fsp1_final,
-        mean_gsh_final: cr.pathway.mean_gsh_final, mean_lp_final: cr.pathway.mean_lp_final,
+        drug: "Control".to_string(),
+        death_rate: cr.death_rate,
+        ci_low: cr.ci_low,
+        ci_high: cr.ci_high,
+        n_dead: cr.n_dead,
+        n_cells: N_CELLS,
+        mean_gpx4_final: cr.pathway.mean_gpx4_final,
+        mean_fsp1_final: cr.pathway.mean_fsp1_final,
+        mean_gsh_final: cr.pathway.mean_gsh_final,
+        mean_lp_final: cr.pathway.mean_lp_final,
     });
 
     for drug in &drugs {
         let cr = run_condition(&[drug], &params, phenotype, N_CELLS, seed);
-        eprintln!("  {}: {:.1}% ({}/{})", drug.name, cr.death_rate * 100.0, cr.n_dead, N_CELLS);
+        eprintln!(
+            "  {}: {:.1}% ({}/{})",
+            drug.name,
+            cr.death_rate * 100.0,
+            cr.n_dead,
+            N_CELLS
+        );
         single_rates.push((drug.name.to_string(), cr.death_rate));
         single_results.push(SingleResult {
-            drug: drug.name.to_string(), death_rate: cr.death_rate, ci_low: cr.ci_low,
-            ci_high: cr.ci_high, n_dead: cr.n_dead, n_cells: N_CELLS,
-            mean_gpx4_final: cr.pathway.mean_gpx4_final, mean_fsp1_final: cr.pathway.mean_fsp1_final,
-            mean_gsh_final: cr.pathway.mean_gsh_final, mean_lp_final: cr.pathway.mean_lp_final,
+            drug: drug.name.to_string(),
+            death_rate: cr.death_rate,
+            ci_low: cr.ci_low,
+            ci_high: cr.ci_high,
+            n_dead: cr.n_dead,
+            n_cells: N_CELLS,
+            mean_gpx4_final: cr.pathway.mean_gpx4_final,
+            mean_fsp1_final: cr.pathway.mean_fsp1_final,
+            mean_gsh_final: cr.pathway.mean_gsh_final,
+            mean_lp_final: cr.pathway.mean_lp_final,
         });
     }
 
@@ -323,9 +346,12 @@ fn main() {
 
             eprintln!(
                 "{:<12} {:<12} {:>7.1}% {:>7.1}% {:>7.1}% {:>7.1}% {:>8.2}",
-                drug_a.name, drug_b.name,
-                rate_a * 100.0, rate_b * 100.0,
-                cr.death_rate * 100.0, bliss * 100.0,
+                drug_a.name,
+                drug_b.name,
+                rate_a * 100.0,
+                rate_b * 100.0,
+                cr.death_rate * 100.0,
+                bliss * 100.0,
                 synergy,
             );
 
@@ -391,8 +417,12 @@ fn main() {
         };
         eprintln!(
             "  {} + {}: synergy={:.2} ({}) — actual {:.1}% vs Bliss {:.1}%",
-            r.drug_a, r.drug_b, r.synergy_score, label,
-            r.rate_combo * 100.0, r.bliss_prediction * 100.0,
+            r.drug_a,
+            r.drug_b,
+            r.synergy_score,
+            label,
+            r.rate_combo * 100.0,
+            r.bliss_prediction * 100.0,
         );
     }
 

--- a/simulations/sim-combo/src/main.rs
+++ b/simulations/sim-combo/src/main.rs
@@ -78,11 +78,13 @@ fn main() {
                     .into_par_iter()
                     .map(|i| {
                         let mut cell_rng = StdRng::seed_from_u64(
-                            args.seed.wrapping_add(i as u64 * 2)
+                            args.seed
+                                .wrapping_add(i as u64 * 2)
                                 .wrapping_add(delay_days as u64 * 1_000_000),
                         );
                         let mut sim_rng = StdRng::seed_from_u64(
-                            args.seed.wrapping_add(i as u64 * 2 + 1)
+                            args.seed
+                                .wrapping_add(i as u64 * 2 + 1)
                                 .wrapping_add(delay_days as u64 * 1_000_000),
                         );
                         let cell = gen_recovered_persister(delay_days, &recovery, &mut cell_rng);
@@ -101,8 +103,10 @@ fn main() {
                 // Phase 3: immune cascade
                 // Scale dead_cell_lps to the biological population size (not simulation sample size)
                 // to avoid saturating the immune cascade with 50K entries against 1K tumor cells.
-                let ferroptosis_killed = (ferroptosis_kill_rate * initial_tumor_cells as f64).round() as usize;
-                let scaled_dead_lps: Vec<f64> = dead_cell_lps.iter()
+                let ferroptosis_killed =
+                    (ferroptosis_kill_rate * initial_tumor_cells as f64).round() as usize;
+                let scaled_dead_lps: Vec<f64> = dead_cell_lps
+                    .iter()
                     .take(ferroptosis_killed)
                     .copied()
                     .collect();
@@ -152,15 +156,13 @@ fn main() {
     }
 
     // Find optimal schedule
-    let best = all_results
-        .iter()
-        .min_by(|a, b| {
-            a["survival_fraction"]
-                .as_f64()
-                .unwrap()
-                .partial_cmp(&b["survival_fraction"].as_f64().unwrap())
-                .unwrap()
-        });
+    let best = all_results.iter().min_by(|a, b| {
+        a["survival_fraction"]
+            .as_f64()
+            .unwrap()
+            .partial_cmp(&b["survival_fraction"].as_f64().unwrap())
+            .unwrap()
+    });
 
     if let Some(best) = best {
         eprintln!("=== Optimal Schedule ===");
@@ -168,7 +170,11 @@ fn main() {
             "  {} at day {:.0} {}: {:.1}% survival ({} survivors / {})",
             best["treatment"],
             best["sdt_delay_days"].as_f64().unwrap(),
-            if best["with_anti_pd1"].as_bool().unwrap() { "+ anti-PD1" } else { "" },
+            if best["with_anti_pd1"].as_bool().unwrap() {
+                "+ anti-PD1"
+            } else {
+                ""
+            },
             best["survival_fraction"].as_f64().unwrap() * 100.0,
             best["survivors"],
             best["initial_tumor_cells"],

--- a/simulations/sim-icd/src/main.rs
+++ b/simulations/sim-icd/src/main.rs
@@ -19,7 +19,10 @@ use ferroptosis_core::io::write_json;
 use ferroptosis_core::params::{ImmuneParams, Params};
 
 #[derive(Parser)]
-#[command(name = "sim-icd", about = "ICD-immune cascade comparison across treatments")]
+#[command(
+    name = "sim-icd",
+    about = "ICD-immune cascade comparison across treatments"
+)]
 struct Args {
     /// Cells per condition.
     #[arg(long, default_value_t = 100_000)]
@@ -71,7 +74,8 @@ fn main() {
                 .into_par_iter()
                 .map(|i| {
                     let mut cell_rng = StdRng::seed_from_u64(args.seed.wrapping_add(i as u64 * 2));
-                    let mut sim_rng = StdRng::seed_from_u64(args.seed.wrapping_add(i as u64 * 2 + 1));
+                    let mut sim_rng =
+                        StdRng::seed_from_u64(args.seed.wrapping_add(i as u64 * 2 + 1));
                     let cell = gen_cell(*pheno, &mut cell_rng);
                     sim_cell(&cell, *tx, &params, &mut sim_rng)
                 })
@@ -140,15 +144,19 @@ fn main() {
 
     eprintln!("=== Key Finding ===");
     // Compare SDT vs RSL3 DAMP per dead cell for persisters
-    let sdt_result = all_results.iter().find(|r| {
-        r["phenotype"] == "Persister" && r["treatment"] == "SDT"
-    });
-    let rsl3_result = all_results.iter().find(|r| {
-        r["phenotype"] == "Persister" && r["treatment"] == "RSL3"
-    });
+    let sdt_result = all_results
+        .iter()
+        .find(|r| r["phenotype"] == "Persister" && r["treatment"] == "SDT");
+    let rsl3_result = all_results
+        .iter()
+        .find(|r| r["phenotype"] == "Persister" && r["treatment"] == "RSL3");
     if let (Some(sdt), Some(rsl3)) = (sdt_result, rsl3_result) {
-        let sdt_damp = sdt["immune_no_pd1"]["damp_per_dead_cell"].as_f64().unwrap_or(0.0);
-        let rsl3_damp = rsl3["immune_no_pd1"]["damp_per_dead_cell"].as_f64().unwrap_or(0.0);
+        let sdt_damp = sdt["immune_no_pd1"]["damp_per_dead_cell"]
+            .as_f64()
+            .unwrap_or(0.0);
+        let rsl3_damp = rsl3["immune_no_pd1"]["damp_per_dead_cell"]
+            .as_f64()
+            .unwrap_or(0.0);
         if rsl3_damp > 0.0 {
             eprintln!(
                 "SDT produces {:.1}× more DAMP per dead cell than RSL3 ({:.1} vs {:.1})",
@@ -157,8 +165,12 @@ fn main() {
                 rsl3_damp,
             );
         }
-        let sdt_kills = sdt["immune_with_pd1"]["immune_kills"].as_f64().unwrap_or(0.0);
-        let rsl3_kills = rsl3["immune_with_pd1"]["immune_kills"].as_f64().unwrap_or(0.0);
+        let sdt_kills = sdt["immune_with_pd1"]["immune_kills"]
+            .as_f64()
+            .unwrap_or(0.0);
+        let rsl3_kills = rsl3["immune_with_pd1"]["immune_kills"]
+            .as_f64()
+            .unwrap_or(0.0);
         eprintln!(
             "SDT+anti-PD1 immune kills: {:.0} vs RSL3+anti-PD1: {:.0}",
             sdt_kills, rsl3_kills,

--- a/simulations/sim-invivo/src/main.rs
+++ b/simulations/sim-invivo/src/main.rs
@@ -17,17 +17,20 @@
 use std::path::PathBuf;
 
 use clap::Parser;
-use rayon::prelude::*;
 use rand::prelude::*;
+use rayon::prelude::*;
 use serde::Serialize;
 
-use ferroptosis_core::cell::{gen_cell, Phenotype, Treatment};
 use ferroptosis_core::biochem::sim_cell;
+use ferroptosis_core::cell::{gen_cell, Phenotype, Treatment};
 use ferroptosis_core::params::Params;
 use ferroptosis_core::stats::wilson_ci;
 
 #[derive(Parser)]
-#[command(name = "sim-invivo", about = "2D vs in-vivo ferroptosis with SCD1/MUFA lipid remodeling")]
+#[command(
+    name = "sim-invivo",
+    about = "2D vs in-vivo ferroptosis with SCD1/MUFA lipid remodeling"
+)]
 struct Args {
     /// Cells per condition for the main comparison.
     #[arg(long, default_value_t = 100_000)]
@@ -108,7 +111,12 @@ fn run_context(
 
             eprintln!(
                 "  [{:<12}] {:<20} + {:<8} → Death: {:7.3}% [{:.3}-{:.3}]",
-                context_name, pname, tname, rate * 100.0, ci_lo * 100.0, ci_hi * 100.0,
+                context_name,
+                pname,
+                tname,
+                rate * 100.0,
+                ci_lo * 100.0,
+                ci_hi * 100.0,
             );
 
             results.push(ComparisonResult {
@@ -171,26 +179,54 @@ fn main() {
     };
 
     eprintln!("--- Context: 2D (MUFA off, scd_mufa_rate=0) ---");
-    let results_2d = run_context("2d", &params_2d, &phenotypes, &treatments, args.n_cells, args.seed);
+    let results_2d = run_context(
+        "2d",
+        &params_2d,
+        &phenotypes,
+        &treatments,
+        args.n_cells,
+        args.seed,
+    );
 
-    eprintln!("--- Context: In-Vivo (MUFA on, rate={}, max={}) ---", params_invivo.scd_mufa_rate, params_invivo.scd_mufa_max);
-    let results_invivo = run_context("invivo", &params_invivo, &phenotypes, &treatments, args.n_cells, args.seed);
+    eprintln!(
+        "--- Context: In-Vivo (MUFA on, rate={}, max={}) ---",
+        params_invivo.scd_mufa_rate, params_invivo.scd_mufa_max
+    );
+    let results_invivo = run_context(
+        "invivo",
+        &params_invivo,
+        &phenotypes,
+        &treatments,
+        args.n_cells,
+        args.seed,
+    );
 
     eprintln!("--- Context: In-Vivo + SCD1i (MUFA off, scd_mufa_rate=0) ---");
-    let results_scd1i = run_context("invivo+scd1i", &params_scd1i, &phenotypes, &treatments, args.n_cells, args.seed);
+    let results_scd1i = run_context(
+        "invivo+scd1i",
+        &params_scd1i,
+        &phenotypes,
+        &treatments,
+        args.n_cells,
+        args.seed,
+    );
 
     // ============================================================
     // Part 2: Protection factor analysis
     // ============================================================
     eprintln!("=== Protection Factors (2D death rate / in-vivo death rate) ===\n");
-    eprintln!("  {:<20} {:<8} {:>10} {:>10} {:>10} {:>10}",
-             "Phenotype", "Tx", "2D %", "InVivo %", "SCD1i %", "Prot.Fac.");
+    eprintln!(
+        "  {:<20} {:<8} {:>10} {:>10} {:>10} {:>10}",
+        "Phenotype", "Tx", "2D %", "InVivo %", "SCD1i %", "Prot.Fac."
+    );
 
     for r2d in &results_2d {
-        let riv = results_invivo.iter()
+        let riv = results_invivo
+            .iter()
             .find(|r| r.phenotype == r2d.phenotype && r.treatment == r2d.treatment)
             .unwrap();
-        let rs = results_scd1i.iter()
+        let rs = results_scd1i
+            .iter()
             .find(|r| r.phenotype == r2d.phenotype && r.treatment == r2d.treatment)
             .unwrap();
 
@@ -202,9 +238,15 @@ fn main() {
             1.0
         };
 
-        eprintln!("  {:<20} {:<8} {:>9.2}% {:>9.2}% {:>9.2}% {:>10.2}×",
-                 r2d.phenotype, r2d.treatment,
-                 r2d.death_rate * 100.0, riv.death_rate * 100.0, rs.death_rate * 100.0, pf);
+        eprintln!(
+            "  {:<20} {:<8} {:>9.2}% {:>9.2}% {:>9.2}% {:>10.2}×",
+            r2d.phenotype,
+            r2d.treatment,
+            r2d.death_rate * 100.0,
+            riv.death_rate * 100.0,
+            rs.death_rate * 100.0,
+            pf
+        );
     }
 
     // ============================================================
@@ -212,26 +254,61 @@ fn main() {
     // ============================================================
     eprintln!("\n=== Key Biological Predictions ===\n");
 
-    let pers_rsl3_2d = results_2d.iter().find(|r| r.phenotype.contains("Persister (") && r.treatment == "RSL3").unwrap();
-    let pers_rsl3_iv = results_invivo.iter().find(|r| r.phenotype.contains("Persister (") && r.treatment == "RSL3").unwrap();
-    let pers_sdt_2d = results_2d.iter().find(|r| r.phenotype.contains("Persister (") && r.treatment == "SDT").unwrap();
-    let pers_sdt_iv = results_invivo.iter().find(|r| r.phenotype.contains("Persister (") && r.treatment == "SDT").unwrap();
-    let pers_rsl3_s = results_scd1i.iter().find(|r| r.phenotype.contains("Persister (") && r.treatment == "RSL3").unwrap();
+    let pers_rsl3_2d = results_2d
+        .iter()
+        .find(|r| r.phenotype.contains("Persister (") && r.treatment == "RSL3")
+        .unwrap();
+    let pers_rsl3_iv = results_invivo
+        .iter()
+        .find(|r| r.phenotype.contains("Persister (") && r.treatment == "RSL3")
+        .unwrap();
+    let pers_sdt_2d = results_2d
+        .iter()
+        .find(|r| r.phenotype.contains("Persister (") && r.treatment == "SDT")
+        .unwrap();
+    let pers_sdt_iv = results_invivo
+        .iter()
+        .find(|r| r.phenotype.contains("Persister (") && r.treatment == "SDT")
+        .unwrap();
+    let pers_rsl3_s = results_scd1i
+        .iter()
+        .find(|r| r.phenotype.contains("Persister (") && r.treatment == "RSL3")
+        .unwrap();
 
     let dixon_pred = pers_rsl3_iv.death_rate < pers_rsl3_2d.death_rate * 0.5;
-    eprintln!("  Dixon 2025 (RSL3 fails in vivo): 2D={:.1}% → InVivo={:.1}% — {}",
-             pers_rsl3_2d.death_rate * 100.0, pers_rsl3_iv.death_rate * 100.0,
-             if dixon_pred { "CONFIRMED" } else { "NOT CONFIRMED" });
+    eprintln!(
+        "  Dixon 2025 (RSL3 fails in vivo): 2D={:.1}% → InVivo={:.1}% — {}",
+        pers_rsl3_2d.death_rate * 100.0,
+        pers_rsl3_iv.death_rate * 100.0,
+        if dixon_pred {
+            "CONFIRMED"
+        } else {
+            "NOT CONFIRMED"
+        }
+    );
 
     let sdt_survives = pers_sdt_iv.death_rate > 0.50;
-    eprintln!("  SDT survives MUFA defense: InVivo={:.1}% — {}",
-             pers_sdt_iv.death_rate * 100.0,
-             if sdt_survives { "YES (>50% kill)" } else { "WEAKENED (<50% kill)" });
+    eprintln!(
+        "  SDT survives MUFA defense: InVivo={:.1}% — {}",
+        pers_sdt_iv.death_rate * 100.0,
+        if sdt_survives {
+            "YES (>50% kill)"
+        } else {
+            "WEAKENED (<50% kill)"
+        }
+    );
 
     let scd1i_resens = pers_rsl3_s.death_rate > pers_rsl3_iv.death_rate * 1.5;
-    eprintln!("  SCD1i resensitizes (Tesfay 2019): InVivo={:.1}% → SCD1i={:.1}% — {}",
-             pers_rsl3_iv.death_rate * 100.0, pers_rsl3_s.death_rate * 100.0,
-             if scd1i_resens { "CONFIRMED" } else { "NOT CONFIRMED" });
+    eprintln!(
+        "  SCD1i resensitizes (Tesfay 2019): InVivo={:.1}% → SCD1i={:.1}% — {}",
+        pers_rsl3_iv.death_rate * 100.0,
+        pers_rsl3_s.death_rate * 100.0,
+        if scd1i_resens {
+            "CONFIRMED"
+        } else {
+            "NOT CONFIRMED"
+        }
+    );
 
     // ============================================================
     // Part 4: MUFA parameter sweep (Persister × SDT and RSL3)
@@ -247,20 +324,15 @@ fn main() {
     let maxes = [0.20, 0.30, 0.40, 0.50, 0.60];
     let decay = params_invivo.scd_mufa_decay;
 
-    let sweep_treatments: [(Treatment, &str); 2] = [
-        (Treatment::SDT, "SDT"),
-        (Treatment::RSL3, "RSL3"),
-    ];
+    let sweep_treatments: [(Treatment, &str); 2] =
+        [(Treatment::SDT, "SDT"), (Treatment::RSL3, "RSL3")];
 
     let baseline_sdt = pers_sdt_2d.death_rate;
     let baseline_rsl3 = pers_rsl3_2d.death_rate;
 
     let mut sweep_results: Vec<SweepResult> = Vec::new();
 
-    let sweep_modes: [(&str, bool); 2] = [
-        ("onset (mufa=0)", false),
-        ("steady-state", true),
-    ];
+    let sweep_modes: [(&str, bool); 2] = [("onset (mufa=0)", false), ("steady-state", true)];
 
     for (mode_label, use_steady_state) in &sweep_modes {
         eprintln!("=== Sweep mode: {} ===\n", mode_label);
@@ -273,8 +345,23 @@ fn main() {
             };
 
             eprintln!("--- Persister + {} ({}) ---", sweep_tx_name, mode_label);
-            eprintln!("  {:>8} | {}", "rate\\max", maxes.iter().map(|m| format!("{:>8.2}", m)).collect::<Vec<_>>().join(" | "));
-            eprintln!("  ---------+-{}", maxes.iter().map(|_| "----------").collect::<Vec<_>>().join("-+-"));
+            eprintln!(
+                "  {:>8} | {}",
+                "rate\\max",
+                maxes
+                    .iter()
+                    .map(|m| format!("{:>8.2}", m))
+                    .collect::<Vec<_>>()
+                    .join(" | ")
+            );
+            eprintln!(
+                "  ---------+-{}",
+                maxes
+                    .iter()
+                    .map(|_| "----------")
+                    .collect::<Vec<_>>()
+                    .join("-+-")
+            );
 
             for &rate in &rates {
                 let mut row_strs = Vec::new();
@@ -295,8 +382,10 @@ fn main() {
                     let outcomes: Vec<(bool, f64, f64, f64)> = (0..n)
                         .into_par_iter()
                         .map(|i| {
-                            let mut cell_rng = StdRng::seed_from_u64(args.seed.wrapping_add(i as u64 * 2));
-                            let mut sim_rng = StdRng::seed_from_u64(args.seed.wrapping_add(i as u64 * 2 + 1));
+                            let mut cell_rng =
+                                StdRng::seed_from_u64(args.seed.wrapping_add(i as u64 * 2));
+                            let mut sim_rng =
+                                StdRng::seed_from_u64(args.seed.wrapping_add(i as u64 * 2 + 1));
                             let cell = gen_cell(Phenotype::Persister, &mut cell_rng);
                             sim_cell(&cell, *sweep_tx, &p, &mut sim_rng)
                         })
@@ -305,7 +394,11 @@ fn main() {
                     let dead = outcomes.iter().filter(|(d, _, _, _)| *d).count();
                     let dr = dead as f64 / n as f64;
                     let (ci_lo, ci_hi) = wilson_ci(n, dead);
-                    let pf = if dr > 0.0001 { baseline / dr } else { f64::INFINITY };
+                    let pf = if dr > 0.0001 {
+                        baseline / dr
+                    } else {
+                        f64::INFINITY
+                    };
 
                     row_strs.push(format!("{:>7.1}%", dr * 100.0));
                     sweep_results.push(SweepResult {

--- a/simulations/sim-original/src/main.rs
+++ b/simulations/sim-original/src/main.rs
@@ -34,9 +34,17 @@ fn main() {
     for (pheno, pname) in &phenotypes {
         for (tx, tname) in &treatments {
             let r = run_condition(*pheno, *tx, &params, n, pname, tname);
-            eprintln!("{:<20} + {:<8} → Death: {:7.3}% [{:.3}-{:.3}]  LP:{:.3} GSH:{:.2} GPX4:{:.3}",
-                     pname, tname, r.death_rate*100.0, r.ci_low*100.0, r.ci_high*100.0,
-                     r.mean_lipid_perox, r.mean_gsh_final, r.mean_gpx4_final);
+            eprintln!(
+                "{:<20} + {:<8} → Death: {:7.3}% [{:.3}-{:.3}]  LP:{:.3} GSH:{:.2} GPX4:{:.3}",
+                pname,
+                tname,
+                r.death_rate * 100.0,
+                r.ci_low * 100.0,
+                r.ci_high * 100.0,
+                r.mean_lipid_perox,
+                r.mean_gsh_final,
+                r.mean_gpx4_final
+            );
             results.push(r);
         }
         eprintln!();
@@ -48,28 +56,59 @@ fn main() {
     let mut v1_pass = true;
     for r in results.iter().filter(|r| r.treatment == "Control") {
         let ok = r.death_rate < 0.02;
-        eprintln!("  Baseline {}: {:.3}% — {}", r.phenotype, r.death_rate*100.0,
-                 if ok { "PASS" } else { "FAIL ⚠" });
-        if !ok { v1_pass = false; }
+        eprintln!(
+            "  Baseline {}: {:.3}% — {}",
+            r.phenotype,
+            r.death_rate * 100.0,
+            if ok { "PASS" } else { "FAIL ⚠" }
+        );
+        if !ok {
+            v1_pass = false;
+        }
     }
 
-    let rsl3_pers = results.iter().find(|r| r.phenotype.contains("Persister (") && r.treatment == "RSL3").unwrap();
+    let rsl3_pers = results
+        .iter()
+        .find(|r| r.phenotype.contains("Persister (") && r.treatment == "RSL3")
+        .unwrap();
     let v2_pass = rsl3_pers.death_rate > 0.05;
-    eprintln!("  RSL3 kills persisters: {:.2}% — {}", rsl3_pers.death_rate*100.0,
-             if v2_pass { "PASS (>5%)" } else { "FAIL ⚠ (should match Higuchi)" });
+    eprintln!(
+        "  RSL3 kills persisters: {:.2}% — {}",
+        rsl3_pers.death_rate * 100.0,
+        if v2_pass {
+            "PASS (>5%)"
+        } else {
+            "FAIL ⚠ (should match Higuchi)"
+        }
+    );
 
-    let sdt_pers = results.iter().find(|r| r.phenotype.contains("Persister (") && r.treatment == "SDT").unwrap();
-    let ctrl_pers = results.iter().find(|r| r.phenotype.contains("Persister (") && r.treatment == "Control").unwrap();
+    let sdt_pers = results
+        .iter()
+        .find(|r| r.phenotype.contains("Persister (") && r.treatment == "SDT")
+        .unwrap();
+    let ctrl_pers = results
+        .iter()
+        .find(|r| r.phenotype.contains("Persister (") && r.treatment == "Control")
+        .unwrap();
     let v3_pass = sdt_pers.death_rate > ctrl_pers.death_rate + 0.01;
-    eprintln!("  SDT > Control for persisters: {:.2}% vs {:.2}% — {}",
-             sdt_pers.death_rate*100.0, ctrl_pers.death_rate*100.0,
-             if v3_pass { "PASS" } else { "FAIL ⚠" });
+    eprintln!(
+        "  SDT > Control for persisters: {:.2}% vs {:.2}% — {}",
+        sdt_pers.death_rate * 100.0,
+        ctrl_pers.death_rate * 100.0,
+        if v3_pass { "PASS" } else { "FAIL ⚠" }
+    );
 
-    let nrf2_sdt = results.iter().find(|r| r.phenotype.contains("NRF2") && r.treatment == "SDT").unwrap();
+    let nrf2_sdt = results
+        .iter()
+        .find(|r| r.phenotype.contains("NRF2") && r.treatment == "SDT")
+        .unwrap();
     let v4_pass = nrf2_sdt.death_rate < sdt_pers.death_rate;
-    eprintln!("  NRF2 protects vs SDT: {:.2}% vs {:.2}% — {}",
-             nrf2_sdt.death_rate*100.0, sdt_pers.death_rate*100.0,
-             if v4_pass { "PASS" } else { "FAIL ⚠" });
+    eprintln!(
+        "  NRF2 protects vs SDT: {:.2}% vs {:.2}% — {}",
+        nrf2_sdt.death_rate * 100.0,
+        sdt_pers.death_rate * 100.0,
+        if v4_pass { "PASS" } else { "FAIL ⚠" }
+    );
 
     if v1_pass && v2_pass && v3_pass && v4_pass {
         eprintln!("\n  ALL VALIDATIONS PASSED ✓");
@@ -80,27 +119,74 @@ fn main() {
     // === COMPARISONS ===
     eprintln!("\n=== Key Comparisons ===");
     for tx_name in ["RSL3", "SDT", "PDT"] {
-        let g = results.iter().find(|r| r.phenotype == "Glycolytic" && r.treatment == tx_name).unwrap();
-        let p = results.iter().find(|r| r.phenotype.contains("Persister (") && r.treatment == tx_name).unwrap();
-        let rr = if g.death_rate > 0.0001 { p.death_rate / g.death_rate } else { f64::NAN };
-        eprintln!("  {}: Persister {:.2}% vs Glycolytic {:.2}% (RR={:.1}×)",
-                 tx_name, p.death_rate*100.0, g.death_rate*100.0, rr);
+        let g = results
+            .iter()
+            .find(|r| r.phenotype == "Glycolytic" && r.treatment == tx_name)
+            .unwrap();
+        let p = results
+            .iter()
+            .find(|r| r.phenotype.contains("Persister (") && r.treatment == tx_name)
+            .unwrap();
+        let rr = if g.death_rate > 0.0001 {
+            p.death_rate / g.death_rate
+        } else {
+            f64::NAN
+        };
+        eprintln!(
+            "  {}: Persister {:.2}% vs Glycolytic {:.2}% (RR={:.1}×)",
+            tx_name,
+            p.death_rate * 100.0,
+            g.death_rate * 100.0,
+            rr
+        );
     }
 
-    let sdt = results.iter().find(|r| r.phenotype.contains("Persister (") && r.treatment == "SDT").unwrap();
-    let rsl3 = results.iter().find(|r| r.phenotype.contains("Persister (") && r.treatment == "RSL3").unwrap();
-    eprintln!("  Persister: SDT {:.2}% vs RSL3 {:.2}%", sdt.death_rate*100.0, rsl3.death_rate*100.0);
+    let sdt = results
+        .iter()
+        .find(|r| r.phenotype.contains("Persister (") && r.treatment == "SDT")
+        .unwrap();
+    let rsl3 = results
+        .iter()
+        .find(|r| r.phenotype.contains("Persister (") && r.treatment == "RSL3")
+        .unwrap();
+    eprintln!(
+        "  Persister: SDT {:.2}% vs RSL3 {:.2}%",
+        sdt.death_rate * 100.0,
+        rsl3.death_rate * 100.0
+    );
 
-    let pdt = results.iter().find(|r| r.phenotype.contains("Persister (") && r.treatment == "PDT").unwrap();
-    eprintln!("  Persister: SDT {:.2}% vs PDT {:.2}% (expected similar)", sdt.death_rate*100.0, pdt.death_rate*100.0);
+    let pdt = results
+        .iter()
+        .find(|r| r.phenotype.contains("Persister (") && r.treatment == "PDT")
+        .unwrap();
+    eprintln!(
+        "  Persister: SDT {:.2}% vs PDT {:.2}% (expected similar)",
+        sdt.death_rate * 100.0,
+        pdt.death_rate * 100.0
+    );
 
     eprintln!("\n=== NRF2 Compensation ===");
     for tx_name in ["RSL3", "SDT"] {
-        let p = results.iter().find(|r| r.phenotype.contains("Persister (") && r.treatment == tx_name).unwrap();
-        let n = results.iter().find(|r| r.phenotype.contains("NRF2") && r.treatment == tx_name).unwrap();
-        let prot = if p.death_rate > 0.001 { (1.0 - n.death_rate / p.death_rate) * 100.0 } else { 0.0 };
-        eprintln!("  {}: NRF2 protection = {:.1}% ({:.2}% → {:.2}%)",
-                 tx_name, prot, p.death_rate*100.0, n.death_rate*100.0);
+        let p = results
+            .iter()
+            .find(|r| r.phenotype.contains("Persister (") && r.treatment == tx_name)
+            .unwrap();
+        let n = results
+            .iter()
+            .find(|r| r.phenotype.contains("NRF2") && r.treatment == tx_name)
+            .unwrap();
+        let prot = if p.death_rate > 0.001 {
+            (1.0 - n.death_rate / p.death_rate) * 100.0
+        } else {
+            0.0
+        };
+        eprintln!(
+            "  {}: NRF2 protection = {:.1}% ({:.2}% → {:.2}%)",
+            tx_name,
+            prot,
+            p.death_rate * 100.0,
+            n.death_rate * 100.0
+        );
     }
 
     // === SENSITIVITY ANALYSIS ===
@@ -108,9 +194,17 @@ fn main() {
     eprintln!("Perturbing each parameter ±50%, testing Persister > Glycolytic under SDT:\n");
 
     let param_names = [
-        "fenton_rate", "gsh_scav", "lp_rate", "lp_propagation",
-        "gpx4_rate", "fsp1_rate", "nrf2_gsh", "gpx4_degrad",
-        "death_threshold", "sdt_ros", "rsl3_inhib",
+        "fenton_rate",
+        "gsh_scav",
+        "lp_rate",
+        "lp_propagation",
+        "gpx4_rate",
+        "fsp1_rate",
+        "nrf2_gsh",
+        "gpx4_degrad",
+        "death_threshold",
+        "sdt_ros",
+        "rsl3_inhib",
     ];
 
     let n_sens = 100_000;
@@ -135,18 +229,36 @@ fn main() {
                 _ => {}
             }
 
-            let g = run_condition(Phenotype::Glycolytic, Treatment::SDT, &p, n_sens, "G", "SDT");
+            let g = run_condition(
+                Phenotype::Glycolytic,
+                Treatment::SDT,
+                &p,
+                n_sens,
+                "G",
+                "SDT",
+            );
             let pe = run_condition(Phenotype::Persister, Treatment::SDT, &p, n_sens, "P", "SDT");
             let holds = pe.death_rate > g.death_rate;
-            if holds { holds_count += 1; }
+            if holds {
+                holds_count += 1;
+            }
 
-            eprintln!("  {} ×{:.1}: P={:.2}% G={:.2}% — {}",
-                     pname, mult, pe.death_rate*100.0, g.death_rate*100.0,
-                     if holds { "HOLDS" } else { "FAILS ⚠" });
+            eprintln!(
+                "  {} ×{:.1}: P={:.2}% G={:.2}% — {}",
+                pname,
+                mult,
+                pe.death_rate * 100.0,
+                g.death_rate * 100.0,
+                if holds { "HOLDS" } else { "FAILS ⚠" }
+            );
         }
     }
-    eprintln!("\n  Result holds in {}/{} conditions ({:.0}%)",
-             holds_count, total_tests, holds_count as f64 / total_tests as f64 * 100.0);
+    eprintln!(
+        "\n  Result holds in {}/{} conditions ({:.0}%)",
+        holds_count,
+        total_tests,
+        holds_count as f64 / total_tests as f64 * 100.0
+    );
 
     // Save
     let json = serde_json::to_string_pretty(&results).unwrap();

--- a/simulations/sim-spatial/src/main.rs
+++ b/simulations/sim-spatial/src/main.rs
@@ -14,7 +14,7 @@ use rand::prelude::*;
 
 use ferroptosis_core::biochem::{sim_cell_step, CellState};
 use ferroptosis_core::cell::{norm, Treatment};
-use ferroptosis_core::grid::{depth_kill_curve, death_heatmap, TumorGrid};
+use ferroptosis_core::grid::{death_heatmap, depth_kill_curve, TumorGrid};
 use ferroptosis_core::io::{write_depth_curves_csv, write_heatmap_csv, write_json};
 use ferroptosis_core::params::{Params, SpatialParams};
 use ferroptosis_core::photosensitizer_pk::{validate_dli_h, Photosensitizer};
@@ -79,7 +79,6 @@ struct Args {
     dli_h: f64,
 }
 
-
 fn run_spatial(
     grid: &mut TumorGrid,
     tx: Treatment,
@@ -129,7 +128,9 @@ fn run_spatial(
                 }
                 if grid.cells[idx].state.dead {
                     if let Some(ds) = grid.cells[idx].state.death_step {
-                        if step >= ds + params.post_death_steps { continue; }
+                        if step >= ds + params.post_death_steps {
+                            continue;
+                        }
                     } else {
                         continue;
                     }
@@ -147,14 +148,8 @@ fn run_spatial(
                 grid.cells[idx].extra_iron = 0.0;
 
                 let gc = &mut grid.cells[idx];
-                let died = sim_cell_step(
-                    &mut gc.state,
-                    &gc.cell,
-                    params,
-                    step,
-                    extra_iron,
-                    &mut rng,
-                );
+                let died =
+                    sim_cell_step(&mut gc.state, &gc.cell, params, step, extra_iron, &mut rng);
 
                 if died {
                     gc.newly_dead = true;
@@ -244,7 +239,8 @@ fn main() {
         eprintln!("--- Treatment: {} ---", tx_name);
 
         // Generate fresh grid for each treatment (same seed = same tumor)
-        let mut grid = TumorGrid::generate(args.grid_size, args.grid_size, args.cell_size, args.seed);
+        let mut grid =
+            TumorGrid::generate(args.grid_size, args.grid_size, args.cell_size, args.seed);
 
         let census_before = grid.census();
         eprintln!(
@@ -288,7 +284,9 @@ fn main() {
 
         // Save death heatmap
         let heatmap = death_heatmap(&grid);
-        let heatmap_path = args.output_dir.join(format!("spatial_death_{}.csv", tx_name.to_lowercase()));
+        let heatmap_path = args
+            .output_dir
+            .join(format!("spatial_death_{}.csv", tx_name.to_lowercase()));
         write_heatmap_csv(&heatmap_path, &heatmap).expect("Failed to write heatmap");
 
         // Compute depth-kill curve

--- a/simulations/sim-tissue-pk/src/main.rs
+++ b/simulations/sim-tissue-pk/src/main.rs
@@ -15,8 +15,7 @@ use serde::Serialize;
 use ferroptosis_core::biochem::sim_cell;
 use ferroptosis_core::cell::{gen_cell, Phenotype, Treatment};
 use ferroptosis_core::drug_transport::{
-    self, concentration_profile, max_distance_um,
-    penetration_length_um, DrugParams, TissueParams,
+    self, concentration_profile, max_distance_um, penetration_length_um, DrugParams, TissueParams,
 };
 use ferroptosis_core::params::Params;
 use ferroptosis_core::stats::wilson_ci;
@@ -136,7 +135,10 @@ fn main() {
     let base_params = Params::default();
     let seed: u64 = 42;
 
-    let drugs: Vec<DrugParams> = vec![drug_transport::rsl3_like(), drug_transport::doxorubicin_transport_reference()];
+    let drugs: Vec<DrugParams> = vec![
+        drug_transport::rsl3_like(),
+        drug_transport::doxorubicin_transport_reference(),
+    ];
 
     let tissues: Vec<TissueParams> = vec![
         drug_transport::epithelial_well_vascularized(),
@@ -151,15 +153,14 @@ fn main() {
     let mut all_summaries: Vec<Summary> = Vec::new();
 
     for drug in &drugs {
-        eprintln!("Drug: {} (λ = {:.1} μm)", drug.name, penetration_length_um(drug));
+        eprintln!(
+            "Drug: {} (λ = {:.1} μm)",
+            drug.name,
+            penetration_length_um(drug)
+        );
         for tissue in &tissues {
-            let (results, summary) = run_tissue_drug(
-                drug,
-                tissue,
-                &base_params,
-                Phenotype::Persister,
-                seed,
-            );
+            let (results, summary) =
+                run_tissue_drug(drug, tissue, &base_params, Phenotype::Persister, seed);
 
             eprintln!(
                 "  {}: kill depth = {:.0} μm, vessel-wall death = {:.1}%, overall = {:.1}%",

--- a/simulations/sim-tme-3d/src/main.rs
+++ b/simulations/sim-tme-3d/src/main.rs
@@ -366,22 +366,24 @@ fn run_one_condition_with_config(condition: &Condition, run_cfg: RunConfig) -> C
         for c in 0..grid.cols {
             for l in 0..grid.layers {
                 let idx = grid.flat_index(r, c, l);
-                let exo_ros_peak = if matches!(
-                    condition.treatment,
-                    Treatment::Control | Treatment::RSL3
-                ) {
-                    0.0
-                } else {
-                    let depth_um = grid.radial_depth_um(r, c, l);
-                    let ros_multiplier =
-                        local_ros_multiplier_3d(depth_um, condition.treatment, &spatial_params);
-                    let mut rng = StdRng::seed_from_u64(cond_seed.wrapping_add(idx as u64));
-                    let peak = base_ros * ros_multiplier;
-                    norm(&mut rng, peak, peak * 0.2).max(0.0)
-                };
+                let exo_ros_peak =
+                    if matches!(condition.treatment, Treatment::Control | Treatment::RSL3) {
+                        0.0
+                    } else {
+                        let depth_um = grid.radial_depth_um(r, c, l);
+                        let ros_multiplier =
+                            local_ros_multiplier_3d(depth_um, condition.treatment, &spatial_params);
+                        let mut rng = StdRng::seed_from_u64(cond_seed.wrapping_add(idx as u64));
+                        let peak = base_ros * ros_multiplier;
+                        norm(&mut rng, peak, peak * 0.2).max(0.0)
+                    };
                 let gc = &mut grid.cells[idx];
-                gc.state =
-                    CellState::from_cell_with_ros(&gc.cell, condition.treatment, &params, exo_ros_peak);
+                gc.state = CellState::from_cell_with_ros(
+                    &gc.cell,
+                    condition.treatment,
+                    &params,
+                    exo_ros_peak,
+                );
                 gc.extra_iron = 0.0;
                 gc.newly_dead = false;
                 // Init to NaN so any code path that reads `lp_at_death`
@@ -402,8 +404,8 @@ fn run_one_condition_with_config(condition: &Condition, run_cfg: RunConfig) -> C
             let drug_factor =
                 ion_trap_factor_from_ph(local_ph, cfg.ph_edge, cfg.ion_trap_sensitivity);
             // Correct GPX4: from (1-inhib) to (1-inhib*drug_factor) — matches sim-tme:614
-            let correction = (1.0 - params.rsl3_gpx4_inhib * drug_factor)
-                / (1.0 - params.rsl3_gpx4_inhib);
+            let correction =
+                (1.0 - params.rsl3_gpx4_inhib * drug_factor) / (1.0 - params.rsl3_gpx4_inhib);
             grid.cells[idx].state.gpx4 *= correction;
         }
     }
@@ -831,7 +833,10 @@ fn main() {
         GRID_DIM as f64 * CELL_SIZE_UM / 1000.0
     );
     eprintln!("Tumor radius: {:.0} µm", tumor_radius_um);
-    eprintln!("O₂ λ sweep: {:?} µm (λ=150 skipped — 3λ > tumor radius)", O2_LAMBDAS);
+    eprintln!(
+        "O₂ λ sweep: {:?} µm (λ=150 skipped — 3λ > tumor radius)",
+        O2_LAMBDAS
+    );
     eprintln!(
         "DAMP diffusion fraction: {} (3D-safe; 2D's 0.08 would trigger immune_3d stability assert!)",
         DAMP_DIFFUSION_FRACTION_3D
@@ -848,7 +853,10 @@ fn main() {
     fs::create_dir_all(output_dir).expect("Failed to create output/tme-3d");
 
     let conditions = generate_conditions();
-    eprintln!("Running {} conditions in parallel via rayon...", conditions.len());
+    eprintln!(
+        "Running {} conditions in parallel via rayon...",
+        conditions.len()
+    );
 
     // Condition-level parallelism. Each run_one_condition allocates its own
     // grid + DAMP/scratch buffers; no shared mutable state.
@@ -1009,7 +1017,9 @@ mod tests {
         };
         let r = run_one_condition_with_config(&cond, cfg);
         assert_eq!(r.immune_mode, "immune_on");
-        let im_kills = r.immune_kills.expect("immune_on must populate immune_kills");
+        let im_kills = r
+            .immune_kills
+            .expect("immune_on must populate immune_kills");
         // Strict invariant: at least one immune kill in this RSL3 + immune-on
         // run. If this fails the immune block has gone no-op.
         assert!(
@@ -1080,7 +1090,8 @@ mod tests {
         let cfg = RunConfig::for_test();
 
         let run = |conds: &[Condition]| -> Vec<ConditionResult> {
-            conds.par_iter()
+            conds
+                .par_iter()
                 .map(|c| run_one_condition_with_config(c, cfg))
                 .collect()
         };
@@ -1138,8 +1149,14 @@ mod tests {
 
         // Center cell is interior tumor → high pH gradient depth → lower pH
         // than surface; lower O₂ than surface; mask=false (no stromal neighbors).
-        assert!(grid.cells[center_idx].is_tumor, "test precondition: center is tumor");
-        assert!(grid.cells[surface_idx].is_tumor, "test precondition: surface is tumor");
+        assert!(
+            grid.cells[center_idx].is_tumor,
+            "test precondition: center is tumor"
+        );
+        assert!(
+            grid.cells[surface_idx].is_tumor,
+            "test precondition: surface is tumor"
+        );
         assert!(
             ph[center_idx] < ph[surface_idx],
             "center pH {} should be lower than surface pH {} — \

--- a/simulations/sim-tme/src/main.rs
+++ b/simulations/sim-tme/src/main.rs
@@ -38,10 +38,12 @@ use serde::Serialize;
 
 use ferroptosis_core::biochem::{sim_cell_step, CellState};
 use ferroptosis_core::cell::{norm, Treatment};
-use ferroptosis_core::grid::{depth_kill_curve, death_heatmap, TumorGrid};
+use ferroptosis_core::grid::{death_heatmap, depth_kill_curve, TumorGrid};
 use ferroptosis_core::immune_3d::{immune_kill_probability, DAMP_KILL_THRESHOLD};
 use ferroptosis_core::io::{write_depth_curves_csv, write_heatmap_csv, write_json};
-use ferroptosis_core::params::{Params, PhConfig, SpatialImmuneConfig, SpatialParams, StromalConfig};
+use ferroptosis_core::params::{
+    Params, PhConfig, SpatialImmuneConfig, SpatialParams, StromalConfig,
+};
 use ferroptosis_core::physics::local_ros_multiplier;
 
 const GRID_SIZE: usize = 500;
@@ -70,10 +72,7 @@ const ZONE_REF_LAMBDA: f64 = 120.0;
 ///
 /// Modifies `cell.basal_ros` in place: `basal_ros *= o2_factor`.
 /// Returns a Vec of (row, col, o2_factor) for heatmap generation.
-fn apply_o2_gradient(
-    grid: &mut TumorGrid,
-    penetration_um: f64,
-) -> Vec<(usize, usize, f64)> {
+fn apply_o2_gradient(grid: &mut TumorGrid, penetration_um: f64) -> Vec<(usize, usize, f64)> {
     let rows = grid.rows;
     let cols = grid.cols;
     let cell_size = grid.cell_size_um;
@@ -93,8 +92,7 @@ fn apply_o2_gradient(
 
             let dist_from_center =
                 ((r as f64 - center_r).powi(2) + (c as f64 - center_c).powi(2)).sqrt();
-            let depth_from_edge_um =
-                (tumor_radius - dist_from_center).max(0.0) * cell_size;
+            let depth_from_edge_um = (tumor_radius - dist_from_center).max(0.0) * cell_size;
 
             let o2_factor = (-depth_from_edge_um / penetration_um).exp().clamp(0.0, 1.0);
 
@@ -135,7 +133,11 @@ fn compute_depth_map(grid: &TumorGrid) -> Vec<f64> {
 /// Square-wave O2 cycling: λ alternates between low (hypoxic) and
 /// high (normoxic) on a fixed period. First half = normoxic, second half = hypoxic.
 fn cycling_lambda(step: u32, period: u32, lambda_low: f64, lambda_high: f64) -> f64 {
-    if (step % period) < period / 2 { lambda_high } else { lambda_low }
+    if (step % period) < period / 2 {
+        lambda_high
+    } else {
+        lambda_low
+    }
 }
 
 // ============================================================
@@ -193,7 +195,9 @@ fn run_spatial(
                 }
                 if grid.cells[idx].state.dead {
                     if let Some(ds) = grid.cells[idx].state.death_step {
-                        if step >= ds + params.post_death_steps { continue; }
+                        if step >= ds + params.post_death_steps {
+                            continue;
+                        }
                     } else {
                         continue;
                     }
@@ -209,14 +213,8 @@ fn run_spatial(
                 grid.cells[idx].extra_iron = 0.0;
 
                 let gc = &mut grid.cells[idx];
-                let died = sim_cell_step(
-                    &mut gc.state,
-                    &gc.cell,
-                    params,
-                    step,
-                    extra_iron,
-                    &mut rng,
-                );
+                let died =
+                    sim_cell_step(&mut gc.state, &gc.cell, params, step, extra_iron, &mut rng);
 
                 if died {
                     gc.newly_dead = true;
@@ -311,7 +309,9 @@ fn run_spatial_cycling(
                 }
                 if grid.cells[idx].state.dead {
                     if let Some(ds) = grid.cells[idx].state.death_step {
-                        if step >= ds + params.post_death_steps { continue; }
+                        if step >= ds + params.post_death_steps {
+                            continue;
+                        }
                     } else {
                         continue;
                     }
@@ -327,14 +327,8 @@ fn run_spatial_cycling(
                 grid.cells[idx].extra_iron = 0.0;
 
                 let gc = &mut grid.cells[idx];
-                let died = sim_cell_step(
-                    &mut gc.state,
-                    &gc.cell,
-                    params,
-                    step,
-                    extra_iron,
-                    &mut rng,
-                );
+                let died =
+                    sim_cell_step(&mut gc.state, &gc.cell, params, step, extra_iron, &mut rng);
 
                 if died {
                     gc.newly_dead = true;
@@ -405,7 +399,11 @@ fn stromal_adjacent_kill_rate(grid: &TumorGrid, mask: &[bool]) -> f64 {
             }
         }
     }
-    if total > 0 { dead as f64 / total as f64 } else { 0.0 }
+    if total > 0 {
+        dead as f64 / total as f64
+    } else {
+        0.0
+    }
 }
 
 // ============================================================
@@ -440,11 +438,10 @@ fn apply_ph_gradient(grid: &mut TumorGrid, cfg: &PhConfig) -> Vec<(usize, usize,
 
             let dist_from_center =
                 ((r as f64 - center_r).powi(2) + (c as f64 - center_c).powi(2)).sqrt();
-            let depth_from_edge_um =
-                (tumor_radius - dist_from_center).max(0.0) * cell_size;
+            let depth_from_edge_um = (tumor_radius - dist_from_center).max(0.0) * cell_size;
 
-            let local_ph = cfg.ph_edge
-                - ph_drop * (1.0 - (-depth_from_edge_um / cfg.lambda_ph_um).exp());
+            let local_ph =
+                cfg.ph_edge - ph_drop * (1.0 - (-depth_from_edge_um / cfg.lambda_ph_um).exp());
             let local_ph = local_ph.clamp(cfg.ph_core, cfg.ph_edge);
 
             // Iron modulation: ferritin destabilization at low pH
@@ -515,12 +512,11 @@ fn run_spatial_with_immune(
                 if !grid.cells[idx].is_tumor {
                     continue;
                 }
-                let drug_factor = (1.0
-                    - ph_cfg.ion_trap_sensitivity * (ph_cfg.ph_edge - local_ph))
+                let drug_factor = (1.0 - ph_cfg.ion_trap_sensitivity * (ph_cfg.ph_edge - local_ph))
                     .clamp(0.3, 1.0);
                 // Correct GPX4: from (1-inhib) to (1-inhib*drug_factor)
-                let correction = (1.0 - params.rsl3_gpx4_inhib * drug_factor)
-                    / (1.0 - params.rsl3_gpx4_inhib);
+                let correction =
+                    (1.0 - params.rsl3_gpx4_inhib * drug_factor) / (1.0 - params.rsl3_gpx4_inhib);
                 grid.cells[idx].state.gpx4 *= correction;
             }
         }
@@ -569,9 +565,8 @@ fn run_spatial_with_immune(
                 grid.cells[idx].extra_iron = 0.0;
 
                 let gc = &mut grid.cells[idx];
-                let died = sim_cell_step(
-                    &mut gc.state, &gc.cell, params, step, extra_iron, &mut rng,
-                );
+                let died =
+                    sim_cell_step(&mut gc.state, &gc.cell, params, step, extra_iron, &mut rng);
 
                 if died {
                     gc.newly_dead = true;
@@ -591,8 +586,8 @@ fn run_spatial_with_immune(
                     if let Some((mask, cfg)) = &stromal {
                         if mask[idx] {
                             let gc = &mut grid.cells[idx];
-                            gc.state.gsh = (gc.state.gsh + cfg.gsh_boost_per_step)
-                                .min(cfg.gsh_boost_cap);
+                            gc.state.gsh =
+                                (gc.state.gsh + cfg.gsh_boost_per_step).min(cfg.gsh_boost_cap);
                             gc.state.mufa_protection = (gc.state.mufa_protection
                                 + cfg.mufa_boost_per_step)
                                 .min(cfg.mufa_boost_cap);
@@ -788,7 +783,11 @@ fn zone_kill_rates(grid: &TumorGrid, shell_depth_um: f64) -> (f64, f64, f64) {
     }
 
     let rate = |d: usize, t: usize| if t > 0 { d as f64 / t as f64 } else { 0.0 };
-    (rate(norm_dead, norm_total), rate(trans_dead, trans_total), rate(hyp_dead, hyp_total))
+    (
+        rate(norm_dead, norm_total),
+        rate(trans_dead, trans_total),
+        rate(hyp_dead, hyp_total),
+    )
 }
 
 // ============================================================
@@ -799,7 +798,8 @@ fn main() {
     eprintln!("=== Tumor Microenvironment: Oxygen Gradients ===");
     eprintln!(
         "Grid: {}×{} ({:.1}mm × {:.1}mm)",
-        GRID_SIZE, GRID_SIZE,
+        GRID_SIZE,
+        GRID_SIZE,
         GRID_SIZE as f64 * CELL_SIZE_UM / 1000.0,
         GRID_SIZE as f64 * CELL_SIZE_UM / 1000.0,
     );
@@ -822,7 +822,11 @@ fn main() {
     fs::create_dir_all(output_dir).expect("Failed to create output directory");
 
     // Remove stale legacy files from previous naming convention (_immune.csv → _immune_run.csv)
-    for name in &["death_control_immune.csv", "death_rsl3_immune.csv", "death_sdt_immune.csv"] {
+    for name in &[
+        "death_control_immune.csv",
+        "death_rsl3_immune.csv",
+        "death_sdt_immune.csv",
+    ] {
         let p = output_dir.join(name);
         if p.exists() {
             let _ = fs::remove_file(&p);
@@ -837,15 +841,24 @@ fn main() {
     for (tx, tx_name) in &treatments {
         let mut grid = TumorGrid::generate(GRID_SIZE, GRID_SIZE, CELL_SIZE_UM, SEED);
         run_spatial(
-            &mut grid, *tx, &params, &spatial_params,
+            &mut grid,
+            *tx,
+            &params,
+            &spatial_params,
             SEED.wrapping_add((*tx as u64) * 10_000_000),
         );
 
         let census = grid.census();
         let overall = census.total_dead as f64 / census.total_tumor.max(1) as f64;
         let (norm_r, trans_r, hyp_r) = zone_kill_rates(&grid, ZONE_REF_LAMBDA);
-        eprintln!("  {}: overall={:.1}%, normoxic={:.1}%, transition={:.1}%, hypoxic={:.1}%",
-            tx_name, overall * 100.0, norm_r * 100.0, trans_r * 100.0, hyp_r * 100.0);
+        eprintln!(
+            "  {}: overall={:.1}%, normoxic={:.1}%, transition={:.1}%, hypoxic={:.1}%",
+            tx_name,
+            overall * 100.0,
+            norm_r * 100.0,
+            trans_r * 100.0,
+            hyp_r * 100.0
+        );
 
         all_results.push(ConditionResult {
             treatment: tx_name.to_string(),
@@ -892,15 +905,24 @@ fn main() {
             let o2_map = apply_o2_gradient(&mut grid, lambda);
 
             run_spatial(
-                &mut grid, *tx, &params, &spatial_params,
+                &mut grid,
+                *tx,
+                &params,
+                &spatial_params,
                 SEED.wrapping_add((*tx as u64) * 10_000_000),
             );
 
             let census = grid.census();
             let overall = census.total_dead as f64 / census.total_tumor.max(1) as f64;
             let (norm_r, trans_r, hyp_r) = zone_kill_rates(&grid, ZONE_REF_LAMBDA);
-            eprintln!("  {}: overall={:.1}%, normoxic={:.1}%, transition={:.1}%, hypoxic={:.1}%",
-                tx_name, overall * 100.0, norm_r * 100.0, trans_r * 100.0, hyp_r * 100.0);
+            eprintln!(
+                "  {}: overall={:.1}%, normoxic={:.1}%, transition={:.1}%, hypoxic={:.1}%",
+                tx_name,
+                overall * 100.0,
+                norm_r * 100.0,
+                trans_r * 100.0,
+                hyp_r * 100.0
+            );
 
             all_results.push(ConditionResult {
                 treatment: tx_name.to_string(),
@@ -934,7 +956,8 @@ fn main() {
             // Save heatmaps for the default lambda (120μm) only to avoid file bloat
             if (lambda - 120.0).abs() < 1.0 {
                 let death_hm = death_heatmap(&grid);
-                let path = output_dir.join(format!("death_{}_o2gradient.csv", tx_name.to_lowercase()));
+                let path =
+                    output_dir.join(format!("death_{}_o2gradient.csv", tx_name.to_lowercase()));
                 write_heatmap_csv(&path, &death_hm).expect("Failed to write heatmap");
 
                 // O2 heatmap
@@ -964,10 +987,16 @@ fn main() {
             let original_ros: Vec<f64> = grid.cells.iter().map(|gc| gc.cell.basal_ros).collect();
 
             run_spatial_cycling(
-                &mut grid, *tx, &params, &spatial_params,
+                &mut grid,
+                *tx,
+                &params,
+                &spatial_params,
                 SEED.wrapping_add((*tx as u64) * 10_000_000),
-                &depths, &original_ros,
-                cycle_period, lambda_low, lambda_high,
+                &depths,
+                &original_ros,
+                cycle_period,
+                lambda_low,
+                lambda_high,
             );
 
             let census = grid.census();
@@ -975,7 +1004,11 @@ fn main() {
             let (norm_r, trans_r, hyp_r) = zone_kill_rates(&grid, ZONE_REF_LAMBDA);
             eprintln!(
                 "  {}: overall={:.1}%, normoxic={:.1}%, transition={:.1}%, hypoxic={:.1}%",
-                tx_name, overall * 100.0, norm_r * 100.0, trans_r * 100.0, hyp_r * 100.0
+                tx_name,
+                overall * 100.0,
+                norm_r * 100.0,
+                trans_r * 100.0,
+                hyp_r * 100.0
             );
 
             all_results.push(ConditionResult {
@@ -1023,7 +1056,10 @@ fn main() {
     // --- Immune coupling (Feature B) at λ=120μm ---
     let immune_modes: Vec<(&str, SpatialImmuneConfig)> = vec![
         ("immune_on", SpatialImmuneConfig::for_2d()),
-        ("immune_anti_pd1", SpatialImmuneConfig::for_2d().with_anti_pd1()),
+        (
+            "immune_anti_pd1",
+            SpatialImmuneConfig::for_2d().with_anti_pd1(),
+        ),
     ];
 
     eprintln!("\n=== Spatial Immune Coupling (O2 gradient λ=120μm) ===");
@@ -1032,15 +1068,24 @@ fn main() {
     eprintln!("Immune model: resident T cell phase only (0-48h), not systemic.\n");
 
     for (immune_label, immune_cfg) in &immune_modes {
-        eprintln!("--- Immune mode: {} (brake={:.0}%) ---\n",
-            immune_label, immune_cfg.effective_brake() * 100.0);
+        eprintln!(
+            "--- Immune mode: {} (brake={:.0}%) ---\n",
+            immune_label,
+            immune_cfg.effective_brake() * 100.0
+        );
 
         for (tx, tx_name) in &treatments {
             let mut grid = TumorGrid::generate(GRID_SIZE, GRID_SIZE, CELL_SIZE_UM, SEED);
             apply_o2_gradient(&mut grid, 120.0);
 
             let (ferr_kills, imm_kills, final_damp) = run_spatial_with_immune(
-                &mut grid, *tx, &params, &spatial_params, immune_cfg, None, None,
+                &mut grid,
+                *tx,
+                &params,
+                &spatial_params,
+                immune_cfg,
+                None,
+                None,
                 SEED.wrapping_add((*tx as u64) * 10_000_000),
             );
 
@@ -1048,8 +1093,15 @@ fn main() {
             let overall = census.total_dead as f64 / census.total_tumor.max(1) as f64;
             let (norm_r, trans_r, hyp_r) = zone_kill_rates(&grid, ZONE_REF_LAMBDA);
             let adj_rate_baseline = stromal_adjacent_kill_rate(&grid, &stromal_mask);
-            eprintln!("  {}: overall={:.1}% (ferr={}, immune={}), hypoxic={:.1}%, stromal_adj={:.1}%",
-                tx_name, overall * 100.0, ferr_kills, imm_kills, hyp_r * 100.0, adj_rate_baseline * 100.0);
+            eprintln!(
+                "  {}: overall={:.1}% (ferr={}, immune={}), hypoxic={:.1}%, stromal_adj={:.1}%",
+                tx_name,
+                overall * 100.0,
+                ferr_kills,
+                imm_kills,
+                hyp_r * 100.0,
+                adj_rate_baseline * 100.0
+            );
 
             // Export DAMP and immune-kill heatmaps for the first immune mode only
             if *immune_label == "immune_on" {
@@ -1069,7 +1121,8 @@ fn main() {
                 // death heatmaps: 0=stromal, 1=dead tumor, 2=alive tumor; does NOT
                 // distinguish immune kills from ferroptotic kills)
                 let death_hm = death_heatmap(&grid);
-                let path = output_dir.join(format!("death_{}_immune_run.csv", tx_name.to_lowercase()));
+                let path =
+                    output_dir.join(format!("death_{}_immune_run.csv", tx_name.to_lowercase()));
                 write_heatmap_csv(&path, &death_hm).expect("Failed to write death heatmap");
             }
 
@@ -1109,30 +1162,47 @@ fn main() {
     let stromal_cfg = StromalConfig::default();
 
     eprintln!("\n=== Stromal Protection / CAF-Mediated Shielding (O2 gradient λ=120μm) ===");
-    eprintln!("Stromal-adjacent tumor cells: {} ({:.1}% of tumor)",
+    eprintln!(
+        "Stromal-adjacent tumor cells: {} ({:.1}% of tumor)",
         stromal_adj_count,
-        stromal_adj_count as f64 / mask_grid.census().total_tumor as f64 * 100.0);
-    eprintln!("CAF boost: GSH +{:.3}/step (cap {:.0}), MUFA +{:.4}/step (cap {:.2})",
-        stromal_cfg.gsh_boost_per_step, stromal_cfg.gsh_boost_cap,
-        stromal_cfg.mufa_boost_per_step, stromal_cfg.mufa_boost_cap);
+        stromal_adj_count as f64 / mask_grid.census().total_tumor as f64 * 100.0
+    );
+    eprintln!(
+        "CAF boost: GSH +{:.3}/step (cap {:.0}), MUFA +{:.4}/step (cap {:.2})",
+        stromal_cfg.gsh_boost_per_step,
+        stromal_cfg.gsh_boost_cap,
+        stromal_cfg.mufa_boost_per_step,
+        stromal_cfg.mufa_boost_cap
+    );
     eprintln!("All parameters ESTIMATED (no textbook coverage). Refs: PMID 34373744, 31813804.\n");
 
     let stromal_immune_modes: Vec<(&str, SpatialImmuneConfig)> = vec![
         ("immune_on", SpatialImmuneConfig::for_2d()),
-        ("immune_anti_pd1", SpatialImmuneConfig::for_2d().with_anti_pd1()),
+        (
+            "immune_anti_pd1",
+            SpatialImmuneConfig::for_2d().with_anti_pd1(),
+        ),
     ];
 
     for (immune_label, immune_cfg) in &stromal_immune_modes {
-        eprintln!("--- Stromal ON + {} (brake={:.0}%) ---\n",
-            immune_label, immune_cfg.effective_brake() * 100.0);
+        eprintln!(
+            "--- Stromal ON + {} (brake={:.0}%) ---\n",
+            immune_label,
+            immune_cfg.effective_brake() * 100.0
+        );
 
         for (tx, tx_name) in &treatments {
             let mut grid = TumorGrid::generate(GRID_SIZE, GRID_SIZE, CELL_SIZE_UM, SEED);
             apply_o2_gradient(&mut grid, 120.0);
 
             let (ferr_kills, imm_kills, _final_damp) = run_spatial_with_immune(
-                &mut grid, *tx, &params, &spatial_params, &immune_cfg,
-                Some((&stromal_mask, &stromal_cfg)), None,
+                &mut grid,
+                *tx,
+                &params,
+                &spatial_params,
+                &immune_cfg,
+                Some((&stromal_mask, &stromal_cfg)),
+                None,
                 SEED.wrapping_add((*tx as u64) * 10_000_000),
             );
 
@@ -1207,16 +1277,22 @@ fn main() {
     let immune_for_ph = SpatialImmuneConfig::for_2d();
 
     eprintln!("\n=== pH Gradient / Ion Trapping (O2 gradient λ=120μm, immune_on) ===");
-    eprintln!("pH range: {:.1} (edge) → {:.1} (core), λ_pH={:.0}μm",
-        ph_cfg.ph_edge, ph_cfg.ph_core, ph_cfg.lambda_ph_um);
-    eprintln!("Iron sensitivity: {:.1} (→ {:.2}× at pH {:.1})",
+    eprintln!(
+        "pH range: {:.1} (edge) → {:.1} (core), λ_pH={:.0}μm",
+        ph_cfg.ph_edge, ph_cfg.ph_core, ph_cfg.lambda_ph_um
+    );
+    eprintln!(
+        "Iron sensitivity: {:.1} (→ {:.2}× at pH {:.1})",
         ph_cfg.iron_ph_sensitivity,
         1.0 + ph_cfg.iron_ph_sensitivity * (ph_cfg.ph_edge - ph_cfg.ph_core),
-        ph_cfg.ph_core);
-    eprintln!("Ion trapping: {:.1} (→ {:.0}% drug loss at pH {:.1}, RSL3 only)",
+        ph_cfg.ph_core
+    );
+    eprintln!(
+        "Ion trapping: {:.1} (→ {:.0}% drug loss at pH {:.1}, RSL3 only)",
         ph_cfg.ion_trap_sensitivity,
         ph_cfg.ion_trap_sensitivity * (ph_cfg.ph_edge - ph_cfg.ph_core) * 100.0,
-        ph_cfg.ph_core);
+        ph_cfg.ph_core
+    );
     eprintln!("All parameters ESTIMATED. Henderson-Hasselbalch: Chemistry2e Sec.14.2.");
     eprintln!("Warburg effect, ferritin iron release: primary literature only.\n");
 
@@ -1226,8 +1302,13 @@ fn main() {
         let ph_map = apply_ph_gradient(&mut grid, &ph_cfg);
 
         let (ferr_kills, imm_kills, _final_damp) = run_spatial_with_immune(
-            &mut grid, *tx, &params, &spatial_params, &immune_for_ph,
-            None, Some((&ph_map, &ph_cfg)),
+            &mut grid,
+            *tx,
+            &params,
+            &spatial_params,
+            &immune_for_ph,
+            None,
+            Some((&ph_map, &ph_cfg)),
             SEED.wrapping_add((*tx as u64) * 10_000_000),
         );
 
@@ -1235,9 +1316,15 @@ fn main() {
         let overall = census.total_dead as f64 / census.total_tumor.max(1) as f64;
         let (norm_r, trans_r, hyp_r) = zone_kill_rates(&grid, ZONE_REF_LAMBDA);
         let adj_rate = stromal_adjacent_kill_rate(&grid, &stromal_mask);
-        eprintln!("  {}: overall={:.1}% (ferr={}, immune={}), normoxic={:.1}%, hypoxic={:.1}%",
-            tx_name, overall * 100.0, ferr_kills, imm_kills,
-            norm_r * 100.0, hyp_r * 100.0);
+        eprintln!(
+            "  {}: overall={:.1}% (ferr={}, immune={}), normoxic={:.1}%, hypoxic={:.1}%",
+            tx_name,
+            overall * 100.0,
+            ferr_kills,
+            imm_kills,
+            norm_r * 100.0,
+            hyp_r * 100.0
+        );
 
         // Export death heatmap
         let death_hm = death_heatmap(&grid);
@@ -1282,7 +1369,8 @@ fn main() {
         let mut ph_hm = ndarray::Array2::<u8>::zeros((GRID_SIZE, GRID_SIZE));
         for &(r, c, ph) in &ph_map_vis {
             // Map pH 6.5-7.4 to 0-255
-            let normed = ((ph - ph_cfg.ph_core) / (ph_cfg.ph_edge - ph_cfg.ph_core)).clamp(0.0, 1.0);
+            let normed =
+                ((ph - ph_cfg.ph_core) / (ph_cfg.ph_edge - ph_cfg.ph_core)).clamp(0.0, 1.0);
             ph_hm[[r, c]] = (normed * 255.0).round() as u8;
         }
         let path = output_dir.join("ph_field.csv");
@@ -1300,7 +1388,15 @@ fn main() {
     eprintln!("\n=== Comparison Table ===\n");
     eprintln!(
         "{:<10} {:<20} {:<18} {:<12} {:<8} {:>10} {:>10} {:>10} {:>10}",
-        "Treatment", "O2 Condition", "Immune", "Stromal", "pH", "Overall", "Normoxic", "Transit.", "Hypoxic"
+        "Treatment",
+        "O2 Condition",
+        "Immune",
+        "Stromal",
+        "pH",
+        "Overall",
+        "Normoxic",
+        "Transit.",
+        "Hypoxic"
     );
     eprintln!("{}", "-".repeat(120));
     for r in &all_results {
@@ -1308,7 +1404,11 @@ fn main() {
         let ph_label = r.ph_mode.as_deref().unwrap_or("off");
         eprintln!(
             "{:<10} {:<20} {:<18} {:<12} {:<8} {:>9.1}% {:>9.1}% {:>9.1}% {:>9.1}%",
-            r.treatment, r.o2_condition, r.immune_mode, stromal_label, ph_label,
+            r.treatment,
+            r.o2_condition,
+            r.immune_mode,
+            stromal_label,
+            ph_label,
             r.overall_kill_rate * 100.0,
             r.normoxic_kill_rate * 100.0,
             r.transition_kill_rate * 100.0,
@@ -1318,18 +1418,35 @@ fn main() {
 
     // --- Sensitivity check: is the SDT-vs-RSL3 differential robust? ---
     eprintln!("\n=== Sensitivity: SDT advantage over RSL3 in hypoxic zone ===\n");
-    eprintln!("{:<10} {:>15} {:>15} {:>15}", "λ (μm)", "RSL3 hypoxic", "SDT hypoxic", "SDT/RSL3 ratio");
+    eprintln!(
+        "{:<10} {:>15} {:>15} {:>15}",
+        "λ (μm)", "RSL3 hypoxic", "SDT hypoxic", "SDT/RSL3 ratio"
+    );
     eprintln!("{}", "-".repeat(57));
     for &lambda in O2_LAMBDAS {
         let cond = format!("gradient_{}um", lambda as u64);
-        let rsl3_hyp = all_results.iter()
+        let rsl3_hyp = all_results
+            .iter()
             .find(|r| r.treatment == "RSL3" && r.o2_condition == cond)
-            .map(|r| r.hypoxic_kill_rate).unwrap_or(0.0);
-        let sdt_hyp = all_results.iter()
+            .map(|r| r.hypoxic_kill_rate)
+            .unwrap_or(0.0);
+        let sdt_hyp = all_results
+            .iter()
             .find(|r| r.treatment == "SDT" && r.o2_condition == cond)
-            .map(|r| r.hypoxic_kill_rate).unwrap_or(0.0);
-        let ratio = if rsl3_hyp > 0.001 { sdt_hyp / rsl3_hyp } else { f64::INFINITY };
-        eprintln!("{:<10} {:>14.1}% {:>14.1}% {:>15.1}×", lambda, rsl3_hyp * 100.0, sdt_hyp * 100.0, ratio);
+            .map(|r| r.hypoxic_kill_rate)
+            .unwrap_or(0.0);
+        let ratio = if rsl3_hyp > 0.001 {
+            sdt_hyp / rsl3_hyp
+        } else {
+            f64::INFINITY
+        };
+        eprintln!(
+            "{:<10} {:>14.1}% {:>14.1}% {:>15.1}×",
+            lambda,
+            rsl3_hyp * 100.0,
+            sdt_hyp * 100.0,
+            ratio
+        );
     }
 
     eprintln!("\nZone definitions (fixed at λ_ref = {ZONE_REF_LAMBDA}μm): normoxic = within {ZONE_REF_LAMBDA}μm of edge, transition = {ZONE_REF_LAMBDA}-{}μm, hypoxic = deeper than {}μm.", ZONE_REF_LAMBDA * 3.0, ZONE_REF_LAMBDA * 3.0);

--- a/simulations/sim-tumor-pk/src/main.rs
+++ b/simulations/sim-tumor-pk/src/main.rs
@@ -40,11 +40,7 @@ struct ScenarioResult {
     protection_factor: Option<f64>,
 }
 
-fn run_scenario(
-    conc_schedule: &[f64],
-    params: &Params,
-    seed: u64,
-) -> (usize, f64, f64, f64) {
+fn run_scenario(conc_schedule: &[f64], params: &Params, seed: u64) -> (usize, f64, f64, f64) {
     let results: Vec<PKCellResult> = (0..N_CELLS)
         .into_par_iter()
         .map(|i| {
@@ -52,7 +48,13 @@ fn run_scenario(
             let mut rng = rand::rngs::StdRng::seed_from_u64(cell_seed);
             let cell = gen_cell(Phenotype::Persister, &mut rng);
             // Use a different seed for sim vs gen_cell to avoid RNG correlation
-            sim_cell_with_pk(&cell, params, conc_schedule, RSL3_INACTIVATION_RATE, cell_seed.wrapping_add(500_000))
+            sim_cell_with_pk(
+                &cell,
+                params,
+                conc_schedule,
+                RSL3_INACTIVATION_RATE,
+                cell_seed.wrapping_add(500_000),
+            )
         })
         .collect();
 
@@ -97,8 +99,7 @@ fn main() {
     let ref_death_rate;
     {
         let conc_schedule: Vec<f64> = vec![1.0; N_STEPS];
-        let (n_dead, mean_lp, mean_gsh, mean_gpx4) =
-            run_scenario(&conc_schedule, &params, SEED);
+        let (n_dead, mean_lp, mean_gsh, mean_gpx4) = run_scenario(&conc_schedule, &params, SEED);
         let (ci_lo, ci_hi) = wilson_ci(N_CELLS, n_dead);
         ref_death_rate = n_dead as f64 / N_CELLS as f64;
 
@@ -131,9 +132,8 @@ fn main() {
     eprintln!();
 
     // --- Tumor-specific PK ---
-    let mut timecourse_rows: Vec<String> = vec![
-        "time_min,tumor_type,c_plasma,c_vascular,c_interstitial".to_string()
-    ];
+    let mut timecourse_rows: Vec<String> =
+        vec!["time_min,tumor_type,c_plasma,c_vascular,c_interstitial".to_string()];
 
     for (tumor_name, tumor_params) in &tumors {
         let pk_result = solve_tumor_pk(&plasma, tumor_params, N_STEPS, 100);
@@ -231,21 +231,24 @@ fn main() {
 
     // Tumor type ↔ tissue type mapping (explicit)
     let tumor_tissue_pairs: Vec<(&str, TumorPKParams, f64)> = vec![
-        ("Breast", breast_tumor(), 60.0),       // half of 120μm inter-vessel
+        ("Breast", breast_tumor(), 60.0), // half of 120μm inter-vessel
         ("Pancreatic", pancreatic_tumor(), 125.0), // half of 250μm
-        ("GBM", glioblastoma_tumor(), 75.0),    // half of 150μm
-        ("Melanoma", melanoma_tumor(), 60.0),    // well-vasc, similar to breast
-        ("Sarcoma", sarcoma_tumor(), 100.0),     // poorly-vasc, half of ~200μm
+        ("GBM", glioblastoma_tumor(), 75.0), // half of 150μm
+        ("Melanoma", melanoma_tumor(), 60.0), // well-vasc, similar to breast
+        ("Sarcoma", sarcoma_tumor(), 100.0), // poorly-vasc, half of ~200μm
     ];
 
     let radial_bins = [0.0, 25.0, 50.0, 75.0, 100.0, 125.0];
 
     eprintln!("\n=== Spatial × Temporal: C(r,t) Kill Rates ===");
-    eprintln!("λ_met = {:.0} μm (metabolism only, no uptake double-counting)", lambda_met);
+    eprintln!(
+        "λ_met = {:.0} μm (metabolism only, no uptake double-counting)",
+        lambda_met
+    );
     eprintln!("Key finding: temporal PK barrier (16-27×) dominates spatial decay (1.3-1.7×).\n");
 
     let mut crt_rows: Vec<String> = vec![
-        "tumor_type,distance_um,peak_conc,death_rate,ci_low,ci_high,n_cells,n_dead".to_string()
+        "tumor_type,distance_um,peak_conc,death_rate,ci_low,ci_high,n_cells,n_dead".to_string(),
     ];
 
     for (tumor_name, tumor_params, r_max) in &tumor_tissue_pairs {
@@ -259,8 +262,7 @@ fn main() {
             let schedule = compute_spatial_temporal_schedule(&pk_result, r, lambda_met);
             let peak: f64 = schedule.iter().cloned().fold(0.0, f64::max);
 
-            let (n_dead, _mean_lp, _mean_gsh, _mean_gpx4) =
-                run_scenario(&schedule, &params, SEED);
+            let (n_dead, _mean_lp, _mean_gsh, _mean_gpx4) = run_scenario(&schedule, &params, SEED);
             let (ci_lo, ci_hi) = wilson_ci(N_CELLS, n_dead);
             let death_rate = n_dead as f64 / N_CELLS as f64;
             let prot = if death_rate > 0.001 {
@@ -271,7 +273,10 @@ fn main() {
 
             eprintln!(
                 "    r={:>5.0}μm: peak_C={:.3}, death={:.1}%, prot={:.1}×",
-                r, peak, death_rate * 100.0, prot
+                r,
+                peak,
+                death_rate * 100.0,
+                prot
             );
 
             crt_rows.push(format!(

--- a/simulations/sim-window/src/main.rs
+++ b/simulations/sim-window/src/main.rs
@@ -18,7 +18,10 @@ use ferroptosis_core::params::Params;
 use ferroptosis_core::stats::wilson_ci;
 
 #[derive(Parser)]
-#[command(name = "sim-window", about = "Ferroptosis vulnerability window dynamics")]
+#[command(
+    name = "sim-window",
+    about = "Ferroptosis vulnerability window dynamics"
+)]
 struct Args {
     /// Cells per condition.
     #[arg(long, default_value_t = 100_000)]
@@ -45,10 +48,9 @@ fn main() {
 
     // Timepoints: 0 to 28 days
     let timepoints_hours: Vec<f64> = vec![
-        0.0, 6.0, 12.0, 24.0, 48.0, 72.0,
-        168.0,   // 1 week
-        336.0,   // 2 weeks
-        672.0,   // 4 weeks
+        0.0, 6.0, 12.0, 24.0, 48.0, 72.0, 168.0, // 1 week
+        336.0, // 2 weeks
+        672.0, // 4 weeks
     ];
 
     let treatments = [
@@ -73,10 +75,14 @@ fn main() {
                 .into_par_iter()
                 .map(|i| {
                     let mut cell_rng = StdRng::seed_from_u64(
-                        args.seed.wrapping_add(i as u64 * 2).wrapping_add(hours as u64 * 1_000_000),
+                        args.seed
+                            .wrapping_add(i as u64 * 2)
+                            .wrapping_add(hours as u64 * 1_000_000),
                     );
                     let mut sim_rng = StdRng::seed_from_u64(
-                        args.seed.wrapping_add(i as u64 * 2 + 1).wrapping_add(hours as u64 * 1_000_000),
+                        args.seed
+                            .wrapping_add(i as u64 * 2 + 1)
+                            .wrapping_add(hours as u64 * 1_000_000),
                     );
                     let cell = gen_recovered_persister(days, &recovery, &mut cell_rng);
                     sim_cell(&cell, *tx, &params, &mut sim_rng)
@@ -139,8 +145,10 @@ fn main() {
             let outcomes: Vec<(bool, f64, f64, f64)> = (0..n)
                 .into_par_iter()
                 .map(|i| {
-                    let mut cell_rng = StdRng::seed_from_u64(args.seed.wrapping_add(i as u64 * 2 + 99999));
-                    let mut sim_rng = StdRng::seed_from_u64(args.seed.wrapping_add(i as u64 * 2 + 100000));
+                    let mut cell_rng =
+                        StdRng::seed_from_u64(args.seed.wrapping_add(i as u64 * 2 + 99999));
+                    let mut sim_rng =
+                        StdRng::seed_from_u64(args.seed.wrapping_add(i as u64 * 2 + 100000));
                     let cell = gen_recovered_persister(days, &r, &mut cell_rng);
                     sim_cell(&cell, Treatment::SDT, &params, &mut sim_rng)
                 })
@@ -149,7 +157,9 @@ fn main() {
             let rate = dead as f64 / n as f64;
             eprintln!(
                 "  {} t½ ×{:.1}: SDT death at 7d = {:.2}%",
-                rate_name, mult, rate * 100.0
+                rate_name,
+                mult,
+                rate * 100.0
             );
         }
     }


### PR DESCRIPTION
## Summary

Closes #209. Two coordinated commits — split for separately-reviewable scope:

1. **`03acb04a` — workspace-wide `cargo fmt --all`** — resets the baseline. Touches 27 files (+1025 / −420). No semantic changes; the delta is overwhelmingly line rewrapping and import reordering.
2. **`a4a76fff` — add `fmt` job to the existing `Rust Tests` workflow** — runs `cargo fmt --all --check` on every PR + push to main that touches `simulations/**`. In parallel with the existing `test` job. 18 lines.

## What was in the drift

Issue #209 reported 157 diffs; the workspace had grown to **168 diffs** by the time this PR was started — the natural drift the gate is intended to stop. After this PR lands, that count drops to 0 and is held there by CI.

## Verification

**Bit-identical (load-bearing per #209's acceptance criteria):**

\`\`\`
$ shasum -a 256 simulations/output/spatial/*  # pre-fmt
e45241d... depth_kill_curves.csv
1365e8f... spatial_death_control.csv
3c61509... spatial_death_pdt.csv
bf20059... spatial_death_rsl3.csv
beb5de3... spatial_death_sdt.csv
ace766b... spatial_summary.json
$ diff before.txt after.txt
$ echo \$?
0   ← 6/6 hashes match after \`cargo fmt --all\`
\`\`\`

**Workspace tests:** \`cargo test --release --workspace --exclude ferroptosis-python\` → **179 passing** (166 ferroptosis-core + 1 sim-spatial + 8 sim-tme-3d + 4 ferroptosis-ffi) — same as pre-fmt.

**Fmt-check:** \`cargo fmt --manifest-path simulations/Cargo.toml --all --check\` exits 0.

## Workflow design choice

Added a second job to the existing \`cargo-test.yml\` rather than creating a separate \`cargo-fmt.yml\`. Reasoning:

- Triggers are identical (\`simulations/**\` on push to main + on PR).
- Both jobs need the Rust toolchain, but only the test job needs the build cache — so they're independent enough to parallelize cleanly.
- One workflow file is one fewer surface to drift.

The new job runs as \`Rust Tests / fmt\` in the GitHub Actions UI alongside the existing \`Rust Tests / test\`.

## Out of scope (per the issue body)

- \`cargo clippy\` warnings (the issue noted 4 pre-existing) — separate follow-up.
- Python formatter (\`ruff\`/\`black\`) — separate stack.

## Test plan

- [ ] CI: \`Rust Tests / test\` green
- [ ] CI: \`Rust Tests / fmt\` green (first run of the new job — this PR is the canary)
- [ ] CodeQL / Analyze (rust) green
- [ ] On a follow-up branch with a deliberate fmt regression, confirm the gate **fails** as intended (sanity check that the new job actually blocks drift, not just lights up green)

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)