### PR TITLE
sim-tme-3d trajectory snapshots + animated GIF renderer (#193)

### DIFF
--- a/scripts/render_tme_3d_trajectory.py
+++ b/scripts/render_tme_3d_trajectory.py
@@ -12,8 +12,8 @@ Writes:
     simulations/output/tme-3d/trajectory_axial.mp4  (if ffmpeg available)
 
 Visualization:
-    Three panels showing the axial mid-slice (l = layers/2) of the
-    spheroid at each step:
+    Three panels showing a central mid-plane slice (the row axis fixed
+    at rows/2) of the spheroid at each step:
       1. Dead-cell mask    (grayscale background + red dead cells)
       2. DAMP field        (inferno colormap, dynamic range)
       3. LP (lipid perox.) (viridis colormap, dynamic range)
@@ -108,8 +108,12 @@ def _render(
     skip_mp4: bool,
 ) -> list[Path]:
     """Build the FuncAnimation and save GIF (+ MP4 unless skip_mp4)."""
-    n_steps, layers, rows, cols = dead.shape
-    mid_l = layers // 2  # axial mid-slice
+    # The Rust grid is stored C-order as (row, col, layer), so np.load
+    # yields axes (step, row, col, layer). The spheroid is a centered,
+    # isotropic 60³ cube, so fixing any spatial axis at its midpoint
+    # gives an equivalent central cross-section through the core.
+    n_steps, n_rows, _n_cols, _n_layers = dead.shape
+    mid = n_rows // 2  # central mid-plane; the slice spans (col, layer)
 
     # Compute global color ranges so the animation has stable color scales
     # (otherwise each frame's vmin/vmax shifts and the animation flickers).
@@ -121,19 +125,19 @@ def _render(
     fig.suptitle(
         f"sim-tme-3d  axial mid-slice  ({cond.get('treatment', '?')}, "
         f"immune={cond.get('immune_mode', '?')}, "
-        f"stromal={cond.get('stromal_mode', 'off')}, "
-        f"ph={cond.get('ph_mode', 'off')}, "
+        f"stromal={cond.get('stromal_mode') or 'off'}, "
+        f"ph={cond.get('ph_mode') or 'off'}, "
         f"λ_O₂={cond.get('o2_lambda_um', '?')}µm)",
         fontsize=10,
     )
 
     dead_cmap = _make_dead_cmap()
-    im_dead = axes[0].imshow(dead[0, mid_l], cmap=dead_cmap, vmin=0, vmax=1, origin="lower")
+    im_dead = axes[0].imshow(dead[0, mid], cmap=dead_cmap, vmin=0, vmax=1, origin="lower")
     im_damp = axes[1].imshow(
-        damp[0, mid_l], cmap="inferno", vmin=0, vmax=damp_max, origin="lower"
+        damp[0, mid], cmap="inferno", vmin=0, vmax=damp_max, origin="lower"
     )
     im_lp = axes[2].imshow(
-        lp[0, mid_l], cmap="viridis", vmin=0, vmax=lp_max, origin="lower"
+        lp[0, mid], cmap="viridis", vmin=0, vmax=lp_max, origin="lower"
     )
 
     axes[0].set_title("Dead-cell mask")
@@ -149,11 +153,11 @@ def _render(
     step_text = fig.text(0.5, 0.02, "", ha="center", fontsize=9, family="monospace")
 
     def update(step: int):
-        im_dead.set_data(dead[step, mid_l])
-        im_damp.set_data(damp[step, mid_l])
-        im_lp.set_data(lp[step, mid_l])
+        im_dead.set_data(dead[step, mid])
+        im_damp.set_data(damp[step, mid])
+        im_lp.set_data(lp[step, mid])
         # Count cumulative dead cells in this slice for a quantitative cue.
-        n_dead_slice = int(dead[step, mid_l].sum())
+        n_dead_slice = int(dead[step, mid].sum())
         step_text.set_text(f"step {step + 1:3d}/{n_steps}    dead-in-slice={n_dead_slice}")
         return [im_dead, im_damp, im_lp, step_text]
 

--- a/scripts/render_tme_3d_trajectory.py
+++ b/scripts/render_tme_3d_trajectory.py
@@ -1,0 +1,219 @@
+"""Render an animated axial-slice GIF (and MP4) of sim-tme-3d's
+per-step trajectory captured by `sim-tme-3d --snapshot` (#193).
+
+Reads:
+    simulations/output/tme-3d/trajectory_dead.npy   (u8, n_steps x layers x rows x cols)
+    simulations/output/tme-3d/trajectory_damp.npy   (f32, same shape)
+    simulations/output/tme-3d/trajectory_lp.npy     (f32, same shape)
+    simulations/output/tme-3d/trajectory_meta.json  (condition + grid descriptor)
+
+Writes:
+    simulations/output/tme-3d/trajectory_axial.gif
+    simulations/output/tme-3d/trajectory_axial.mp4  (if ffmpeg available)
+
+Visualization:
+    Three panels showing the axial mid-slice (l = layers/2) of the
+    spheroid at each step:
+      1. Dead-cell mask    (grayscale background + red dead cells)
+      2. DAMP field        (inferno colormap, dynamic range)
+      3. LP (lipid perox.) (viridis colormap, dynamic range)
+    180 frames at 15 fps = 12s animation.
+
+Run:
+    python3 scripts/render_tme_3d_trajectory.py
+    python3 scripts/render_tme_3d_trajectory.py --fps 30 --no-mp4
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import matplotlib.animation as animation
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.colors import ListedColormap
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TRAJ_DIR = REPO_ROOT / "simulations" / "output" / "tme-3d"
+EXPECTED_SCHEMA_VERSION = 1
+
+
+def _load_trajectory(traj_dir: Path) -> tuple[np.ndarray, np.ndarray, np.ndarray, dict]:
+    """Load the three trajectory arrays + metadata; assert schema version.
+
+    Returns (dead, damp, lp, meta). Raises SystemExit on missing files
+    or schema mismatch with a clear, actionable message.
+    """
+    required = [
+        "trajectory_dead.npy",
+        "trajectory_damp.npy",
+        "trajectory_lp.npy",
+        "trajectory_meta.json",
+    ]
+    missing = [f for f in required if not (traj_dir / f).exists()]
+    if missing:
+        raise SystemExit(
+            f"ERROR: missing trajectory file(s) in {traj_dir}: {missing}\n"
+            f"Run `cargo run --release -p sim-tme-3d -- --snapshot` first."
+        )
+
+    meta = json.loads((traj_dir / "trajectory_meta.json").read_text())
+    v = meta.get("schema_version")
+    if v != EXPECTED_SCHEMA_VERSION:
+        raise SystemExit(
+            f"ERROR: trajectory_meta.json schema_version={v!r}, expected "
+            f"{EXPECTED_SCHEMA_VERSION}. Bump the renderer or regenerate "
+            f"the trajectory with a matching binary."
+        )
+
+    dead = np.load(traj_dir / "trajectory_dead.npy")
+    damp = np.load(traj_dir / "trajectory_damp.npy")
+    lp = np.load(traj_dir / "trajectory_lp.npy")
+
+    # Shape sanity — the renderer assumes 4-D (steps, layers, rows, cols).
+    for name, a in [("dead", dead), ("damp", damp), ("lp", lp)]:
+        if a.ndim != 4:
+            raise SystemExit(
+                f"ERROR: trajectory_{name}.npy has ndim={a.ndim}, expected 4 "
+                f"(steps, layers, rows, cols)."
+            )
+    if not (dead.shape == damp.shape == lp.shape):
+        raise SystemExit(
+            f"ERROR: trajectory arrays disagree on shape: "
+            f"dead={dead.shape}, damp={damp.shape}, lp={lp.shape}."
+        )
+    return dead, damp, lp, meta
+
+
+def _make_dead_cmap() -> ListedColormap:
+    """Binary cmap: 0 → very light grey (alive/background), 1 → red (dead).
+
+    Distinct from `Reds` so the spheroid is visible even when there
+    are zero dead cells in a slice.
+    """
+    return ListedColormap([(0.92, 0.92, 0.92, 1.0), (0.86, 0.14, 0.14, 1.0)])
+
+
+def _render(
+    dead: np.ndarray,
+    damp: np.ndarray,
+    lp: np.ndarray,
+    meta: dict,
+    out_dir: Path,
+    fps: int,
+    skip_mp4: bool,
+) -> list[Path]:
+    """Build the FuncAnimation and save GIF (+ MP4 unless skip_mp4)."""
+    n_steps, layers, rows, cols = dead.shape
+    mid_l = layers // 2  # axial mid-slice
+
+    # Compute global color ranges so the animation has stable color scales
+    # (otherwise each frame's vmin/vmax shifts and the animation flickers).
+    damp_max = max(float(damp.max()), 1e-6)
+    lp_max = max(float(lp.max()), 1e-6)
+
+    fig, axes = plt.subplots(1, 3, figsize=(13, 4.5), constrained_layout=True)
+    cond = meta.get("condition", {})
+    fig.suptitle(
+        f"sim-tme-3d  axial mid-slice  ({cond.get('treatment', '?')}, "
+        f"immune={cond.get('immune_mode', '?')}, "
+        f"stromal={cond.get('stromal_mode', 'off')}, "
+        f"ph={cond.get('ph_mode', 'off')}, "
+        f"λ_O₂={cond.get('o2_lambda_um', '?')}µm)",
+        fontsize=10,
+    )
+
+    dead_cmap = _make_dead_cmap()
+    im_dead = axes[0].imshow(dead[0, mid_l], cmap=dead_cmap, vmin=0, vmax=1, origin="lower")
+    im_damp = axes[1].imshow(
+        damp[0, mid_l], cmap="inferno", vmin=0, vmax=damp_max, origin="lower"
+    )
+    im_lp = axes[2].imshow(
+        lp[0, mid_l], cmap="viridis", vmin=0, vmax=lp_max, origin="lower"
+    )
+
+    axes[0].set_title("Dead-cell mask")
+    axes[1].set_title(f"DAMP field (max={damp_max:.2f})")
+    axes[2].set_title(f"LP field (max={lp_max:.2f})")
+    for ax in axes:
+        ax.set_xticks([])
+        ax.set_yticks([])
+
+    fig.colorbar(im_damp, ax=axes[1], fraction=0.045, pad=0.04)
+    fig.colorbar(im_lp, ax=axes[2], fraction=0.045, pad=0.04)
+
+    step_text = fig.text(0.5, 0.02, "", ha="center", fontsize=9, family="monospace")
+
+    def update(step: int):
+        im_dead.set_data(dead[step, mid_l])
+        im_damp.set_data(damp[step, mid_l])
+        im_lp.set_data(lp[step, mid_l])
+        # Count cumulative dead cells in this slice for a quantitative cue.
+        n_dead_slice = int(dead[step, mid_l].sum())
+        step_text.set_text(f"step {step + 1:3d}/{n_steps}    dead-in-slice={n_dead_slice}")
+        return [im_dead, im_damp, im_lp, step_text]
+
+    interval_ms = max(1, int(1000.0 / fps))
+    anim = animation.FuncAnimation(
+        fig, update, frames=n_steps, interval=interval_ms, blit=False
+    )
+
+    written: list[Path] = []
+    gif_path = out_dir / "trajectory_axial.gif"
+    print(f"Writing {gif_path.relative_to(REPO_ROOT)} ({n_steps} frames @ {fps} fps)…")
+    anim.save(gif_path, writer=animation.PillowWriter(fps=fps))
+    written.append(gif_path)
+
+    if not skip_mp4:
+        mp4_path = out_dir / "trajectory_axial.mp4"
+        try:
+            print(f"Writing {mp4_path.relative_to(REPO_ROOT)} (ffmpeg)…")
+            anim.save(mp4_path, writer=animation.FFMpegWriter(fps=fps, bitrate=2400))
+            written.append(mp4_path)
+        except (FileNotFoundError, RuntimeError) as e:
+            # ffmpeg not on PATH or matplotlib's writer rejected the
+            # invocation. GIF still landed, so this is degraded-output,
+            # not a hard fail.
+            print(f"  skipped MP4 ({type(e).__name__}: {e}); GIF still produced.")
+
+    plt.close(fig)
+    return written
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "--traj-dir",
+        type=Path,
+        default=TRAJ_DIR,
+        help=f"Trajectory directory (default: {TRAJ_DIR.relative_to(REPO_ROOT)})",
+    )
+    parser.add_argument(
+        "--fps",
+        type=int,
+        default=15,
+        help="Frames per second (default 15 → 12s for 180 steps)",
+    )
+    parser.add_argument(
+        "--no-mp4",
+        action="store_true",
+        help="Skip MP4 output (GIF only). Useful when ffmpeg is unavailable.",
+    )
+    args = parser.parse_args()
+
+    dead, damp, lp, meta = _load_trajectory(args.traj_dir)
+    written = _render(
+        dead, damp, lp, meta, args.traj_dir, fps=args.fps, skip_mp4=args.no_mp4
+    )
+    print(f"\nDone. Wrote {len(written)} file(s):")
+    for p in written:
+        print(f"  {p.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/simulations/sim-tme-3d/README.md
+++ b/simulations/sim-tme-3d/README.md
@@ -53,6 +53,30 @@ python3 ../scripts/generate_3d_comparison_table.py
 
 The 3D 24-condition run takes ~15-30 seconds on 8 cores (rayon condition-level parallelism). The 2D prerequisite (`sim-tme`) is much heavier — 10-30 minutes on the same hardware.
 
+## Trajectory snapshot (`--snapshot`, #193)
+
+For visualization, pass `--snapshot` to run **one** condition (RSL3 + immune_on + stromal_on + ph_on at λ=120 µm — the most visually rich cell of the matrix) with per-step state capture:
+
+```bash
+cd simulations
+cargo run --release -p sim-tme-3d -- --snapshot
+# → output/tme-3d/trajectory_dead.npy   (180 × 60 × 60 × 60, u8)
+# → output/tme-3d/trajectory_damp.npy   (180 × 60 × 60 × 60, f32)
+# → output/tme-3d/trajectory_lp.npy     (180 × 60 × 60 × 60, f32)
+# → output/tme-3d/trajectory_meta.json  (schema + condition descriptor)
+
+# Render an animated axial mid-slice GIF (+ MP4 if ffmpeg available)
+python3 ../scripts/render_tme_3d_trajectory.py
+# → output/tme-3d/trajectory_axial.gif  (~4 MB, 180 frames @ 15 fps = 12s)
+# → output/tme-3d/trajectory_axial.mp4  (if ffmpeg on PATH)
+```
+
+The default 24-condition matrix path (no `--snapshot` flag) is **byte-identical** to before #193 — `summary.json` hash is unchanged. Only the snapshot path touches the new trajectory capture code.
+
+**On-disk size**: ~333 MB total (37 MB dead + 148 MB damp + 148 MB lp). `output/` is git-ignored; the trajectory is meant to be regenerated locally.
+
+**Schema versioning**: `trajectory_meta.json` carries its own `schema_version: u32` (currently `1`), separate from `summary.json`'s schema. The Python renderer hard-asserts the version to fail loudly on drift.
+
 ## Condition matrix
 
 | Category | Conditions | Description |

--- a/simulations/sim-tme-3d/README.md
+++ b/simulations/sim-tme-3d/README.md
@@ -53,13 +53,25 @@ python3 ../scripts/generate_3d_comparison_table.py
 
 The 3D 24-condition run takes ~15-30 seconds on 8 cores (rayon condition-level parallelism). The 2D prerequisite (`sim-tme`) is much heavier — 10-30 minutes on the same hardware.
 
-## Trajectory snapshot (`--snapshot`, #193)
+## Trajectory snapshot (`--snapshot[=NAME]`, #193)
 
 For visualization, pass `--snapshot` to run **one** condition (RSL3 + immune_on + stromal_on + ph_on at λ=120 µm — the most visually rich cell of the matrix) with per-step state capture:
 
+**Presets** (`--snapshot=NAME`; bare `--snapshot` resolves to `combined`,
+so the original UX is preserved). An unknown name prints the list and
+exits 2; add a preset via a one-entry change to the `SNAPSHOTS` registry
+in `main.rs`. All presets are RSL3 at λ=120 µm; the toggles vary, and the
+output files use the same names regardless of preset (a rerun overwrites).
+
+| Name | Condition |
+|---|---|
+| `combined` (default) | RSL3 + immune_on + stromal_on + ph_on. All TME protections active, the most visually rich cell of the matrix. |
+| `bare` | RSL3 with none of the TME protections. The death front sweeps the spheroid more visibly (~3x higher kill rate than `combined`). |
+
 ```bash
 cd simulations
-cargo run --release -p sim-tme-3d -- --snapshot
+cargo run --release -p sim-tme-3d -- --snapshot          # = --snapshot=combined
+cargo run --release -p sim-tme-3d -- --snapshot=bare     # unprotected baseline (overwrites the files)
 # → output/tme-3d/trajectory_dead.npy   (180 × 60 × 60 × 60, u8)
 # → output/tme-3d/trajectory_damp.npy   (180 × 60 × 60 × 60, f32)
 # → output/tme-3d/trajectory_lp.npy     (180 × 60 × 60 × 60, f32)

--- a/simulations/sim-tme-3d/src/main.rs
+++ b/simulations/sim-tme-3d/src/main.rs
@@ -830,37 +830,103 @@ fn generate_conditions() -> Vec<Condition> {
 // Main
 // ============================================================
 
-/// Run a single condition with per-step trajectory capture, then write
-/// `trajectory_{dead,damp,lp}.npy` + `trajectory_meta.json` to
-/// `output_dir`. Used by the `--snapshot` CLI flag (#193).
-///
-/// Hard-coded to the RSL3 + immune + stromal + pH condition at λ=120
-/// — the most visually interesting cell of the matrix (ferroptosis
-/// kill front + immune kills at boundary + stromal shielding + pH
-/// iron release all visible). A future PR can make the condition
-/// CLI-selectable.
-fn run_snapshot(output_dir: &Path, tumor_radius_um: f64) {
-    let condition = Condition {
-        name: "snapshot_combined_RSL3".to_string(),
-        treatment: Treatment::RSL3,
-        treatment_name: "RSL3".to_string(),
-        o2_lambda: Some(ZONE_REF_LAMBDA),
+/// Parse a `--snapshot[=NAME]` argument from the CLI args iterator.
+/// Returns `Some(name)` if the flag is present (defaults to
+/// `"combined"` if no `=NAME` suffix), `None` otherwise. Unknown
+/// preset names are validated downstream by [`resolve_snapshot`].
+fn parse_snapshot_arg<I: IntoIterator<Item = String>>(args: I) -> Option<String> {
+    for a in args {
+        if a == "--snapshot" {
+            return Some("combined".to_string());
+        }
+        if let Some(name) = a.strip_prefix("--snapshot=") {
+            return Some(name.to_string());
+        }
+    }
+    None
+}
+
+/// One entry in the `--snapshot=NAME` registry. Each entry pins a
+/// reproducible condition for visualization. Names are stable; adding
+/// a new variant doesn't change existing ones. See [`SNAPSHOTS`].
+struct SnapshotPreset {
+    /// CLI name (e.g. `combined`, `bare`). Used as `--snapshot=NAME`.
+    name: &'static str,
+    /// Short human-readable description for the eprintln banner.
+    desc: &'static str,
+    /// True if immune kills + DAMP coupling are on (immune_mode = "immune_on").
+    immune_on: bool,
+    /// True if stromal protection (CAF GSH/MUFA shielding) is on.
+    stromal_on: bool,
+    /// True if the pH gradient + iron release + ion-trap are on.
+    ph_on: bool,
+}
+
+/// Visualization presets for `--snapshot=NAME`. Keep this list small —
+/// each entry costs ~333 MB on disk when its trajectory is generated.
+const SNAPSHOTS: &[SnapshotPreset] = &[
+    SnapshotPreset {
+        name: "combined",
+        desc: "RSL3 + immune + stromal + pH (all TME protections active)",
         immune_on: true,
         stromal_on: true,
         ph_on: true,
+    },
+    SnapshotPreset {
+        name: "bare",
+        desc: "RSL3, no immune / stromal / pH (the unprotected baseline)",
+        immune_on: false,
+        stromal_on: false,
+        ph_on: false,
+    },
+];
+
+/// Look up a snapshot preset by name, or print available choices and exit.
+fn resolve_snapshot(name: &str) -> &'static SnapshotPreset {
+    SNAPSHOTS
+        .iter()
+        .find(|s| s.name == name)
+        .unwrap_or_else(|| {
+            eprintln!("ERROR: unknown --snapshot name `{name}`. Available presets:");
+            for s in SNAPSHOTS {
+                eprintln!("  {:<10} — {}", s.name, s.desc);
+            }
+            std::process::exit(2);
+        })
+}
+
+/// Run a single condition with per-step trajectory capture, then write
+/// `trajectory_{dead,damp,lp}.npy` + `trajectory_meta.json` to
+/// `output_dir`. Driven by the `--snapshot[=NAME]` CLI flag (#193).
+///
+/// All snapshots use RSL3 at λ=120 µm; the toggles (immune / stromal /
+/// pH) vary by [`SnapshotPreset`]. Files are written under the same
+/// names regardless of preset — running a second time overwrites; rename
+/// manually if you want to keep multiple side by side.
+fn run_snapshot(output_dir: &Path, tumor_radius_um: f64, name: &str) {
+    let preset = resolve_snapshot(name);
+    let condition = Condition {
+        name: format!("snapshot_{}_RSL3", preset.name),
+        treatment: Treatment::RSL3,
+        treatment_name: "RSL3".to_string(),
+        o2_lambda: Some(ZONE_REF_LAMBDA),
+        immune_on: preset.immune_on,
+        stromal_on: preset.stromal_on,
+        ph_on: preset.ph_on,
     };
 
     eprintln!(
-        "=== --snapshot: capturing trajectory for `{}` ({}³ × {} steps) ===",
-        condition.name, GRID_DIM, N_STEPS,
+        "=== --snapshot={}: {} ({}³ × {} steps) ===",
+        preset.name, preset.desc, GRID_DIM, N_STEPS,
     );
 
     let run_cfg = RunConfig::production();
     let mut buffers = snapshot::SnapshotBuffers::new(run_cfg.grid_dim, run_cfg.n_steps);
     let result = run_one_condition_with_config(&condition, run_cfg, Some(&mut buffers));
     eprintln!(
-        "  done — total_kill={:.1}%, immune_kills={}, captured {} steps",
+        "  done — total_kill={:.1}%, ferroptosis_kills={}, immune_kills={}, captured {} steps",
         result.overall_kill_rate * 100.0,
+        result.ferroptosis_kills.unwrap_or(0),
         result.immune_kills.unwrap_or(0),
         buffers.steps_captured(),
     );
@@ -879,9 +945,9 @@ fn run_snapshot(output_dir: &Path, tumor_radius_um: f64) {
             treatment: "RSL3".to_string(),
             o2_condition: "gradient".to_string(),
             o2_lambda_um: Some(ZONE_REF_LAMBDA),
-            immune_mode: "immune_on".to_string(),
-            stromal_mode: Some("stromal_on".to_string()),
-            ph_mode: Some("ph_on".to_string()),
+            immune_mode: if preset.immune_on { "immune_on" } else { "off" }.to_string(),
+            stromal_mode: preset.stromal_on.then(|| "stromal_on".to_string()),
+            ph_mode: preset.ph_on.then(|| "ph_on".to_string()),
         },
     };
     let meta_path = output_dir.join("trajectory_meta.json");
@@ -940,13 +1006,14 @@ fn main() {
     let output_dir = Path::new("output/tme-3d");
     fs::create_dir_all(output_dir).expect("Failed to create output/tme-3d");
 
-    // `--snapshot` runs ONE visualization-focused condition (RSL3 with
-    // immune + stromal + pH on at λ=120) and captures per-step state
-    // for the Python animation. Default path (no flag) is unchanged:
-    // runs the full 24-condition matrix → summary.json. Bit-identical
-    // when the flag is absent (snapshot path doesn't touch the matrix).
-    if std::env::args().any(|a| a == "--snapshot") {
-        run_snapshot(output_dir, tumor_radius_um);
+    // `--snapshot[=NAME]` runs ONE visualization-focused condition with
+    // per-step state capture for the Python animation. Default path (no
+    // flag) is unchanged: runs the full 24-condition matrix →
+    // summary.json. Bit-identical when the flag is absent (snapshot path
+    // doesn't touch the matrix). Names listed in `SNAPSHOTS`; bare
+    // `--snapshot` defaults to `combined`.
+    if let Some(name) = parse_snapshot_arg(std::env::args()) {
+        run_snapshot(output_dir, tumor_radius_um, &name);
         return;
     }
 
@@ -1007,6 +1074,39 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `--snapshot` (no `=NAME`) defaults to `combined`.
+    #[test]
+    fn parse_snapshot_arg_bare_defaults_to_combined() {
+        let args = vec!["sim-tme-3d".to_string(), "--snapshot".to_string()];
+        assert_eq!(parse_snapshot_arg(args), Some("combined".to_string()));
+    }
+
+    /// `--snapshot=bare` extracts the name after `=`.
+    #[test]
+    fn parse_snapshot_arg_equals_form_extracts_name() {
+        let args = vec!["sim-tme-3d".to_string(), "--snapshot=bare".to_string()];
+        assert_eq!(parse_snapshot_arg(args), Some("bare".to_string()));
+    }
+
+    /// Absent flag returns None (the default 24-condition matrix path).
+    #[test]
+    fn parse_snapshot_arg_absent_returns_none() {
+        let args = vec!["sim-tme-3d".to_string()];
+        assert_eq!(parse_snapshot_arg(args), None);
+    }
+
+    /// All `SNAPSHOTS` entries have unique names (used as the `=NAME`
+    /// match key downstream). A typo or copy-paste duplicate would
+    /// make `resolve_snapshot` ambiguous (first-match-wins).
+    #[test]
+    fn snapshot_preset_names_are_unique() {
+        let mut names: Vec<&str> = SNAPSHOTS.iter().map(|s| s.name).collect();
+        names.sort();
+        let original = names.len();
+        names.dedup();
+        assert_eq!(names.len(), original, "duplicate snapshot preset name");
+    }
 
     /// Smoke test: condition matrix is non-empty and well-formed.
     #[test]

--- a/simulations/sim-tme-3d/src/main.rs
+++ b/simulations/sim-tme-3d/src/main.rs
@@ -49,6 +49,7 @@ use std::fs;
 use std::path::Path;
 
 mod npy;
+mod snapshot;
 
 use ferroptosis_core::biochem::{sim_cell_step, CellState};
 use ferroptosis_core::cell::Treatment;
@@ -276,10 +277,14 @@ impl RunConfig {
 }
 
 fn run_one_condition(condition: &Condition) -> ConditionResult {
-    run_one_condition_with_config(condition, RunConfig::production())
+    run_one_condition_with_config(condition, RunConfig::production(), None)
 }
 
-fn run_one_condition_with_config(condition: &Condition, run_cfg: RunConfig) -> ConditionResult {
+fn run_one_condition_with_config(
+    condition: &Condition,
+    run_cfg: RunConfig,
+    mut snapshot: Option<&mut snapshot::SnapshotBuffers>,
+) -> ConditionResult {
     let params = Params::default();
     let spatial_params = SpatialParams {
         cell_size_um: CELL_SIZE_UM,
@@ -588,6 +593,14 @@ fn run_one_condition_with_config(condition: &Condition, run_cfg: RunConfig) -> C
                 }
             }
         }
+
+        // Per-step trajectory capture for `--snapshot` runs. No-op for the
+        // default 24-condition matrix path (snapshot is None there).
+        // Captured *after* all per-step work (biochem + DAMP + immune kill)
+        // so the snapshot reflects end-of-step state.
+        if let Some(buf) = snapshot.as_mut() {
+            buf.capture_step(&grid, &damp_field);
+        }
     }
 
     // Late DAMP release for cells still in their post-death grace period at
@@ -817,6 +830,71 @@ fn generate_conditions() -> Vec<Condition> {
 // Main
 // ============================================================
 
+/// Run a single condition with per-step trajectory capture, then write
+/// `trajectory_{dead,damp,lp}.npy` + `trajectory_meta.json` to
+/// `output_dir`. Used by the `--snapshot` CLI flag (#193).
+///
+/// Hard-coded to the RSL3 + immune + stromal + pH condition at λ=120
+/// — the most visually interesting cell of the matrix (ferroptosis
+/// kill front + immune kills at boundary + stromal shielding + pH
+/// iron release all visible). A future PR can make the condition
+/// CLI-selectable.
+fn run_snapshot(output_dir: &Path, tumor_radius_um: f64) {
+    let condition = Condition {
+        name: "snapshot_combined_RSL3".to_string(),
+        treatment: Treatment::RSL3,
+        treatment_name: "RSL3".to_string(),
+        o2_lambda: Some(ZONE_REF_LAMBDA),
+        immune_on: true,
+        stromal_on: true,
+        ph_on: true,
+    };
+
+    eprintln!(
+        "=== --snapshot: capturing trajectory for `{}` ({}³ × {} steps) ===",
+        condition.name, GRID_DIM, N_STEPS,
+    );
+
+    let run_cfg = RunConfig::production();
+    let mut buffers = snapshot::SnapshotBuffers::new(run_cfg.grid_dim, run_cfg.n_steps);
+    let result = run_one_condition_with_config(&condition, run_cfg, Some(&mut buffers));
+    eprintln!(
+        "  done — total_kill={:.1}%, immune_kills={}, captured {} steps",
+        result.overall_kill_rate * 100.0,
+        result.immune_kills.unwrap_or(0),
+        buffers.steps_captured(),
+    );
+
+    buffers
+        .write(output_dir)
+        .expect("Failed to write trajectory .npy files");
+
+    let meta = snapshot::TrajectoryMeta {
+        schema_version: snapshot::TRAJECTORY_SCHEMA_VERSION,
+        grid_dim: run_cfg.grid_dim,
+        cell_size_um: CELL_SIZE_UM,
+        tumor_radius_um,
+        n_steps: run_cfg.n_steps,
+        condition: snapshot::TrajectoryCondition {
+            treatment: "RSL3".to_string(),
+            o2_condition: "gradient".to_string(),
+            o2_lambda_um: Some(ZONE_REF_LAMBDA),
+            immune_mode: "immune_on".to_string(),
+            stromal_mode: Some("stromal_on".to_string()),
+            ph_mode: Some("ph_on".to_string()),
+        },
+    };
+    let meta_path = output_dir.join("trajectory_meta.json");
+    fs::write(&meta_path, serde_json::to_string_pretty(&meta).unwrap())
+        .expect("Failed to write trajectory_meta.json");
+
+    eprintln!(
+        "Wrote {} + trajectory_{{dead,damp,lp}}.npy",
+        meta_path.display()
+    );
+    eprintln!("Render with: python3 scripts/render_tme_3d_trajectory.py");
+}
+
 fn main() {
     // Guard against silent drift between this binary's metadata const and
     // the library's runtime value: if a future PR tunes
@@ -861,6 +939,16 @@ fn main() {
 
     let output_dir = Path::new("output/tme-3d");
     fs::create_dir_all(output_dir).expect("Failed to create output/tme-3d");
+
+    // `--snapshot` runs ONE visualization-focused condition (RSL3 with
+    // immune + stromal + pH on at λ=120) and captures per-step state
+    // for the Python animation. Default path (no flag) is unchanged:
+    // runs the full 24-condition matrix → summary.json. Bit-identical
+    // when the flag is absent (snapshot path doesn't touch the matrix).
+    if std::env::args().any(|a| a == "--snapshot") {
+        run_snapshot(output_dir, tumor_radius_um);
+        return;
+    }
 
     let conditions = generate_conditions();
     eprintln!(
@@ -956,7 +1044,7 @@ mod tests {
             stromal_on: false,
             ph_on: false,
         };
-        let r = run_one_condition_with_config(&cond, RunConfig::for_test());
+        let r = run_one_condition_with_config(&cond, RunConfig::for_test(), None);
         assert_eq!(r.treatment, "Control");
         assert_eq!(r.o2_condition, "uniform");
         assert_eq!(r.immune_mode, "off");
@@ -985,8 +1073,8 @@ mod tests {
             stromal_on: false,
             ph_on: false,
         };
-        let r1 = run_one_condition_with_config(&cond, RunConfig::for_test());
-        let r2 = run_one_condition_with_config(&cond, RunConfig::for_test());
+        let r1 = run_one_condition_with_config(&cond, RunConfig::for_test(), None);
+        let r2 = run_one_condition_with_config(&cond, RunConfig::for_test(), None);
         assert_eq!(r1.total_dead, r2.total_dead);
         assert_eq!(r1.total_tumor, r2.total_tumor);
         assert_eq!(r1.overall_kill_rate, r2.overall_kill_rate);
@@ -1026,7 +1114,7 @@ mod tests {
             grid_dim: 25,
             n_steps: 130,
         };
-        let r = run_one_condition_with_config(&cond, cfg);
+        let r = run_one_condition_with_config(&cond, cfg, None);
         assert_eq!(r.immune_mode, "immune_on");
         let im_kills = r
             .immune_kills
@@ -1062,7 +1150,7 @@ mod tests {
             grid_dim: 15,
             n_steps: 80,
         };
-        let r = run_one_condition_with_config(&cond, cfg);
+        let r = run_one_condition_with_config(&cond, cfg, None);
         let ferro = r.ferroptosis_kills.expect("immune_on populates this");
         let im = r.immune_kills.expect("immune_on populates this");
         assert_eq!(
@@ -1103,7 +1191,7 @@ mod tests {
         let run = |conds: &[Condition]| -> Vec<ConditionResult> {
             conds
                 .par_iter()
-                .map(|c| run_one_condition_with_config(c, cfg))
+                .map(|c| run_one_condition_with_config(c, cfg, None))
                 .collect()
         };
 

--- a/simulations/sim-tme-3d/src/main.rs
+++ b/simulations/sim-tme-3d/src/main.rs
@@ -48,6 +48,8 @@
 use std::fs;
 use std::path::Path;
 
+mod npy;
+
 use ferroptosis_core::biochem::{sim_cell_step, CellState};
 use ferroptosis_core::cell::Treatment;
 use ferroptosis_core::grid::{TumorGrid3D, TUMOR_RADIUS_FRACTION};

--- a/simulations/sim-tme-3d/src/npy.rs
+++ b/simulations/sim-tme-3d/src/npy.rs
@@ -1,0 +1,202 @@
+//! Minimal NumPy `.npy` v1.0 writer for sim-tme-3d trajectory snapshots
+//! (#193).
+//!
+//! Supports flat n-dimensional arrays in `u8` (dead-cell mask) and `f32`
+//! (DAMP, LP fields). Hand-rolled because adding `ndarray-npy` would
+//! pull `ndarray` back into sim-tme-3d's dep graph (deliberately
+//! omitted per the #195 follow-up note in `Cargo.toml`), and the format
+//! is small enough that a focused writer is easier to audit.
+//!
+//! Format reference:
+//! <https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html>
+//!
+//! Output bytes:
+//! ```text
+//! \x93NUMPY \x01 \x00 <hdr_len: u16 LE> <dict ASCII> <spaces…> '\n' <data LE>
+//! ```
+//! where the prefix + dict + padding + newline must be a multiple of 64
+//! (so the data payload is 64-byte aligned for fast NumPy reads).
+//!
+//! Roundtrip is verified manually with `numpy.load`; the test below
+//! pins the exact header bytes for a known shape to catch any
+//! formatting drift.
+
+// `write_u8_array` and `write_f32_array` are consumed by the
+// `--snapshot` path added in the next commit. They're exercised by
+// the tests below, so the dead-code warning isn't load-bearing.
+#![allow(dead_code)]
+
+use std::fs::File;
+use std::io::{self, BufWriter, Write};
+use std::path::Path;
+
+const MAGIC: &[u8] = b"\x93NUMPY";
+const VERSION: &[u8] = b"\x01\x00";
+const HEADER_ALIGN: usize = 64;
+
+/// Build the ASCII Python-dict header. NumPy parses this with
+/// `ast.literal_eval`, so it must be valid Python syntax.
+fn build_header_dict(descr: &str, shape: &[usize]) -> String {
+    let shape_str = if shape.len() == 1 {
+        // 1-D needs trailing comma so Python parses it as a tuple, not int.
+        format!("({},)", shape[0])
+    } else {
+        shape
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    let shape_paren = if shape.len() == 1 {
+        shape_str
+    } else {
+        format!("({})", shape_str)
+    };
+    format!(
+        "{{'descr': '{}', 'fortran_order': False, 'shape': {}, }}",
+        descr, shape_paren
+    )
+}
+
+/// Write magic + version + len-prefixed dict header, padded so the
+/// data payload starts at a 64-byte boundary.
+fn write_header<W: Write>(w: &mut W, descr: &str, shape: &[usize]) -> io::Result<()> {
+    let dict = build_header_dict(descr, shape);
+    // Prefix: 6 magic + 2 version + 2 header-length = 10 bytes.
+    let prefix_len = MAGIC.len() + VERSION.len() + 2;
+    // Header body is dict + final newline; padded to align.
+    let unpadded = prefix_len + dict.len() + 1;
+    let pad = if unpadded.is_multiple_of(HEADER_ALIGN) {
+        0
+    } else {
+        HEADER_ALIGN - (unpadded % HEADER_ALIGN)
+    };
+    let header_len = dict.len() + pad + 1;
+    assert!(
+        header_len <= u16::MAX as usize,
+        "npy header too long ({header_len} bytes); use v2.0 format for headers > 65535"
+    );
+
+    w.write_all(MAGIC)?;
+    w.write_all(VERSION)?;
+    w.write_all(&(header_len as u16).to_le_bytes())?;
+    w.write_all(dict.as_bytes())?;
+    // Pad with spaces, then a final newline.
+    for _ in 0..pad {
+        w.write_all(b" ")?;
+    }
+    w.write_all(b"\n")?;
+    Ok(())
+}
+
+/// Write a flat `u8` array as a `.npy` file with the given shape.
+/// `data.len()` must equal the product of `shape`.
+pub fn write_u8_array<P: AsRef<Path>>(path: P, shape: &[usize], data: &[u8]) -> io::Result<()> {
+    let expected: usize = shape.iter().product();
+    assert_eq!(
+        data.len(),
+        expected,
+        "npy::write_u8_array: data.len()={} != shape product={} (shape={:?})",
+        data.len(),
+        expected,
+        shape
+    );
+    let mut w = BufWriter::new(File::create(path)?);
+    write_header(&mut w, "|u1", shape)?;
+    w.write_all(data)?;
+    w.flush()?;
+    Ok(())
+}
+
+/// Write a flat `f32` array as a `.npy` file with the given shape.
+/// `data.len()` must equal the product of `shape`. Values are written
+/// little-endian (matches the `'<f4'` dtype string).
+pub fn write_f32_array<P: AsRef<Path>>(path: P, shape: &[usize], data: &[f32]) -> io::Result<()> {
+    let expected: usize = shape.iter().product();
+    assert_eq!(
+        data.len(),
+        expected,
+        "npy::write_f32_array: data.len()={} != shape product={} (shape={:?})",
+        data.len(),
+        expected,
+        shape
+    );
+    let mut w = BufWriter::new(File::create(path)?);
+    write_header(&mut w, "<f4", shape)?;
+    for &v in data {
+        w.write_all(&v.to_le_bytes())?;
+    }
+    w.flush()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn header_dict_4d_matches_expected() {
+        let dict = build_header_dict("|u1", &[180, 60, 60, 60]);
+        assert_eq!(
+            dict,
+            "{'descr': '|u1', 'fortran_order': False, 'shape': (180, 60, 60, 60), }"
+        );
+    }
+
+    #[test]
+    fn header_dict_1d_has_trailing_comma() {
+        let dict = build_header_dict("<f4", &[5]);
+        // 1-D shape needs `(5,)` not `(5)` — otherwise Python parses as int.
+        assert_eq!(
+            dict,
+            "{'descr': '<f4', 'fortran_order': False, 'shape': (5,), }"
+        );
+    }
+
+    /// Full file bytes for a tiny u8 array. Locks the prefix + header
+    /// padding + body format so any future refactor that breaks
+    /// `numpy.load` compatibility trips this test.
+    #[test]
+    fn write_u8_array_bytes_are_npy_v1_compatible() {
+        let mut buf: Vec<u8> = Vec::new();
+        let mut w = Cursor::new(&mut buf);
+        write_header(&mut w, "|u1", &[2, 3]).unwrap();
+        // Data: 6 bytes
+        w.write_all(&[0u8, 1, 2, 3, 4, 5]).unwrap();
+
+        // Prefix bytes (magic + version + header-length u16)
+        assert_eq!(&buf[..6], b"\x93NUMPY");
+        assert_eq!(&buf[6..8], b"\x01\x00");
+        let header_len = u16::from_le_bytes([buf[8], buf[9]]) as usize;
+        // Total prefix + header MUST align to 64.
+        assert!(
+            (10 + header_len).is_multiple_of(HEADER_ALIGN),
+            "total prefix+header = {} bytes, not a multiple of {}",
+            10 + header_len,
+            HEADER_ALIGN
+        );
+        // Last byte of the header is the newline terminator.
+        assert_eq!(buf[10 + header_len - 1], b'\n');
+        // Header dict is parseable ASCII.
+        let header_str = std::str::from_utf8(&buf[10..10 + header_len - 1]).unwrap();
+        assert!(header_str.contains("'descr': '|u1'"));
+        assert!(header_str.contains("'fortran_order': False"));
+        assert!(header_str.contains("'shape': (2, 3)"));
+        // Body follows immediately after the header.
+        let body_start = 10 + header_len;
+        assert_eq!(&buf[body_start..body_start + 6], &[0u8, 1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn write_f32_array_uses_little_endian() {
+        let mut buf: Vec<u8> = Vec::new();
+        let mut w = Cursor::new(&mut buf);
+        write_header(&mut w, "<f4", &[1]).unwrap();
+        w.write_all(&1.0f32.to_le_bytes()).unwrap();
+        let header_len = u16::from_le_bytes([buf[8], buf[9]]) as usize;
+        let body_start = 10 + header_len;
+        // 1.0 f32 LE = 0x00 0x00 0x80 0x3F
+        assert_eq!(&buf[body_start..body_start + 4], &[0x00, 0x00, 0x80, 0x3F]);
+    }
+}

--- a/simulations/sim-tme-3d/src/snapshot.rs
+++ b/simulations/sim-tme-3d/src/snapshot.rs
@@ -1,0 +1,112 @@
+//! Per-step trajectory capture for visualizing sim-tme-3d runs (#193).
+//!
+//! Activated only when the binary is invoked with `--snapshot`; the
+//! default 24-condition matrix path doesn't touch any of this code,
+//! preserving bit-identical output. Captured data is written as three
+//! `.npy` files alongside a small JSON metadata sidecar, then consumed
+//! by `scripts/render_tme_3d_trajectory.py` to produce an animated
+//! axial-slice GIF/MP4.
+//!
+//! Memory budget at 60³ × 180 steps:
+//! - `dead`: 27000 × 180 × 1 byte = 4.9 MB
+//! - `damp`: 27000 × 180 × 4 bytes = 19.4 MB (f64 source cast to f32)
+//! - `lp`:   27000 × 180 × 4 bytes = 19.4 MB (same)
+//! Total ≈ 44 MB held during the snapshot run, dropped at write time.
+
+use std::path::Path;
+
+use ferroptosis_core::grid::TumorGrid3D;
+use serde::Serialize;
+
+use crate::npy;
+
+/// Schema version for `trajectory_meta.json`. Bump when the trajectory
+/// output shape changes (file count, axis order, dtype).
+pub const TRAJECTORY_SCHEMA_VERSION: u32 = 1;
+
+/// In-memory buffers for per-step trajectory state. Flat layout:
+/// `value(step, idx) = buf[step * n_cells + idx]`. The renderer
+/// reshapes to `(n_steps, layers, rows, cols)` per the meta sidecar.
+pub struct SnapshotBuffers {
+    pub dead: Vec<u8>,
+    pub damp: Vec<f32>,
+    pub lp: Vec<f32>,
+    grid_dim: usize,
+    steps_captured: u32,
+}
+
+impl SnapshotBuffers {
+    pub fn new(grid_dim: usize, n_steps: u32) -> Self {
+        let n_cells = grid_dim.pow(3);
+        let total = n_cells * n_steps as usize;
+        Self {
+            dead: Vec::with_capacity(total),
+            damp: Vec::with_capacity(total),
+            lp: Vec::with_capacity(total),
+            grid_dim,
+            steps_captured: 0,
+        }
+    }
+
+    /// Append one step of state. Must be called exactly once per
+    /// simulation step, in step order. `damp_field` length must match
+    /// `grid.cells.len()`.
+    pub fn capture_step(&mut self, grid: &TumorGrid3D, damp_field: &[f64]) {
+        debug_assert_eq!(
+            grid.cells.len(),
+            damp_field.len(),
+            "snapshot capture: grid/damp length mismatch"
+        );
+        for (idx, gc) in grid.cells.iter().enumerate() {
+            self.dead.push(u8::from(gc.state.dead));
+            self.damp.push(damp_field[idx] as f32);
+            self.lp.push(gc.state.lp as f32);
+        }
+        self.steps_captured += 1;
+    }
+
+    /// Write the three trajectory `.npy` files to `output_dir`.
+    /// Shape on disk: `(steps_captured, grid_dim, grid_dim, grid_dim)`.
+    pub fn write(&self, output_dir: &Path) -> std::io::Result<()> {
+        let shape = [
+            self.steps_captured as usize,
+            self.grid_dim,
+            self.grid_dim,
+            self.grid_dim,
+        ];
+        npy::write_u8_array(output_dir.join("trajectory_dead.npy"), &shape, &self.dead)?;
+        npy::write_f32_array(output_dir.join("trajectory_damp.npy"), &shape, &self.damp)?;
+        npy::write_f32_array(output_dir.join("trajectory_lp.npy"), &shape, &self.lp)?;
+        Ok(())
+    }
+
+    pub fn steps_captured(&self) -> u32 {
+        self.steps_captured
+    }
+}
+
+/// Metadata sidecar (`trajectory_meta.json`) describing the run that
+/// produced the `trajectory_*.npy` files. Lets the Python renderer
+/// label the animation without inferring from the binary.
+#[derive(Serialize)]
+pub struct TrajectoryMeta {
+    pub schema_version: u32,
+    pub grid_dim: usize,
+    pub cell_size_um: f64,
+    pub tumor_radius_um: f64,
+    pub n_steps: u32,
+    pub condition: TrajectoryCondition,
+}
+
+/// Subset of the run's `Condition` that's relevant for visualization
+/// labels. Mirrors the shape of `sim-tme-3d`'s `ConditionResult` for
+/// the immune/stromal/ph fields.
+#[derive(Serialize)]
+pub struct TrajectoryCondition {
+    pub treatment: String,
+    pub o2_condition: String,
+    pub o2_lambda_um: Option<f64>,
+    pub immune_mode: String,
+    pub stromal_mode: Option<String>,
+    pub ph_mode: Option<String>,
+}

--- a/simulations/sim-tme-3d/src/snapshot.rs
+++ b/simulations/sim-tme-3d/src/snapshot.rs
@@ -7,11 +7,15 @@
 //! by `scripts/render_tme_3d_trajectory.py` to produce an animated
 //! axial-slice GIF/MP4.
 //!
-//! Memory budget at 60³ × 180 steps:
-//! - `dead`: 27000 × 180 × 1 byte = 4.9 MB
-//! - `damp`: 27000 × 180 × 4 bytes = 19.4 MB (f64 source cast to f32)
-//! - `lp`:   27000 × 180 × 4 bytes = 19.4 MB (same)
-//! Total ≈ 44 MB held during the snapshot run, dropped at write time.
+//! Memory budget at 60³ × 180 steps (216 000 cells/step × 180 =
+//! 38.88 M elements per field):
+//!
+//! - `dead`: 38.88 M × 1 byte  ≈ 37 MB
+//! - `damp`: 38.88 M × 4 bytes ≈ 148 MB (f64 source cast to f32)
+//! - `lp`:   38.88 M × 4 bytes ≈ 148 MB (same)
+//!
+//! Total ≈ 333 MB held in RAM during the snapshot run, dropped at write
+//! time (matches the on-disk size — the `.npy` payloads are uncompressed).
 
 use std::path::Path;
 


### PR DESCRIPTION
## Summary

Adds 3D-simulation visualization for sim-tme-3d. Three commits:

- **1/3** \`c62d2567\` — Hand-rolled NumPy .npy v1.0 writer (no new deps), 4 unit tests.
- **2/3** \`fcc7d6b6\` — \`--snapshot\` CLI flag captures per-step state for one condition (RSL3 + immune + stromal + pH at λ=120 µm) and writes 3 .npy files + metadata sidecar. **Default 24-condition matrix path is byte-identical** (summary.json SHA matches post-#224 baseline \`1cf8866312...\`).
- **3/3** \`ad6b57ea\` — \`scripts/render_tme_3d_trajectory.py\` produces an animated axial mid-slice GIF (~4 MB, 180 frames @ 15 fps = 12s) and an MP4 (if ffmpeg available; graceful fallback). Plus docs.

Partial close on #193 — covers the axial-slice GIF / MP4 layer. Full 3D volume rendering (PyVista / plotly) is a deliberate follow-up.

## How to use

\`\`\`bash
cd simulations
cargo run --release -p sim-tme-3d -- --snapshot     # → trajectory_*.npy
python3 ../scripts/render_tme_3d_trajectory.py      # → trajectory_axial.gif
\`\`\`

## Visualization

Three side-by-side panels of the spheroid's axial mid-slice (layer = layers/2), animated through all 180 steps:

1. **Dead-cell mask** — light-grey background, red dead cells. Custom binary cmap so the spheroid outline is visible even with zero dead cells in the slice.
2. **DAMP field** — inferno colormap with fixed global vmax (no flicker between frames).
3. **LP (lipid peroxide) field** — viridis, same fixed-vmax treatment.

Suptitle echoes the condition; footer shows step counter + per-frame in-slice dead count.

## Verification

- \`cargo test --release -p sim-tme-3d\`: **12 passing** (8 existing + 4 new .npy writer tests).
- \`cargo fmt --all --check\`: exits 0.
- **Default-path bit-identical**: \`summary.json\` SHA-256 = \`1cf8866312...\` (matches post-#224 baseline). \`--snapshot\` flag is the only switch into the new capture path.
- **Snapshot output validated**: \`numpy.load\` reads all three files with expected shape \`(180, 60, 60, 60)\` and dtypes (\`uint8\`, \`float32\`, \`float32\`).
- **GIF validated**: 180 frames, 2600×900, GIF89a, loads in PIL.

## On-disk size

Per snapshot: ~333 MB total (37 MB dead + 148 MB DAMP + 148 MB LP). \`output/\` is git-ignored; trajectories are meant to be regenerated locally.

## Out of scope

- Full 3D volume rendering (PyVista / plotly) — heavy dep + X-server requirement on Linux CI.
- Per-step snapshot subsampling.
- Multi-condition snapshots (1 PR per condition's disk usage).
- CI integration test for the snapshot path — local manual verification is sufficient for now.

## Test plan

- [ ] CI: \`Rust Tests / test\` green
- [ ] CI: \`Rust Tests / fmt\` green
- [ ] CI: \`CodeQL\` / \`Analyze (rust)\` green
- [ ] Local: render the GIF and visually confirm the spheroid death front propagates from edge to core

🤖 Generated with [Claude Code](https://claude.com/claude-code)