### PR TITLE
Multi-dose pharmacokinetics: time-varying drug schedules (#239)

### DIFF
--- a/scripts/render_tme_3d_trajectory.py
+++ b/scripts/render_tme_3d_trajectory.py
@@ -120,14 +120,28 @@ def _render(
     damp_max = max(float(damp.max()), 1e-6)
     lp_max = max(float(lp.max()), 1e-6)
 
+    # Dose-administration steps (#239). Empty for steady-state Constant
+    # presets; non-empty for multi-dose / bolus / infusion snapshots, where
+    # we annotate the frames so the viewer can see death waves sync to doses.
+    dose_steps = set(int(s) for s in meta.get("dose_steps", []))
+    # Highlight the dose frame plus a few following frames (the death wave
+    # lags the dose), so the marker is visible for a beat rather than 1 frame.
+    dose_window = set()
+    for d in dose_steps:
+        for k in range(d, d + 5):
+            dose_window.add(k)
+
     fig, axes = plt.subplots(1, 3, figsize=(13, 4.5), constrained_layout=True)
     cond = meta.get("condition", {})
+    dose_caption = (
+        f"   doses@{sorted(dose_steps)}" if dose_steps else "   (constant dosing)"
+    )
     fig.suptitle(
         f"sim-tme-3d  axial mid-slice  ({cond.get('treatment', '?')}, "
         f"immune={cond.get('immune_mode', '?')}, "
         f"stromal={cond.get('stromal_mode') or 'off'}, "
         f"ph={cond.get('ph_mode') or 'off'}, "
-        f"λ_O₂={cond.get('o2_lambda_um', '?')}µm)",
+        f"λ_O₂={cond.get('o2_lambda_um', '?')}µm){dose_caption}",
         fontsize=10,
     )
 
@@ -158,7 +172,22 @@ def _render(
         im_lp.set_data(lp[step, mid])
         # Count cumulative dead cells in this slice for a quantitative cue.
         n_dead_slice = int(dead[step, mid].sum())
-        step_text.set_text(f"step {step + 1:3d}/{n_steps}    dead-in-slice={n_dead_slice}")
+        # Mark dose frames so multi-dose death waves are visually attributable.
+        if step in dose_steps:
+            dose_marker = "  💉 DOSE"
+        elif step in dose_window:
+            dose_marker = "  💉 ···"
+        else:
+            dose_marker = ""
+        step_text.set_text(
+            f"step {step + 1:3d}/{n_steps}    dead-in-slice={n_dead_slice}{dose_marker}"
+        )
+        # Red frame border on the dose step itself — a hard-to-miss cue.
+        border_on = step in dose_steps
+        for ax in axes:
+            for spine in ax.spines.values():
+                spine.set_edgecolor("red" if border_on else "none")
+                spine.set_linewidth(3.0 if border_on else 0.0)
         return [im_dead, im_damp, im_lp, step_text]
 
     interval_ms = max(1, int(1000.0 / fps))

--- a/simulations/ferroptosis-core/src/biochem.rs
+++ b/simulations/ferroptosis-core/src/biochem.rs
@@ -117,6 +117,27 @@ fn update_mufa_protection(current: f64, params: &Params) -> f64 {
     (current + growth - decay).clamp(0.0, params.scd_mufa_max.max(0.0))
 }
 
+/// Deterministic exogenous-ROS decay envelope for the post-bolus phase.
+///
+/// Models singlet-oxygen / exogenous-ROS decay after a single treatment
+/// bolus: `1.0` for `step < 30` (the pre-decay plateau, where
+/// [`sim_cell_step`] instead applies multiplicative noise), then
+/// `0.5^((step-30)/15)` — a 15-step half-life decay.
+///
+/// Exposed so a time-varying [`crate::dose_schedule::DoseSchedule`]
+/// consumer can **divide it out**: for multi-dose SDT/PDT the schedule's
+/// own per-dose rise+decay is the availability envelope, and this
+/// single-bolus envelope (keyed to run start) would otherwise
+/// double-count decay for later doses (#239).
+#[inline]
+pub fn exo_decay_factor(step: u32) -> f64 {
+    if step < 30 {
+        1.0
+    } else {
+        0.5_f64.powf((step - 30) as f64 / 15.0)
+    }
+}
+
 /// Execute a single timestep of the ferroptosis biochemistry.
 ///
 /// Returns `true` if the cell died this step.
@@ -142,7 +163,7 @@ pub fn sim_cell_step(
                 let exo = if step < 30 {
                     state.exo_ros_peak * norm(rng, 1.0, 0.1).max(0.0)
                 } else {
-                    state.exo_ros_peak * 0.5_f64.powf((step - 30) as f64 / 15.0)
+                    state.exo_ros_peak * exo_decay_factor(step)
                 };
                 let total_ros = cell.basal_ros + exo + fenton;
                 let effective_unsat = cell.lipid_unsat; // no MUFA protection
@@ -160,7 +181,7 @@ pub fn sim_cell_step(
     let exo = if step < 30 {
         state.exo_ros_peak * norm(rng, 1.0, 0.1).max(0.0)
     } else {
-        state.exo_ros_peak * 0.5_f64.powf((step - 30) as f64 / 15.0)
+        state.exo_ros_peak * exo_decay_factor(step)
     };
     let total_ros = cell.basal_ros + exo + fenton;
 
@@ -255,7 +276,7 @@ pub fn sim_cell(
         let exo = if step < 30 {
             exo_ros_peak * norm(rng, 1.0, 0.1).max(0.0)
         } else {
-            exo_ros_peak * 0.5_f64.powf((step - 30) as f64 / 15.0)
+            exo_ros_peak * exo_decay_factor(step)
         };
         let total_ros = cell.basal_ros + exo + fenton;
 
@@ -326,6 +347,23 @@ mod tests {
     use super::*;
     use crate::cell::{gen_cell, Phenotype};
     use rand::SeedableRng;
+
+    #[test]
+    fn exo_decay_factor_matches_envelope_formula() {
+        // Plateau: 1.0 for every step < 30.
+        for step in [0u32, 1, 15, 29] {
+            assert_eq!(exo_decay_factor(step), 1.0, "plateau must be 1.0");
+        }
+        // At the decay onset (step 30): exactly 1.0 (0.5^0).
+        assert_eq!(exo_decay_factor(30), 1.0);
+        // One half-life (15 steps) later: exactly 0.5.
+        assert!((exo_decay_factor(45) - 0.5).abs() < 1e-12);
+        // Two half-lives later: 0.25.
+        assert!((exo_decay_factor(60) - 0.25).abs() < 1e-12);
+        // Matches the raw formula it replaced, for an arbitrary later step.
+        let raw = 0.5_f64.powf((123 - 30) as f64 / 15.0);
+        assert_eq!(exo_decay_factor(123), raw);
+    }
 
     #[test]
     fn control_does_not_kill_glycolytic() {

--- a/simulations/ferroptosis-core/src/biochem.rs
+++ b/simulations/ferroptosis-core/src/biochem.rs
@@ -49,15 +49,43 @@ impl CellState {
 
     /// Initialize with a custom exogenous ROS peak (for spatial model where
     /// ROS dose depends on depth/position).
+    ///
+    /// Applies RSL3's one-shot GPX4 knockdown at init (the steady-state
+    /// model: drug is present from t=0 and immediately inhibits GPX4). This
+    /// is the historical behavior; callers using a time-varying
+    /// [`crate::dose_schedule::DoseSchedule`] for RSL3 should instead use
+    /// [`from_cell_with_ros_opts`](Self::from_cell_with_ros_opts) with
+    /// `apply_rsl3_init = false` and apply per-step inactivation themselves.
     pub fn from_cell_with_ros(
         cell: &Cell,
         tx: Treatment,
         params: &Params,
         exo_ros_peak: f64,
     ) -> Self {
+        Self::from_cell_with_ros_opts(cell, tx, params, exo_ros_peak, true)
+    }
+
+    /// Like [`from_cell_with_ros`](Self::from_cell_with_ros) but with
+    /// explicit control over the RSL3 one-shot init knockdown.
+    ///
+    /// `apply_rsl3_init = true` reproduces `from_cell_with_ros` exactly
+    /// (byte-identical). `apply_rsl3_init = false` skips the
+    /// `gpx4 *= 1 - rsl3_gpx4_inhib` step so a time-varying dose schedule
+    /// can drive GPX4 inactivation per step instead of one-shot at t=0
+    /// (the `tumor_pk::sim_cell_with_pk` model, #239). Has no effect for
+    /// non-RSL3 treatments.
+    pub fn from_cell_with_ros_opts(
+        cell: &Cell,
+        tx: Treatment,
+        params: &Params,
+        exo_ros_peak: f64,
+        apply_rsl3_init: bool,
+    ) -> Self {
         let mut gpx4 = cell.gpx4;
-        if let Treatment::RSL3 = tx {
-            gpx4 *= 1.0 - params.rsl3_gpx4_inhib;
+        if apply_rsl3_init {
+            if let Treatment::RSL3 = tx {
+                gpx4 *= 1.0 - params.rsl3_gpx4_inhib;
+            }
         }
         CellState {
             gsh: cell.gsh,

--- a/simulations/ferroptosis-core/src/biochem.rs
+++ b/simulations/ferroptosis-core/src/biochem.rs
@@ -129,6 +129,15 @@ fn update_mufa_protection(current: f64, params: &Params) -> f64 {
 /// own per-dose rise+decay is the availability envelope, and this
 /// single-bolus envelope (keyed to run start) would otherwise
 /// double-count decay for later doses (#239).
+///
+/// **Contract (load-bearing):** [`sim_cell_step`] applies *exactly* this
+/// factor to `exo_ros_peak` for `step >= 30`, and the dosed SDT/PDT path
+/// in `sim-tme-3d` divides *exactly* this factor back out. Both the
+/// producer (here, via `sim_cell_step`) and the consumer (the binary)
+/// must call this one function so they cannot drift. **Do not inline the
+/// `0.5^((step-30)/15)` formula at either site** — if the envelope shape
+/// ever changes, both ends must change together, which only happens if
+/// they share this function.
 #[inline]
 pub fn exo_decay_factor(step: u32) -> f64 {
     if step < 30 {

--- a/simulations/ferroptosis-core/src/dose_schedule.rs
+++ b/simulations/ferroptosis-core/src/dose_schedule.rs
@@ -31,6 +31,21 @@
 //! The factor is dimensionless drug *availability* in `[0, ∞)`. For the
 //! analytic shapes it is normalized so a single full-strength dose peaks at
 //! `peak` (typically `1.0`).
+//!
+//! ## Scope / future evolution (TODO #240)
+//!
+//! `factor_at(step)` is a single **global, time-only** scalar: at each step
+//! every cell sees the same availability. That is correct for #239's
+//! uniform-distribution premise, but it does **not** model spatial drug
+//! heterogeneity — radial penetration gradients, vessel-distance occlusion,
+//! interstitial-pressure exclusion. The patient-scale / vasculature work
+//! (#240, #191) will need per-cell availability that varies in space as well
+//! as time. When that lands, the likely shape is a split: keep this type as
+//! the **temporal** schedule (rename toward `DoseTiming`) and introduce a
+//! separate **spatial** `DrugAvailability(cell) -> f64` that composes with
+//! it multiplicatively. The cell-type-efficacy (#241) and immune
+//! dose-response (#243) work will probably ride on that same split. Capturing
+//! the boundary here so the eventual refactor is planned, not a surprise.
 
 use serde::{Deserialize, Serialize};
 

--- a/simulations/ferroptosis-core/src/dose_schedule.rs
+++ b/simulations/ferroptosis-core/src/dose_schedule.rs
@@ -54,10 +54,11 @@ use serde::{Deserialize, Serialize};
 /// `Constant` is the default and the identity (always `1.0`). The other
 /// variants are time-varying. See the module docs for how each modality
 /// applies the factor.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
 pub enum DoseSchedule {
     /// Constant full availability for the whole run: `factor_at ≡ 1.0`.
     /// The identity case — preserves byte-identical pre-#239 output.
+    #[default]
     Constant,
 
     /// Single bolus administered at `dose_step`: availability is `0.0`
@@ -77,6 +78,15 @@ pub enum DoseSchedule {
     /// contribution that has been administered by then — so overlapping
     /// doses accumulate (clinically realistic for short inter-dose
     /// intervals). Models a multi-dose protocol.
+    ///
+    /// Because contributions sum, `factor_at` can **exceed `peak`** when
+    /// doses overlap. How a consumer treats the overshoot is modality-
+    /// dependent and asymmetric by design: the RSL3 path clamps the factor
+    /// into `[0, 1]` (it's a drug *concentration*, and the validated
+    /// `sim_cell_with_pk` model is calibrated for `conc ≤ 1`), whereas the
+    /// SDT/PDT path does **not** clamp (exogenous ROS is additive across
+    /// overlapping pulses, so >1 is physically meaningful). Pick `peak` and
+    /// spacing with the consuming modality's clamp in mind.
     MultiDose {
         /// Steps at which doses are administered (need not be sorted).
         dose_steps: Vec<u32>,
@@ -107,12 +117,6 @@ pub enum DoseSchedule {
         /// Per-step availability factors (index = step).
         series: Vec<f64>,
     },
-}
-
-impl Default for DoseSchedule {
-    fn default() -> Self {
-        DoseSchedule::Constant
-    }
 }
 
 impl DoseSchedule {
@@ -163,9 +167,10 @@ impl DoseSchedule {
     }
 
     /// The discrete administration steps for the analytic shapes (for
-    /// metadata / visualization annotation). `Constant`/`Infusion`/`FromPk`
-    /// have no discrete dose events and return an empty Vec; `Infusion`
-    /// returns its `start` as a single "begins here" marker.
+    /// metadata / visualization annotation). `Constant` and `FromPk` have no
+    /// discrete dose events and return an empty Vec. `Bolus` returns its
+    /// single `dose_step`; `MultiDose` returns its `dose_steps` (sorted);
+    /// `Infusion` returns its `start` as a single "begins here" marker.
     #[must_use]
     pub fn dose_steps(&self) -> Vec<u32> {
         match self {

--- a/simulations/ferroptosis-core/src/dose_schedule.rs
+++ b/simulations/ferroptosis-core/src/dose_schedule.rs
@@ -1,0 +1,341 @@
+//! Time-varying drug-administration schedules for spatial simulations (#239).
+//!
+//! The spatial binaries (sim-tme, sim-tme-3d) historically modeled drug as
+//! present at constant strength for the entire run. Real treatment is
+//! time-varying: a bolus rises and decays, multi-dose protocols pulse,
+//! infusions hold a level for a window, and full PK models produce an
+//! arbitrary concentration timecourse. `DoseSchedule` captures all four
+//! shapes behind a single per-step factor.
+//!
+//! ## Design (mirrors `photosensitizer_pk::Photosensitizer`)
+//!
+//! - **Identity default.** [`DoseSchedule::Constant`] returns exactly `1.0`
+//!   from [`factor_at`](DoseSchedule::factor_at) for every step. When all
+//!   simulation conditions use `Constant`, the run is byte-identical to the
+//!   pre-#239 steady-state behavior (`x * 1.0 == x` is exact in IEEE-754).
+//! - **Per-step evaluation** (like sim-tme's `run_spatial_cycling` O₂-λ
+//!   recompute): the consumer calls `factor_at(step)` once per step and
+//!   composes the result multiplicatively with the modality's existing
+//!   drug mechanism.
+//!
+//! ## How consumers apply the factor
+//!
+//! - **SDT / PDT** (exogenous ROS): scale the per-cell exogenous-ROS bolus
+//!   magnitude — `effective_peak = base_peak * factor_at(step)`.
+//! - **RSL3** (covalent GPX4 inhibitor): drive per-step GPX4 inactivation —
+//!   `gpx4 -= k_inact * factor_at(step) * gpx4`, mirroring the validated
+//!   `tumor_pk::sim_cell_with_pk` mechanism. (The `Constant` steady-state
+//!   keeps RSL3's original one-shot init knockdown instead; see
+//!   `biochem::CellState::from_cell_with_ros_opts`.)
+//!
+//! The factor is dimensionless drug *availability* in `[0, ∞)`. For the
+//! analytic shapes it is normalized so a single full-strength dose peaks at
+//! `peak` (typically `1.0`).
+
+use serde::{Deserialize, Serialize};
+
+/// A drug-administration schedule producing a per-step availability factor.
+///
+/// `Constant` is the default and the identity (always `1.0`). The other
+/// variants are time-varying. See the module docs for how each modality
+/// applies the factor.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum DoseSchedule {
+    /// Constant full availability for the whole run: `factor_at ≡ 1.0`.
+    /// The identity case — preserves byte-identical pre-#239 output.
+    Constant,
+
+    /// Single bolus administered at `dose_step`: availability is `0.0`
+    /// before the dose, jumps to `peak` at `dose_step`, then decays
+    /// exponentially with `half_life_steps`.
+    Bolus {
+        /// Step at which the dose is administered.
+        dose_step: u32,
+        /// Peak availability at the moment of administration.
+        peak: f64,
+        /// Exponential decay half-life, in steps. Must be > 0.
+        half_life_steps: f64,
+    },
+
+    /// Repeated boluses, one per entry in `dose_steps`. The factor at any
+    /// step is the **sum** of every dose's exponentially-decaying
+    /// contribution that has been administered by then — so overlapping
+    /// doses accumulate (clinically realistic for short inter-dose
+    /// intervals). Models a multi-dose protocol.
+    MultiDose {
+        /// Steps at which doses are administered (need not be sorted).
+        dose_steps: Vec<u32>,
+        /// Peak availability contributed by each individual dose.
+        peak: f64,
+        /// Per-dose exponential decay half-life, in steps. Must be > 0.
+        half_life_steps: f64,
+    },
+
+    /// Continuous infusion: availability is `level` for steps in
+    /// `[start, end)`, `0.0` otherwise. Models a constant IV drip.
+    Infusion {
+        /// First step of the infusion window (inclusive).
+        start: u32,
+        /// One past the last step of the infusion window (exclusive).
+        end: u32,
+        /// Availability held during the window.
+        level: f64,
+    },
+
+    /// Explicit per-step availability series — e.g. the normalized
+    /// interstitial-concentration timecourse from
+    /// `tumor_pk::solve_tumor_pk`. `factor_at(step)` reads `series[step]`,
+    /// clamping to the last value past the end (and `0.0` if empty). The
+    /// bridge that lets the validated two-compartment PK ODE drive the
+    /// spatial grid without coupling the grid to the solver.
+    FromPk {
+        /// Per-step availability factors (index = step).
+        series: Vec<f64>,
+    },
+}
+
+impl Default for DoseSchedule {
+    fn default() -> Self {
+        DoseSchedule::Constant
+    }
+}
+
+impl DoseSchedule {
+    /// Per-step drug-availability factor in `[0, ∞)`.
+    ///
+    /// `Constant ⇒ 1.0` exactly for all steps — the identity that keeps
+    /// the default simulation path byte-identical.
+    #[must_use]
+    pub fn factor_at(&self, step: u32) -> f64 {
+        match self {
+            DoseSchedule::Constant => 1.0,
+            DoseSchedule::Bolus {
+                dose_step,
+                peak,
+                half_life_steps,
+            } => bolus_contribution(step, *dose_step, *peak, *half_life_steps),
+            DoseSchedule::MultiDose {
+                dose_steps,
+                peak,
+                half_life_steps,
+            } => dose_steps
+                .iter()
+                .map(|&d| bolus_contribution(step, d, *peak, *half_life_steps))
+                .sum(),
+            DoseSchedule::Infusion { start, end, level } => {
+                if step >= *start && step < *end {
+                    *level
+                } else {
+                    0.0
+                }
+            }
+            DoseSchedule::FromPk { series } => {
+                if series.is_empty() {
+                    0.0
+                } else {
+                    series[(step as usize).min(series.len() - 1)]
+                }
+            }
+        }
+    }
+
+    /// `true` only for [`DoseSchedule::Constant`]. Consumers use this to
+    /// skip **all** per-step dose modulation on the default path, which is
+    /// what guarantees byte-identical output when no schedule is set.
+    #[must_use]
+    pub fn is_constant(&self) -> bool {
+        matches!(self, DoseSchedule::Constant)
+    }
+
+    /// The discrete administration steps for the analytic shapes (for
+    /// metadata / visualization annotation). `Constant`/`Infusion`/`FromPk`
+    /// have no discrete dose events and return an empty Vec; `Infusion`
+    /// returns its `start` as a single "begins here" marker.
+    #[must_use]
+    pub fn dose_steps(&self) -> Vec<u32> {
+        match self {
+            DoseSchedule::Constant | DoseSchedule::FromPk { .. } => Vec::new(),
+            DoseSchedule::Bolus { dose_step, .. } => vec![*dose_step],
+            DoseSchedule::MultiDose { dose_steps, .. } => {
+                let mut v = dose_steps.clone();
+                v.sort_unstable();
+                v
+            }
+            DoseSchedule::Infusion { start, .. } => vec![*start],
+        }
+    }
+}
+
+/// One bolus's exponentially-decaying contribution at `step`: `0.0` before
+/// `dose_step`, `peak` at it, halving every `half_life_steps`.
+#[inline]
+fn bolus_contribution(step: u32, dose_step: u32, peak: f64, half_life_steps: f64) -> f64 {
+    debug_assert!(
+        half_life_steps > 0.0,
+        "DoseSchedule half_life_steps must be > 0, got {half_life_steps}"
+    );
+    if step < dose_step {
+        return 0.0;
+    }
+    let elapsed = (step - dose_step) as f64;
+    // Guard against a non-positive half-life in release (debug_assert catches
+    // it in dev): treat as an instantaneous spike that's gone by the next step.
+    if half_life_steps <= 0.0 {
+        return if step == dose_step { peak } else { 0.0 };
+    }
+    peak * 0.5_f64.powf(elapsed / half_life_steps)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constant_is_identity_for_all_steps() {
+        let s = DoseSchedule::Constant;
+        for step in [0u32, 1, 30, 60, 179, 1000] {
+            assert_eq!(s.factor_at(step), 1.0, "Constant must be exactly 1.0");
+        }
+        assert!(s.is_constant());
+    }
+
+    #[test]
+    fn default_is_constant() {
+        assert_eq!(DoseSchedule::default(), DoseSchedule::Constant);
+        assert!(DoseSchedule::default().is_constant());
+    }
+
+    #[test]
+    fn bolus_zero_before_dose_peak_at_dose_half_at_halflife() {
+        let s = DoseSchedule::Bolus {
+            dose_step: 10,
+            peak: 1.0,
+            half_life_steps: 12.0,
+        };
+        assert_eq!(s.factor_at(9), 0.0, "no drug before the dose");
+        assert_eq!(s.factor_at(10), 1.0, "peak at dose step");
+        assert!(
+            (s.factor_at(22) - 0.5).abs() < 1e-12,
+            "half at one half-life later, got {}",
+            s.factor_at(22)
+        );
+        assert!(!s.is_constant());
+    }
+
+    #[test]
+    fn multidose_sums_overlapping_contributions() {
+        let s = DoseSchedule::MultiDose {
+            dose_steps: vec![10, 20],
+            peak: 1.0,
+            half_life_steps: 12.0,
+        };
+        // At step 9: nothing yet.
+        assert_eq!(s.factor_at(9), 0.0);
+        // At step 10: first dose peaks (1.0), second not yet → 1.0.
+        assert!((s.factor_at(10) - 1.0).abs() < 1e-12);
+        // At step 20: first dose decayed 10 steps + second dose peaks.
+        let first_at_20 = 0.5_f64.powf(10.0 / 12.0);
+        let expected = first_at_20 + 1.0;
+        assert!(
+            (s.factor_at(20) - expected).abs() < 1e-12,
+            "doses must sum: got {}, expected {}",
+            s.factor_at(20),
+            expected
+        );
+    }
+
+    #[test]
+    fn infusion_holds_level_inside_window_only() {
+        let s = DoseSchedule::Infusion {
+            start: 30,
+            end: 90,
+            level: 0.7,
+        };
+        assert_eq!(s.factor_at(29), 0.0);
+        assert_eq!(s.factor_at(30), 0.7, "level at window start (inclusive)");
+        assert_eq!(s.factor_at(89), 0.7);
+        assert_eq!(s.factor_at(90), 0.0, "window end is exclusive");
+    }
+
+    #[test]
+    fn frompk_reads_series_and_clamps_past_end() {
+        let s = DoseSchedule::FromPk {
+            series: vec![0.0, 0.5, 1.0, 0.8],
+        };
+        assert_eq!(s.factor_at(0), 0.0);
+        assert_eq!(s.factor_at(2), 1.0);
+        assert_eq!(s.factor_at(3), 0.8);
+        assert_eq!(s.factor_at(99), 0.8, "clamps to last value past end");
+    }
+
+    #[test]
+    fn frompk_empty_series_is_zero() {
+        let s = DoseSchedule::FromPk { series: vec![] };
+        assert_eq!(s.factor_at(0), 0.0);
+        assert_eq!(s.factor_at(50), 0.0);
+    }
+
+    #[test]
+    fn non_constant_variants_report_not_constant() {
+        for s in [
+            DoseSchedule::Bolus {
+                dose_step: 0,
+                peak: 1.0,
+                half_life_steps: 1.0,
+            },
+            DoseSchedule::MultiDose {
+                dose_steps: vec![0],
+                peak: 1.0,
+                half_life_steps: 1.0,
+            },
+            DoseSchedule::Infusion {
+                start: 0,
+                end: 1,
+                level: 1.0,
+            },
+            DoseSchedule::FromPk { series: vec![1.0] },
+        ] {
+            assert!(!s.is_constant(), "{s:?} must not report is_constant");
+        }
+    }
+
+    #[test]
+    fn dose_steps_reports_administration_events() {
+        assert_eq!(DoseSchedule::Constant.dose_steps(), Vec::<u32>::new());
+        assert_eq!(
+            DoseSchedule::Bolus {
+                dose_step: 15,
+                peak: 1.0,
+                half_life_steps: 5.0
+            }
+            .dose_steps(),
+            vec![15]
+        );
+        assert_eq!(
+            DoseSchedule::MultiDose {
+                dose_steps: vec![30, 10, 20],
+                peak: 1.0,
+                half_life_steps: 5.0
+            }
+            .dose_steps(),
+            vec![10, 20, 30],
+            "dose_steps are sorted"
+        );
+        assert_eq!(
+            DoseSchedule::Infusion {
+                start: 40,
+                end: 80,
+                level: 1.0
+            }
+            .dose_steps(),
+            vec![40]
+        );
+        assert_eq!(
+            DoseSchedule::FromPk {
+                series: vec![1.0, 2.0]
+            }
+            .dose_steps(),
+            Vec::<u32>::new()
+        );
+    }
+}

--- a/simulations/ferroptosis-core/src/lib.rs
+++ b/simulations/ferroptosis-core/src/lib.rs
@@ -33,10 +33,12 @@
 //! | [`io`] | JSON and CSV output helpers |
 //! | [`drug_transport`] | Tissue-specific drug penetration (Krogh cylinder approximation) |
 //! | [`tumor_pk`] | Two-compartment vascular/interstitial pharmacokinetics |
+//! | [`dose_schedule`] | Time-varying drug-administration schedules (bolus / multi-dose / infusion / PK-driven) |
 
 pub mod cell;
 // Listed before `params` because `SpatialParams` holds a `Photosensitizer`.
 pub mod biochem;
+pub mod dose_schedule;
 pub mod drug_transport;
 pub mod grid;
 pub mod immune;

--- a/simulations/ferroptosis-core/src/tumor_pk.rs
+++ b/simulations/ferroptosis-core/src/tumor_pk.rs
@@ -498,6 +498,8 @@ pub struct PKCellResult {
 }
 
 /// GPX4 inactivation rate for RSL3-like covalent GPX4 inhibitors.
+/// Re-exported conceptually for spatial binaries that drive RSL3 via a
+/// time-varying `dose_schedule::DoseSchedule` (#239).
 /// Calibrated directly in Rust (10K Persister cells, constant conc=1.0):
 /// k_inact=0.015 gives ~41% death rate, matching sim_cell RSL3+Persister
 /// death rate (~42.5%). Internal state (LP, GSH, GPX4) differs.

--- a/simulations/ferroptosis-core/src/tumor_pk.rs
+++ b/simulations/ferroptosis-core/src/tumor_pk.rs
@@ -498,8 +498,9 @@ pub struct PKCellResult {
 }
 
 /// GPX4 inactivation rate for RSL3-like covalent GPX4 inhibitors.
-/// Re-exported conceptually for spatial binaries that drive RSL3 via a
-/// time-varying `dose_schedule::DoseSchedule` (#239).
+/// `pub` so spatial binaries (sim-tme-3d) can import it directly when
+/// driving RSL3 via a time-varying `dose_schedule::DoseSchedule` (#239),
+/// reusing the same constant `sim_cell_with_pk` is calibrated against.
 /// Calibrated directly in Rust (10K Persister cells, constant conc=1.0):
 /// k_inact=0.015 gives ~41% death rate, matching sim_cell RSL3+Persister
 /// death rate (~42.5%). Internal state (LP, GSH, GPX4) differs.

--- a/simulations/sim-tme-3d/README.md
+++ b/simulations/sim-tme-3d/README.md
@@ -89,6 +89,34 @@ The default 24-condition matrix path (no `--snapshot` flag) is **byte-identical*
 
 **Schema versioning**: `trajectory_meta.json` carries its own `schema_version: u32` (currently `1`), separate from `summary.json`'s schema. The Python renderer hard-asserts the version to fail loudly on drift.
 
+### Snapshot presets (`--snapshot=NAME`)
+
+| name | treatment | toggles | schedule |
+|---|---|---|---|
+| `combined` (default) | RSL3 | immune + stromal + pH | constant |
+| `bare` | RSL3 | none | constant |
+| `multidose` | SDT | immune | **4-dose multi-dose (#239)** |
+
+The `multidose` preset shows **death waves synced to each dose**: four SDT ROS pulses at steps 10/55/100/145, each triggering a ferroptotic death wave + DAMP bloom + immune response. The renderer draws a red frame border + `💉 DOSE` marker on each dose step.
+
+## Time-varying dosing (`--dose-sweep` + `DoseSchedule`, #239)
+
+By default the simulator models drug as present at **constant** strength for the whole run. `ferroptosis-core::dose_schedule::DoseSchedule` adds time-varying administration: `Constant` (the byte-identical default), `Bolus`, `MultiDose`, `Infusion`, and `FromPk` (driven by the two-compartment `tumor_pk` ODE).
+
+- **SDT/PDT**: the schedule scales the per-step exogenous-ROS bolus. The intrinsic single-bolus decay envelope inside `sim_cell_step` is divided out on the dosed path (`biochem::exo_decay_factor`), so the schedule is the sole availability envelope — otherwise later doses would be wrongly crushed by the from-t=0 decay.
+- **RSL3**: the schedule drives per-step covalent GPX4 inactivation (`gpx4 -= RSL3_INACTIVATION_RATE · availability · gpx4`, the validated `tumor_pk::sim_cell_with_pk` model) instead of the one-shot init knockdown. pH ion-trapping composes as a per-cell spatial availability multiplier.
+
+`--dose-sweep` runs RSL3 across all five protocols at a fixed combined-TME context and writes `dose_comparison.json`:
+
+```bash
+cargo run --release -p sim-tme-3d -- --dose-sweep
+# → output/tme-3d/dose_comparison.json  (one row per protocol, shared grid + RNG seed)
+```
+
+All protocols share the same tumor grid and runtime RNG seed, so kill-rate differences reflect the dosing protocol alone, not stochastic noise. On this machine the steady-state `constant` model kills ~10–60× more than any realistic time-varying protocol — a direct quantification of how much the "drug present at full strength forever" idealization overestimates efficacy. **Absolute magnitudes are uncalibrated v1** (`RSL3_INACTIVATION_RATE` was tuned for sustained `conc=1.0`); the informative signal is the cross-protocol ordering.
+
+**Bit-identical guarantee**: when every condition uses `DoseSchedule::Constant` (the entire default 24-condition matrix), the run is byte-identical to pre-#239 — `summary.json` SHA unchanged. The dose machinery is gated behind `DoseSchedule::is_constant()`; `--dose-sweep` writes a separate file and never touches `summary.json`.
+
 ## Condition matrix
 
 | Category | Conditions | Description |

--- a/simulations/sim-tme-3d/src/main.rs
+++ b/simulations/sim-tme-3d/src/main.rs
@@ -387,10 +387,14 @@ fn run_one_condition_with_config(
     // skipped and the run is byte-identical to the pre-#239 behavior.
     let schedule = &condition.dose_schedule;
     let dosed = !schedule.is_constant();
-    // For SDT/PDT under a non-constant schedule we rescale each cell's
-    // exogenous-ROS bolus per step, so we must retain the per-cell *base*
-    // peak (the init value). Empty on the Constant path (never read).
-    let mut base_exo: Vec<f64> = if dosed {
+    // `base_exo` is read ONLY by the SDT/PDT per-step rescale arm. Allocate
+    // (and init-write) it only when that arm can run — i.e. a non-constant
+    // schedule on an exogenous-ROS treatment. Empty (never indexed) on the
+    // Constant path AND on the RSL3 dosed path, which keeps the
+    // "empty ⇒ never read" invariant tight (review #7).
+    let dose_modulates_exo =
+        dosed && matches!(condition.treatment, Treatment::SDT | Treatment::PDT);
+    let mut base_exo: Vec<f64> = if dose_modulates_exo {
         vec![0.0; n_cells]
     } else {
         Vec::new()
@@ -412,7 +416,7 @@ fn run_one_condition_with_config(
                         let peak = base_ros * ros_multiplier;
                         norm(&mut rng, peak, peak * 0.2).max(0.0)
                     };
-                if dosed {
+                if dose_modulates_exo {
                     base_exo[idx] = exo_ros_peak;
                 }
                 let gc = &mut grid.cells[idx];
@@ -554,16 +558,32 @@ fn run_one_condition_with_config(
 
                     // Time-varying drug modulation (#239). Skipped entirely on
                     // the Constant default path (`dosed == false`), so output
-                    // is byte-identical there. Applied to LIVE cells only:
-                    // a cell's drug exposure freezes at its death step (dead
-                    // cells in the post-death grace period keep their last
-                    // value, matching `tumor_pk::sim_cell_with_pk`).
+                    // is byte-identical there. Applied to LIVE cells only —
+                    // once a cell is dead, this block no longer runs, so its
+                    // STORED drug state (gpx4 for RSL3, exo_ros_peak for
+                    // SDT/PDT) is frozen at its death-step value.
+                    //
+                    // Nuance for SDT/PDT: freezing the stored *peak* is not the
+                    // same as freezing the *effective* exo. The post-death
+                    // branch in `biochem::sim_cell_step` keeps multiplying the
+                    // frozen peak by `exo_decay_factor(step)`, so a dead cell's
+                    // residual exo continues to shrink (~0.5^(k/15)) across its
+                    // ≤5-step grace window — the same intrinsic decay baseline
+                    // dead cells see. This perturbs only post-death `lp` (hence
+                    // `lp_at_death`/`damp_field`) in the SDT multidose snapshot;
+                    // it does NOT affect death determination, summary.json, or
+                    // the RSL3 path. (RSL3 truly freezes: gpx4 is untouched once
+                    // dead, matching `tumor_pk::sim_cell_with_pk`.)
                     if dosed && !grid.cells[idx].state.dead {
                         match condition.treatment {
                             Treatment::RSL3 => {
                                 // Covalent GPX4 inactivation proportional to
                                 // drug availability = schedule × spatial pH
                                 // ion-trap factor. Mirrors sim_cell_with_pk:538.
+                                debug_assert!(
+                                    !rsl3_drug_avail.is_empty(),
+                                    "rsl3_drug_avail must be populated on the dosed RSL3 path"
+                                );
                                 let conc = (dose_factor * rsl3_drug_avail[idx]).clamp(0.0, 1.0);
                                 let st = &mut grid.cells[idx].state;
                                 st.gpx4 -= RSL3_INACTIVATION_RATE * conc * st.gpx4;
@@ -590,6 +610,10 @@ fn run_one_condition_with_config(
                                 // multiplies the envelope back in — the
                                 // amplified value never reaches any other
                                 // computation.
+                                debug_assert!(
+                                    !base_exo.is_empty(),
+                                    "base_exo must be populated on the dosed SDT/PDT path"
+                                );
                                 let decay = exo_decay_factor(step).max(1e-9);
                                 grid.cells[idx].state.exo_ros_peak =
                                     base_exo[idx] * dose_factor / decay;
@@ -1433,9 +1457,10 @@ mod tests {
 
     // Golden integer kill counts for the Constant-path regression guard
     // (`constant_path_golden_kill_counts`), captured from SDT + immune +
-    // stromal + pH at grid_dim=20, n_steps=80. Deterministic across
-    // platforms (seeded RNG + IEEE f64). Update ONLY after confirming a
-    // default-path change is intentional.
+    // stromal + pH at grid_dim=20, n_steps=80. Deterministic on a fixed
+    // platform/toolchain (seeded RNG + IEEE f64); may differ by an ULP-edge
+    // count on other libm/CPU builds — see the test's doc. Update ONLY after
+    // confirming a default-path change is intentional.
     const GOLDEN_TOTAL_TUMOR: usize = 3071;
     const GOLDEN_TOTAL_DEAD: usize = 2992;
     const GOLDEN_FERRO_KILLS: usize = 2990;
@@ -1751,14 +1776,22 @@ mod tests {
 
     /// **Byte-identity regression guard for the Constant default path.**
     /// Pins the exact integer kill counts of a representative Constant
-    /// condition (SDT + immune + stromal + pH) at a fixed small config.
-    /// Integer counts are deterministic across platforms (same f64 ops +
-    /// seeded RNG), so this catches ANY drift in the default (non-dosed)
-    /// path — the load-bearing "summary.json byte-identical" property — at
-    /// unit-test speed, without the full 60³×180 production run. If a future
-    /// refactor changes these numbers, the byte-identical claim is broken
-    /// and this fails loudly. (Companion to the production SHA-256 check
-    /// done manually in #239's PR.)
+    /// condition (SDT + immune + stromal + pH) at a fixed small config,
+    /// catching ANY drift in the default (non-dosed) path — the load-bearing
+    /// "summary.json byte-identical" property — at unit-test speed, without
+    /// the full 60³×180 production run.
+    ///
+    /// **Scope: deterministic on a fixed platform + toolchain.** The kill
+    /// counts are integers, but the death decision is a strict
+    /// `lp > threshold` on values flowing through `powf` and the Ziggurat
+    /// normal sampler, which are not bit-identical across libm/CPU
+    /// implementations — so a cell within an ULP of the threshold could flip
+    /// a count on a different platform. (This is a pre-existing
+    /// whole-simulation property, not introduced by #239.) This test is the
+    /// same-platform CI guard against accidental drift; the production
+    /// SHA-256 check (done manually in #239's PR) is the cross-build
+    /// authority. If these numbers change, the byte-identical claim is broken
+    /// — investigate before updating.
     #[test]
     fn constant_path_golden_kill_counts() {
         let cond = Condition {
@@ -1834,6 +1867,71 @@ mod tests {
             "kill rate must be a valid fraction, got {}",
             r1.overall_kill_rate
         );
+    }
+
+    /// End-to-end coverage for the `Infusion` variant (review #10): runs
+    /// RSL3 under a continuous infusion through the full per-step dosed
+    /// path and asserts it's deterministic and produces a valid fraction.
+    #[test]
+    fn dosed_rsl3_infusion_runs_and_is_deterministic() {
+        let cond = Condition {
+            name: "test_rsl3_infusion".to_string(),
+            treatment: Treatment::RSL3,
+            treatment_name: "RSL3".to_string(),
+            o2_lambda: Some(ZONE_REF_LAMBDA),
+            immune_on: true,
+            stromal_on: false,
+            ph_on: true,
+            dose_schedule: DoseSchedule::Infusion {
+                start: 2,
+                end: 28,
+                level: 1.0,
+            },
+        };
+        let cfg = RunConfig {
+            grid_dim: 20,
+            n_steps: 30,
+        };
+        let r1 = run_one_condition_with_config(&cond, cfg, None);
+        let r2 = run_one_condition_with_config(&cond, cfg, None);
+        assert_eq!(
+            r1.total_dead, r2.total_dead,
+            "Infusion run must be deterministic"
+        );
+        assert!(r1.total_tumor > 0);
+        assert!((0.0..=1.0).contains(&r1.overall_kill_rate));
+    }
+
+    /// End-to-end coverage for the `FromPk` variant (review #10): runs RSL3
+    /// driven by the tumor_pk-derived availability series through the full
+    /// per-step dosed path. Exercises the ODE-bridge → grid wiring beyond
+    /// the `factor_at`-level unit test.
+    #[test]
+    fn dosed_rsl3_frompk_runs_and_is_deterministic() {
+        let cfg = RunConfig {
+            grid_dim: 20,
+            n_steps: 30,
+        };
+        let cond = Condition {
+            name: "test_rsl3_frompk".to_string(),
+            treatment: Treatment::RSL3,
+            treatment_name: "RSL3".to_string(),
+            o2_lambda: Some(ZONE_REF_LAMBDA),
+            immune_on: true,
+            stromal_on: false,
+            ph_on: true,
+            dose_schedule: DoseSchedule::FromPk {
+                series: rsl3_pk_factor_series(cfg.n_steps),
+            },
+        };
+        let r1 = run_one_condition_with_config(&cond, cfg, None);
+        let r2 = run_one_condition_with_config(&cond, cfg, None);
+        assert_eq!(
+            r1.total_dead, r2.total_dead,
+            "FromPk run must be deterministic"
+        );
+        assert!(r1.total_tumor > 0);
+        assert!((0.0..=1.0).contains(&r1.overall_kill_rate));
     }
 
     /// The FromPk bridge series must be a valid normalized availability

--- a/simulations/sim-tme-3d/src/main.rs
+++ b/simulations/sim-tme-3d/src/main.rs
@@ -1431,6 +1431,16 @@ fn main() {
 mod tests {
     use super::*;
 
+    // Golden integer kill counts for the Constant-path regression guard
+    // (`constant_path_golden_kill_counts`), captured from SDT + immune +
+    // stromal + pH at grid_dim=20, n_steps=80. Deterministic across
+    // platforms (seeded RNG + IEEE f64). Update ONLY after confirming a
+    // default-path change is intentional.
+    const GOLDEN_TOTAL_TUMOR: usize = 3071;
+    const GOLDEN_TOTAL_DEAD: usize = 2992;
+    const GOLDEN_FERRO_KILLS: usize = 2990;
+    const GOLDEN_IMMUNE_KILLS: usize = 2;
+
     /// `--snapshot` (no `=NAME`) defaults to `combined`.
     #[test]
     fn parse_snapshot_arg_bare_defaults_to_combined() {
@@ -1736,6 +1746,55 @@ mod tests {
              fewer than the Constant one-shot: bolus={}, constant={}",
             bolus.total_dead,
             constant.total_dead
+        );
+    }
+
+    /// **Byte-identity regression guard for the Constant default path.**
+    /// Pins the exact integer kill counts of a representative Constant
+    /// condition (SDT + immune + stromal + pH) at a fixed small config.
+    /// Integer counts are deterministic across platforms (same f64 ops +
+    /// seeded RNG), so this catches ANY drift in the default (non-dosed)
+    /// path — the load-bearing "summary.json byte-identical" property — at
+    /// unit-test speed, without the full 60³×180 production run. If a future
+    /// refactor changes these numbers, the byte-identical claim is broken
+    /// and this fails loudly. (Companion to the production SHA-256 check
+    /// done manually in #239's PR.)
+    #[test]
+    fn constant_path_golden_kill_counts() {
+        let cond = Condition {
+            name: "golden_constant_SDT".to_string(),
+            treatment: Treatment::SDT,
+            treatment_name: "SDT".to_string(),
+            o2_lambda: Some(ZONE_REF_LAMBDA),
+            immune_on: true,
+            stromal_on: true,
+            ph_on: true,
+            dose_schedule: DoseSchedule::Constant,
+        };
+        let cfg = RunConfig {
+            grid_dim: 20,
+            n_steps: 80,
+        };
+        let r = run_one_condition_with_config(&cond, cfg, None);
+        // Golden values captured from the Constant path. A change here means
+        // the default-path numerics drifted — investigate before updating.
+        assert_eq!(
+            r.total_tumor, GOLDEN_TOTAL_TUMOR,
+            "tumor-cell count drifted"
+        );
+        assert_eq!(
+            r.total_dead, GOLDEN_TOTAL_DEAD,
+            "Constant-path total_dead drifted"
+        );
+        assert_eq!(
+            r.ferroptosis_kills,
+            Some(GOLDEN_FERRO_KILLS),
+            "Constant-path ferroptosis_kills drifted"
+        );
+        assert_eq!(
+            r.immune_kills,
+            Some(GOLDEN_IMMUNE_KILLS),
+            "Constant-path immune_kills drifted"
         );
     }
 

--- a/simulations/sim-tme-3d/src/main.rs
+++ b/simulations/sim-tme-3d/src/main.rs
@@ -53,6 +53,7 @@ mod snapshot;
 
 use ferroptosis_core::biochem::{sim_cell_step, CellState};
 use ferroptosis_core::cell::Treatment;
+use ferroptosis_core::dose_schedule::DoseSchedule;
 use ferroptosis_core::grid::{TumorGrid3D, TUMOR_RADIUS_FRACTION};
 use ferroptosis_core::immune_spatial::{
     dc_activation, diffuse_damp_3d_step, immune_kill_probability, DAMP_KILL_THRESHOLD,
@@ -64,6 +65,7 @@ use ferroptosis_core::params::{
 use ferroptosis_core::ph::{ion_trap_factor_from_ph, iron_multiplier_from_ph, radial_ph_field};
 use ferroptosis_core::physics::local_ros_multiplier_3d;
 use ferroptosis_core::stromal::stromal_adjacency_mask_3d;
+use ferroptosis_core::tumor_pk::RSL3_INACTIVATION_RATE;
 use rand::distributions::Distribution;
 use rand::prelude::*;
 use rand::rngs::StdRng;
@@ -198,6 +200,10 @@ struct Condition {
     immune_on: bool,
     stromal_on: bool,
     ph_on: bool,
+    /// Drug-administration schedule over time (#239). `Constant` (the
+    /// default) reproduces the historical steady-state behavior exactly;
+    /// non-constant schedules drive per-step drug modulation.
+    dose_schedule: DoseSchedule,
 }
 
 // ============================================================
@@ -376,6 +382,20 @@ fn run_one_condition_with_config(
         Treatment::RSL3 | Treatment::Control => 0.0,
     };
 
+    // Time-varying dose schedule (#239). `dosed == false` for the default
+    // `Constant` schedule, in which case EVERY dose-related branch below is
+    // skipped and the run is byte-identical to the pre-#239 behavior.
+    let schedule = &condition.dose_schedule;
+    let dosed = !schedule.is_constant();
+    // For SDT/PDT under a non-constant schedule we rescale each cell's
+    // exogenous-ROS bolus per step, so we must retain the per-cell *base*
+    // peak (the init value). Empty on the Constant path (never read).
+    let mut base_exo: Vec<f64> = if dosed {
+        vec![0.0; n_cells]
+    } else {
+        Vec::new()
+    };
+
     // Initialize cell states with per-cell ROS peak
     for r in 0..grid.rows {
         for c in 0..grid.cols {
@@ -392,13 +412,32 @@ fn run_one_condition_with_config(
                         let peak = base_ros * ros_multiplier;
                         norm(&mut rng, peak, peak * 0.2).max(0.0)
                     };
+                if dosed {
+                    base_exo[idx] = exo_ros_peak;
+                }
                 let gc = &mut grid.cells[idx];
-                gc.state = CellState::from_cell_with_ros(
-                    &gc.cell,
-                    condition.treatment,
-                    &params,
-                    exo_ros_peak,
-                );
+                // For RSL3 under a non-constant schedule, skip the one-shot
+                // init GPX4 knockdown — the schedule drives per-step covalent
+                // inactivation instead (the `tumor_pk::sim_cell_with_pk`
+                // model). Every other case keeps the historical one-shot
+                // init via `from_cell_with_ros` (= `..._opts(.., true)`),
+                // preserving byte-identical output on the default path.
+                gc.state = if dosed && condition.treatment == Treatment::RSL3 {
+                    CellState::from_cell_with_ros_opts(
+                        &gc.cell,
+                        condition.treatment,
+                        &params,
+                        exo_ros_peak,
+                        false,
+                    )
+                } else {
+                    CellState::from_cell_with_ros(
+                        &gc.cell,
+                        condition.treatment,
+                        &params,
+                        exo_ros_peak,
+                    )
+                };
                 gc.extra_iron = 0.0;
                 gc.newly_dead = false;
                 // Init to NaN so any code path that reads `lp_at_death`
@@ -410,20 +449,47 @@ fn run_one_condition_with_config(
         }
     }
 
-    // pH-dependent RSL3 ion trapping correction (consumer-side, same pattern as sim-tme)
-    if let (Some((ph_map, cfg)), Treatment::RSL3) = (&ph_field, condition.treatment) {
-        for (idx, &local_ph) in ph_map.iter().enumerate() {
-            if !grid.cells[idx].is_tumor {
-                continue;
+    // pH-dependent RSL3 ion trapping correction (consumer-side, same pattern
+    // as sim-tme). This is the CONSTANT-schedule path: it corrects the
+    // one-shot init knockdown for spatial drug availability. For a non-constant
+    // schedule the init knockdown was skipped, so this correction would have
+    // nothing to correct — instead the per-cell availability is folded into
+    // the per-step inactivation via `rsl3_drug_avail` below.
+    if !dosed {
+        if let (Some((ph_map, cfg)), Treatment::RSL3) = (&ph_field, condition.treatment) {
+            for (idx, &local_ph) in ph_map.iter().enumerate() {
+                if !grid.cells[idx].is_tumor {
+                    continue;
+                }
+                let drug_factor =
+                    ion_trap_factor_from_ph(local_ph, cfg.ph_edge, cfg.ion_trap_sensitivity);
+                // Correct GPX4: from (1-inhib) to (1-inhib*drug_factor) — matches sim-tme:614
+                let correction =
+                    (1.0 - params.rsl3_gpx4_inhib * drug_factor) / (1.0 - params.rsl3_gpx4_inhib);
+                grid.cells[idx].state.gpx4 *= correction;
             }
-            let drug_factor =
-                ion_trap_factor_from_ph(local_ph, cfg.ph_edge, cfg.ion_trap_sensitivity);
-            // Correct GPX4: from (1-inhib) to (1-inhib*drug_factor) — matches sim-tme:614
-            let correction =
-                (1.0 - params.rsl3_gpx4_inhib * drug_factor) / (1.0 - params.rsl3_gpx4_inhib);
-            grid.cells[idx].state.gpx4 *= correction;
         }
     }
+
+    // Per-cell spatial drug-availability multiplier for the DOSED RSL3 path
+    // (#239): pH ion-trapping reduces effective drug in acidic regions. The
+    // value is composed multiplicatively with the schedule's `factor_at(step)`
+    // in the per-step inactivation below. `1.0` everywhere when pH is off;
+    // empty (never indexed) on the Constant path or for non-RSL3 treatments.
+    let rsl3_drug_avail: Vec<f64> = if dosed && condition.treatment == Treatment::RSL3 {
+        let mut avail = vec![1.0_f64; n_cells];
+        if let Some((ph_map, cfg)) = &ph_field {
+            for (idx, &local_ph) in ph_map.iter().enumerate() {
+                if grid.cells[idx].is_tumor {
+                    avail[idx] =
+                        ion_trap_factor_from_ph(local_ph, cfg.ph_edge, cfg.ion_trap_sensitivity);
+                }
+            }
+        }
+        avail
+    } else {
+        Vec::new()
+    };
 
     // --- Main 180-step loop ---
     let immune_cfg = SpatialImmuneConfig::for_3d();
@@ -433,6 +499,11 @@ fn run_one_condition_with_config(
     let mut immune_kills = 0usize;
 
     for step in 0..run_cfg.n_steps {
+        // Drug availability for this step (#239). `1.0` on the Constant
+        // default path (and the `dosed` guard below skips all modulation
+        // there anyway, so it's never actually read for Constant).
+        let dose_factor = if dosed { schedule.factor_at(step) } else { 1.0 };
+
         // Ferroptosis biochem + stromal protection
         for r in 0..grid.rows {
             for c in 0..grid.cols {
@@ -480,6 +551,33 @@ fn run_one_condition_with_config(
 
                     let extra_iron = grid.cells[idx].extra_iron;
                     grid.cells[idx].extra_iron = 0.0;
+
+                    // Time-varying drug modulation (#239). Skipped entirely on
+                    // the Constant default path (`dosed == false`), so output
+                    // is byte-identical there. Applied to LIVE cells only:
+                    // a cell's drug exposure freezes at its death step (dead
+                    // cells in the post-death grace period keep their last
+                    // value, matching `tumor_pk::sim_cell_with_pk`).
+                    if dosed && !grid.cells[idx].state.dead {
+                        match condition.treatment {
+                            Treatment::RSL3 => {
+                                // Covalent GPX4 inactivation proportional to
+                                // drug availability = schedule × spatial pH
+                                // ion-trap factor. Mirrors sim_cell_with_pk:538.
+                                let conc = (dose_factor * rsl3_drug_avail[idx]).clamp(0.0, 1.0);
+                                let st = &mut grid.cells[idx].state;
+                                st.gpx4 -= RSL3_INACTIVATION_RATE * conc * st.gpx4;
+                                st.gpx4 = st.gpx4.max(0.0);
+                            }
+                            Treatment::SDT | Treatment::PDT => {
+                                // Scale the exogenous-ROS bolus by drug
+                                // availability this step. The intra-cell decay
+                                // envelope inside sim_cell_step composes on top.
+                                grid.cells[idx].state.exo_ros_peak = base_exo[idx] * dose_factor;
+                            }
+                            Treatment::Control => {}
+                        }
+                    }
 
                     let gc = &mut grid.cells[idx];
                     let died =
@@ -749,6 +847,7 @@ fn generate_conditions() -> Vec<Condition> {
             immune_on: false,
             stromal_on: false,
             ph_on: false,
+            dose_schedule: DoseSchedule::Constant,
         });
     }
 
@@ -763,6 +862,7 @@ fn generate_conditions() -> Vec<Condition> {
                 immune_on: false,
                 stromal_on: false,
                 ph_on: false,
+                dose_schedule: DoseSchedule::Constant,
             });
         }
     }
@@ -777,6 +877,7 @@ fn generate_conditions() -> Vec<Condition> {
             immune_on: true,
             stromal_on: false,
             ph_on: false,
+            dose_schedule: DoseSchedule::Constant,
         });
     }
 
@@ -793,6 +894,7 @@ fn generate_conditions() -> Vec<Condition> {
             immune_on: true,
             stromal_on: true,
             ph_on: false,
+            dose_schedule: DoseSchedule::Constant,
         });
     }
 
@@ -807,6 +909,7 @@ fn generate_conditions() -> Vec<Condition> {
             immune_on: true,
             stromal_on: false,
             ph_on: true,
+            dose_schedule: DoseSchedule::Constant,
         });
     }
 
@@ -820,6 +923,7 @@ fn generate_conditions() -> Vec<Condition> {
             immune_on: true,
             stromal_on: true,
             ph_on: true,
+            dose_schedule: DoseSchedule::Constant,
         });
     }
 
@@ -913,6 +1017,7 @@ fn run_snapshot(output_dir: &Path, tumor_radius_um: f64, name: &str) {
         immune_on: preset.immune_on,
         stromal_on: preset.stromal_on,
         ph_on: preset.ph_on,
+        dose_schedule: DoseSchedule::Constant,
     };
 
     eprintln!(
@@ -1143,6 +1248,7 @@ mod tests {
             immune_on: false,
             stromal_on: false,
             ph_on: false,
+            dose_schedule: DoseSchedule::Constant,
         };
         let r = run_one_condition_with_config(&cond, RunConfig::for_test(), None);
         assert_eq!(r.treatment, "Control");
@@ -1172,6 +1278,7 @@ mod tests {
             immune_on: false,
             stromal_on: false,
             ph_on: false,
+            dose_schedule: DoseSchedule::Constant,
         };
         let r1 = run_one_condition_with_config(&cond, RunConfig::for_test(), None);
         let r2 = run_one_condition_with_config(&cond, RunConfig::for_test(), None);
@@ -1202,6 +1309,7 @@ mod tests {
             immune_on: true,
             stromal_on: false,
             ph_on: false,
+            dose_schedule: DoseSchedule::Constant,
         };
         // Larger config than the smoke tests: need IMMUNE_START_STEP=60 +
         // buffer for DAMP to accumulate above the 0.01 kill threshold.
@@ -1245,6 +1353,7 @@ mod tests {
             immune_on: true,
             stromal_on: false,
             ph_on: false,
+            dose_schedule: DoseSchedule::Constant,
         };
         let cfg = RunConfig {
             grid_dim: 15,
@@ -1260,6 +1369,160 @@ mod tests {
             r.total_dead,
             ferro,
             im
+        );
+    }
+
+    // ============================================================
+    // Time-varying dose schedule (#239)
+    // ============================================================
+
+    /// A zero-availability schedule (a bolus scheduled past the end of the
+    /// run, so `factor_at ≡ 0`) must suppress SDT kills relative to the
+    /// Constant full-availability default — proving the SDT exo-ROS rescale
+    /// path is actually wired in.
+    #[test]
+    fn dosed_zero_availability_schedule_suppresses_sdt_kills() {
+        let cfg = RunConfig {
+            grid_dim: 20,
+            n_steps: 60,
+        };
+        let constant = run_one_condition_with_config(
+            &Condition {
+                name: "test_sdt_constant".to_string(),
+                treatment: Treatment::SDT,
+                treatment_name: "SDT".to_string(),
+                o2_lambda: Some(ZONE_REF_LAMBDA),
+                immune_on: false,
+                stromal_on: false,
+                ph_on: false,
+                dose_schedule: DoseSchedule::Constant,
+            },
+            cfg,
+            None,
+        );
+        let zero = run_one_condition_with_config(
+            &Condition {
+                name: "test_sdt_zero_drug".to_string(),
+                treatment: Treatment::SDT,
+                treatment_name: "SDT".to_string(),
+                o2_lambda: Some(ZONE_REF_LAMBDA),
+                immune_on: false,
+                stromal_on: false,
+                ph_on: false,
+                // Dose never arrives within the run → factor_at ≡ 0 → no SDT ROS.
+                dose_schedule: DoseSchedule::Bolus {
+                    dose_step: 9999,
+                    peak: 1.0,
+                    half_life_steps: 10.0,
+                },
+            },
+            cfg,
+            None,
+        );
+        assert!(
+            constant.total_dead > 0,
+            "Constant SDT should kill cells at 20³×60; got {}",
+            constant.total_dead
+        );
+        assert!(
+            zero.total_dead < constant.total_dead,
+            "zero-availability schedule must suppress SDT kills: zero={}, constant={}",
+            zero.total_dead,
+            constant.total_dead
+        );
+    }
+
+    /// A gentle single-bolus RSL3 schedule (continuous covalent inactivation)
+    /// must kill fewer cells than the Constant one-shot 92% GPX4 knockdown —
+    /// proving the RSL3 dosed path is live and the no-init-knockdown +
+    /// per-step inactivation mechanism differs from the steady-state default.
+    #[test]
+    fn dosed_rsl3_bolus_kills_less_than_constant_oneshot() {
+        let cfg = RunConfig {
+            grid_dim: 20,
+            n_steps: 60,
+        };
+        let constant = run_one_condition_with_config(
+            &Condition {
+                name: "test_rsl3_constant".to_string(),
+                treatment: Treatment::RSL3,
+                treatment_name: "RSL3".to_string(),
+                o2_lambda: Some(ZONE_REF_LAMBDA),
+                immune_on: false,
+                stromal_on: false,
+                ph_on: false,
+                dose_schedule: DoseSchedule::Constant,
+            },
+            cfg,
+            None,
+        );
+        let bolus = run_one_condition_with_config(
+            &Condition {
+                name: "test_rsl3_bolus".to_string(),
+                treatment: Treatment::RSL3,
+                treatment_name: "RSL3".to_string(),
+                o2_lambda: Some(ZONE_REF_LAMBDA),
+                immune_on: false,
+                stromal_on: false,
+                ph_on: false,
+                dose_schedule: DoseSchedule::Bolus {
+                    dose_step: 2,
+                    peak: 1.0,
+                    half_life_steps: 8.0,
+                },
+            },
+            cfg,
+            None,
+        );
+        assert!(
+            constant.total_dead > 0,
+            "Constant RSL3 (one-shot 92% knockdown) should kill cells; got {}",
+            constant.total_dead
+        );
+        assert!(
+            bolus.total_dead < constant.total_dead,
+            "a single decaying RSL3 bolus (gentle continuous inactivation) must kill \
+             fewer than the Constant one-shot: bolus={}, constant={}",
+            bolus.total_dead,
+            constant.total_dead
+        );
+    }
+
+    /// The full dosed stack (RSL3 + immune + stromal + pH + MultiDose) must
+    /// run end-to-end without panicking and be deterministic across runs.
+    /// Exercises `rsl3_drug_avail` indexing (pH on), the no-knockdown init,
+    /// per-step inactivation, and the immune/stromal interactions together.
+    #[test]
+    fn dosed_rsl3_full_stack_runs_and_is_deterministic() {
+        let cond = Condition {
+            name: "test_rsl3_multidose_full".to_string(),
+            treatment: Treatment::RSL3,
+            treatment_name: "RSL3".to_string(),
+            o2_lambda: Some(ZONE_REF_LAMBDA),
+            immune_on: true,
+            stromal_on: true,
+            ph_on: true,
+            dose_schedule: DoseSchedule::MultiDose {
+                dose_steps: vec![2, 10, 18],
+                peak: 1.0,
+                half_life_steps: 6.0,
+            },
+        };
+        let cfg = RunConfig {
+            grid_dim: 20,
+            n_steps: 30,
+        };
+        let r1 = run_one_condition_with_config(&cond, cfg, None);
+        let r2 = run_one_condition_with_config(&cond, cfg, None);
+        assert_eq!(
+            r1.total_dead, r2.total_dead,
+            "dosed full-stack run must be deterministic"
+        );
+        assert!(r1.total_tumor > 0, "expected tumor cells");
+        assert!(
+            (0.0..=1.0).contains(&r1.overall_kill_rate),
+            "kill rate must be a valid fraction, got {}",
+            r1.overall_kill_rate
         );
     }
 

--- a/simulations/sim-tme-3d/src/main.rs
+++ b/simulations/sim-tme-3d/src/main.rs
@@ -1066,6 +1066,174 @@ fn run_snapshot(output_dir: &Path, tumor_radius_um: f64, name: &str) {
     eprintln!("Render with: python3 scripts/render_tme_3d_trajectory.py");
 }
 
+/// Schema version for `dose_comparison.json` (#239). Independent of
+/// `summary.json`'s schema.
+const DOSE_SWEEP_SCHEMA_VERSION: u32 = 1;
+
+/// One row of the dose-sweep comparison: RSL3 kill outcome under a single
+/// dosing protocol, all else equal.
+#[derive(Serialize)]
+struct DoseSweepEntry {
+    /// Short protocol label (constant / bolus / multidose / infusion / frompk).
+    schedule: String,
+    /// Human-readable protocol description.
+    description: String,
+    total_tumor: usize,
+    total_dead: usize,
+    overall_kill_rate: f64,
+    ferroptosis_kills: usize,
+    immune_kills: usize,
+}
+
+#[derive(Serialize)]
+struct DoseSweepResult {
+    schema_version: u32,
+    treatment: String,
+    /// The fixed biological context shared by every protocol.
+    context: String,
+    grid_dim: usize,
+    n_steps: u32,
+    /// One entry per dosing protocol, all sharing the same grid + RNG seed
+    /// so differences reflect the protocol alone, not stochastic noise.
+    schedules: Vec<DoseSweepEntry>,
+}
+
+/// Normalized RSL3 interstitial-concentration factor series from the
+/// two-compartment tumor PK ODE (#239 `DoseSchedule::FromPk` bridge).
+///
+/// Solves `tumor_pk::solve_tumor_pk` for an IV bolus into a breast-tumor
+/// compartment, then normalizes the interstitial timecourse to peak 1.0 so
+/// it reads as a drug-availability factor. This is what finally wires the
+/// (previously orphaned) PK ODE into the spatial grid, without coupling the
+/// grid to the solver — the grid just consumes the resulting `&[f64]`.
+fn rsl3_pk_factor_series(n_steps: u32) -> Vec<f64> {
+    use ferroptosis_core::tumor_pk::{breast_tumor, solve_tumor_pk, PlasmaModel};
+    // IV bolus, ~35-step plasma half-life (k_el = ln2 / 35 ≈ 0.0198 /min).
+    let plasma = PlasmaModel::IvBolus {
+        c0: 1.0,
+        k_el: 0.0198,
+    };
+    let tumor = breast_tumor();
+    let res = solve_tumor_pk(&plasma, &tumor, n_steps as usize, 10);
+    let max = res
+        .c_interstitial
+        .iter()
+        .cloned()
+        .fold(0.0_f64, f64::max)
+        .max(1e-9);
+    res.c_interstitial
+        .iter()
+        .map(|c| (c / max).clamp(0.0, 1.0))
+        .collect()
+}
+
+/// `--dose-sweep`: run RSL3 across all five dosing protocols at the
+/// combined-TME context (immune + stromal + pH, λ=120) and write
+/// `dose_comparison.json` (#239).
+///
+/// **Controlled comparison**: every protocol uses the SAME tumor grid
+/// (fixed `SEED`) and the SAME runtime RNG seed (all conditions share one
+/// name), so the only thing that varies between rows is the dosing
+/// schedule. Differences in kill rate therefore reflect the protocol, not
+/// stochastic noise.
+fn run_dose_sweep(output_dir: &Path) {
+    eprintln!(
+        "=== --dose-sweep: RSL3 across dosing protocols ({}³ × {} steps) ===",
+        GRID_DIM, N_STEPS
+    );
+
+    // (label, description, schedule). All run RSL3 + immune + stromal + pH.
+    let protocols: Vec<(&str, &str, DoseSchedule)> = vec![
+        (
+            "constant",
+            "Steady-state full availability (one-shot GPX4 knockdown)",
+            DoseSchedule::Constant,
+        ),
+        (
+            "bolus",
+            "Single bolus at step 10, 20-step half-life",
+            DoseSchedule::Bolus {
+                dose_step: 10,
+                peak: 1.0,
+                half_life_steps: 20.0,
+            },
+        ),
+        (
+            "multidose",
+            "4 doses at steps 10/55/100/145, 18-step half-life",
+            DoseSchedule::MultiDose {
+                dose_steps: vec![10, 55, 100, 145],
+                peak: 1.0,
+                half_life_steps: 18.0,
+            },
+        ),
+        (
+            "infusion",
+            "Continuous infusion, level 0.5, steps 10-170",
+            DoseSchedule::Infusion {
+                start: 10,
+                end: 170,
+                level: 0.5,
+            },
+        ),
+        (
+            "frompk",
+            "tumor_pk two-compartment IV-bolus interstitial curve (breast tumor)",
+            DoseSchedule::FromPk {
+                series: rsl3_pk_factor_series(N_STEPS),
+            },
+        ),
+    ];
+
+    let entries: Vec<DoseSweepEntry> = protocols
+        .par_iter()
+        .map(|(label, desc, sched)| {
+            let cond = Condition {
+                // Shared name → shared cond_seed → matched RNG across protocols.
+                name: "dosesweep_RSL3".to_string(),
+                treatment: Treatment::RSL3,
+                treatment_name: "RSL3".to_string(),
+                o2_lambda: Some(ZONE_REF_LAMBDA),
+                immune_on: true,
+                stromal_on: true,
+                ph_on: true,
+                dose_schedule: sched.clone(),
+            };
+            let r = run_one_condition(&cond);
+            eprintln!(
+                "  {label:<10} → kill={:.2}% (ferro={}, immune={})",
+                r.overall_kill_rate * 100.0,
+                r.ferroptosis_kills.unwrap_or(0),
+                r.immune_kills.unwrap_or(0),
+            );
+            DoseSweepEntry {
+                schedule: (*label).to_string(),
+                description: (*desc).to_string(),
+                total_tumor: r.total_tumor,
+                total_dead: r.total_dead,
+                overall_kill_rate: r.overall_kill_rate,
+                ferroptosis_kills: r.ferroptosis_kills.unwrap_or(0),
+                immune_kills: r.immune_kills.unwrap_or(0),
+            }
+        })
+        .collect();
+
+    let result = DoseSweepResult {
+        schema_version: DOSE_SWEEP_SCHEMA_VERSION,
+        treatment: "RSL3".to_string(),
+        context: "immune + stromal + pH at λ=120 µm; shared grid + RNG seed across protocols"
+            .to_string(),
+        grid_dim: GRID_DIM,
+        n_steps: N_STEPS,
+        schedules: entries,
+    };
+
+    let path = output_dir.join("dose_comparison.json");
+    fs::write(&path, serde_json::to_string_pretty(&result).unwrap())
+        .expect("Failed to write dose_comparison.json");
+    eprintln!("Wrote {}", path.display());
+}
+
 fn main() {
     // Guard against silent drift between this binary's metadata const and
     // the library's runtime value: if a future PR tunes
@@ -1119,6 +1287,16 @@ fn main() {
     // `--snapshot` defaults to `combined`.
     if let Some(name) = parse_snapshot_arg(std::env::args()) {
         run_snapshot(output_dir, tumor_radius_um, &name);
+        return;
+    }
+
+    // `--dose-sweep` runs RSL3 across all five dosing protocols (Constant /
+    // Bolus / MultiDose / Infusion / FromPk) at the combined-TME context and
+    // writes `dose_comparison.json` — the quantitative "does dosing protocol
+    // change efficacy?" answer (#239). Separate file; does NOT touch
+    // summary.json (which stays byte-identical to the 24-condition matrix).
+    if std::env::args().any(|a| a == "--dose-sweep") {
+        run_dose_sweep(output_dir);
         return;
     }
 
@@ -1523,6 +1701,24 @@ mod tests {
             (0.0..=1.0).contains(&r1.overall_kill_rate),
             "kill rate must be a valid fraction, got {}",
             r1.overall_kill_rate
+        );
+    }
+
+    /// The FromPk bridge series must be a valid normalized availability
+    /// factor: correct length, all values in [0, 1], and peak ≈ 1.0
+    /// (normalization target). Guards the `tumor_pk` → spatial-grid wiring.
+    #[test]
+    fn rsl3_pk_factor_series_is_normalized() {
+        let series = rsl3_pk_factor_series(180);
+        assert_eq!(series.len(), 180, "series length must match n_steps");
+        assert!(
+            series.iter().all(|&f| (0.0..=1.0).contains(&f)),
+            "all factors must be in [0, 1]"
+        );
+        let peak = series.iter().cloned().fold(0.0_f64, f64::max);
+        assert!(
+            (peak - 1.0).abs() < 1e-9,
+            "series must be normalized to peak 1.0, got {peak}"
         );
     }
 

--- a/simulations/sim-tme-3d/src/main.rs
+++ b/simulations/sim-tme-3d/src/main.rs
@@ -579,6 +579,17 @@ fn run_one_condition_with_config(
                                 // should decay from dose N, not from t=0 (#239).
                                 // Net effective exo in sim_cell_step is then
                                 // exactly `base * dose_factor(step)`.
+                                //
+                                // The `.max(1e-9)` only guards a 0/0; in
+                                // practice exo_decay_factor bottoms out near
+                                // ~1e-3 at step 179, so the stored exo_ros_peak
+                                // is amplified up to ~1000×. That's finite and
+                                // safe because `base * dose_factor` is itself
+                                // tiny that late in the run (the dose has
+                                // decayed), and sim_cell_step immediately
+                                // multiplies the envelope back in — the
+                                // amplified value never reaches any other
+                                // computation.
                                 let decay = exo_decay_factor(step).max(1e-9);
                                 grid.cells[idx].state.exo_ros_peak =
                                     base_exo[idx] * dose_factor / decay;
@@ -1021,6 +1032,9 @@ const SNAPSHOTS: &[SnapshotPreset] = &[
 /// The multi-dose schedule used by the `multidose` snapshot preset:
 /// four ROS pulses across the 180-step run. Sharp half-life (8 steps) so
 /// each pulse rises and fades distinctly, producing visible death waves.
+///
+/// These parameters are **illustrative** — chosen for visual clarity of
+/// the death-wave dynamics, NOT calibrated to a clinical SDT protocol.
 fn multidose_snapshot_schedule() -> DoseSchedule {
     DoseSchedule::MultiDose {
         dose_steps: vec![10, 55, 100, 145],
@@ -1196,6 +1210,12 @@ fn run_dose_sweep(output_dir: &Path) {
     );
 
     // (label, description, schedule). All run RSL3 + immune + stromal + pH.
+    //
+    // The half-life / peak / level numbers below are ILLUSTRATIVE v1 values,
+    // not calibrated to clinical protocols (RSL3_INACTIVATION_RATE itself was
+    // tuned for sustained conc=1.0). The informative output is the
+    // cross-protocol ORDERING of kill rates, not the absolute magnitudes —
+    // dose_comparison.json's `context` field and the README record this.
     let protocols: Vec<(&str, &str, DoseSchedule)> = vec![
         (
             "constant",

--- a/simulations/sim-tme-3d/src/main.rs
+++ b/simulations/sim-tme-3d/src/main.rs
@@ -51,7 +51,7 @@ use std::path::Path;
 mod npy;
 mod snapshot;
 
-use ferroptosis_core::biochem::{sim_cell_step, CellState};
+use ferroptosis_core::biochem::{exo_decay_factor, sim_cell_step, CellState};
 use ferroptosis_core::cell::Treatment;
 use ferroptosis_core::dose_schedule::DoseSchedule;
 use ferroptosis_core::grid::{TumorGrid3D, TUMOR_RADIUS_FRACTION};
@@ -570,10 +570,18 @@ fn run_one_condition_with_config(
                                 st.gpx4 = st.gpx4.max(0.0);
                             }
                             Treatment::SDT | Treatment::PDT => {
-                                // Scale the exogenous-ROS bolus by drug
-                                // availability this step. The intra-cell decay
-                                // envelope inside sim_cell_step composes on top.
-                                grid.cells[idx].state.exo_ros_peak = base_exo[idx] * dose_factor;
+                                // Set the exogenous-ROS bolus so the schedule
+                                // is the SOLE availability envelope. We divide
+                                // out sim_cell_step's intrinsic single-bolus
+                                // decay (`exo_decay_factor`, 1.0 for step<30)
+                                // because it would otherwise double-count decay
+                                // for later doses — ROS generated at dose N
+                                // should decay from dose N, not from t=0 (#239).
+                                // Net effective exo in sim_cell_step is then
+                                // exactly `base * dose_factor(step)`.
+                                let decay = exo_decay_factor(step).max(1e-9);
+                                grid.cells[idx].state.exo_ros_peak =
+                                    base_exo[idx] * dose_factor / decay;
                             }
                             Treatment::Control => {}
                         }
@@ -958,12 +966,21 @@ struct SnapshotPreset {
     name: &'static str,
     /// Short human-readable description for the eprintln banner.
     desc: &'static str,
+    /// Treatment modality for this preset.
+    treatment: Treatment,
+    /// Display name for `treatment` (avoids a Debug-format dependency).
+    treatment_name: &'static str,
     /// True if immune kills + DAMP coupling are on (immune_mode = "immune_on").
     immune_on: bool,
     /// True if stromal protection (CAF GSH/MUFA shielding) is on.
     stromal_on: bool,
     /// True if the pH gradient + iron release + ion-trap are on.
     ph_on: bool,
+    /// True if this preset uses the multi-dose schedule (#239) instead of
+    /// the steady-state `Constant` default. The concrete `DoseSchedule` is
+    /// built at runtime in `run_snapshot` (a `const` can't hold the
+    /// `MultiDose` Vec).
+    multidose: bool,
 }
 
 /// Visualization presets for `--snapshot=NAME`. Keep this list small —
@@ -972,18 +989,45 @@ const SNAPSHOTS: &[SnapshotPreset] = &[
     SnapshotPreset {
         name: "combined",
         desc: "RSL3 + immune + stromal + pH (all TME protections active)",
+        treatment: Treatment::RSL3,
+        treatment_name: "RSL3",
         immune_on: true,
         stromal_on: true,
         ph_on: true,
+        multidose: false,
     },
     SnapshotPreset {
         name: "bare",
         desc: "RSL3, no immune / stromal / pH (the unprotected baseline)",
+        treatment: Treatment::RSL3,
+        treatment_name: "RSL3",
         immune_on: false,
         stromal_on: false,
         ph_on: false,
+        multidose: false,
+    },
+    SnapshotPreset {
+        name: "multidose",
+        desc: "SDT multi-dose (4 pulses) + immune — death waves sync to each dose (#239)",
+        treatment: Treatment::SDT,
+        treatment_name: "SDT",
+        immune_on: true,
+        stromal_on: false,
+        ph_on: false,
+        multidose: true,
     },
 ];
+
+/// The multi-dose schedule used by the `multidose` snapshot preset:
+/// four ROS pulses across the 180-step run. Sharp half-life (8 steps) so
+/// each pulse rises and fades distinctly, producing visible death waves.
+fn multidose_snapshot_schedule() -> DoseSchedule {
+    DoseSchedule::MultiDose {
+        dose_steps: vec![10, 55, 100, 145],
+        peak: 1.0,
+        half_life_steps: 8.0,
+    }
+}
 
 /// Look up a snapshot preset by name, or print available choices and exit.
 fn resolve_snapshot(name: &str) -> &'static SnapshotPreset {
@@ -1001,23 +1045,31 @@ fn resolve_snapshot(name: &str) -> &'static SnapshotPreset {
 
 /// Run a single condition with per-step trajectory capture, then write
 /// `trajectory_{dead,damp,lp}.npy` + `trajectory_meta.json` to
-/// `output_dir`. Driven by the `--snapshot[=NAME]` CLI flag (#193).
+/// `output_dir`. Driven by the `--snapshot[=NAME]` CLI flag (#193, #239).
 ///
-/// All snapshots use RSL3 at λ=120 µm; the toggles (immune / stromal /
-/// pH) vary by [`SnapshotPreset`]. Files are written under the same
-/// names regardless of preset — running a second time overwrites; rename
-/// manually if you want to keep multiple side by side.
+/// Treatment, TME toggles, and dose schedule vary by [`SnapshotPreset`].
+/// Files are written under the same names regardless of preset — running
+/// a second time overwrites; rename manually to keep several side by side.
 fn run_snapshot(output_dir: &Path, tumor_radius_um: f64, name: &str) {
     let preset = resolve_snapshot(name);
+    let dose_schedule = if preset.multidose {
+        multidose_snapshot_schedule()
+    } else {
+        DoseSchedule::Constant
+    };
+    // Administration steps for metadata / renderer dose markers (empty for
+    // the steady-state Constant presets).
+    let dose_steps = dose_schedule.dose_steps();
+
     let condition = Condition {
-        name: format!("snapshot_{}_RSL3", preset.name),
-        treatment: Treatment::RSL3,
-        treatment_name: "RSL3".to_string(),
+        name: format!("snapshot_{}_{}", preset.name, preset.treatment_name),
+        treatment: preset.treatment,
+        treatment_name: preset.treatment_name.to_string(),
         o2_lambda: Some(ZONE_REF_LAMBDA),
         immune_on: preset.immune_on,
         stromal_on: preset.stromal_on,
         ph_on: preset.ph_on,
-        dose_schedule: DoseSchedule::Constant,
+        dose_schedule,
     };
 
     eprintln!(
@@ -1046,8 +1098,9 @@ fn run_snapshot(output_dir: &Path, tumor_radius_um: f64, name: &str) {
         cell_size_um: CELL_SIZE_UM,
         tumor_radius_um,
         n_steps: run_cfg.n_steps,
+        dose_steps,
         condition: snapshot::TrajectoryCondition {
-            treatment: "RSL3".to_string(),
+            treatment: preset.treatment_name.to_string(),
             o2_condition: "gradient".to_string(),
             o2_lambda_um: Some(ZONE_REF_LAMBDA),
             immune_mode: if preset.immune_on { "immune_on" } else { "off" }.to_string(),

--- a/simulations/sim-tme-3d/src/snapshot.rs
+++ b/simulations/sim-tme-3d/src/snapshot.rs
@@ -99,6 +99,10 @@ pub struct TrajectoryMeta {
     pub cell_size_um: f64,
     pub tumor_radius_um: f64,
     pub n_steps: u32,
+    /// Steps at which a drug dose is administered (#239). Empty for the
+    /// steady-state `Constant` presets. The Python renderer draws a marker
+    /// on these frames so the viewer can see death waves sync to doses.
+    pub dose_steps: Vec<u32>,
     pub condition: TrajectoryCondition,
 }
 


### PR DESCRIPTION
## Summary

Implements issue #239 (multi-dose / time-varying pharmacokinetics). The simulator previously modeled drug as present at **constant** strength for the whole run; this adds a `DoseSchedule` abstraction (bolus / multi-dose / infusion / PK-curve) and wires it into sim-tme-3d, behind a gate that keeps the default path **byte-identical**.

> **Update:** #238 has merged to main, and this branch has been **rebased onto current main** (the duplicated viz commits dropped; one renderer conflict resolved to keep main's refactor + the #239 dose markers). Base is now `main`; the diff is the #239 work only. Re-verified under CI's pinned toolchain (rust 1.96.0): fmt clean, 189 ferroptosis-core + 23 sim-tme-3d tests pass, default `summary.json` SHA `1cf8866312…` unchanged, dose-sweep numbers unchanged.

## The keystone finding

The understand-phase mapping revealed that `ferroptosis-core::tumor_pk` **already** had validated per-step time-varying drug logic (`sim_cell_with_pk`) — it was just orphaned to the `sim-tumor-pk` scalar binary and never wired into the spatial grid. So #239 was fundamentally a **wiring/abstraction** problem, not new physics.

## Four commits

| # | What |
|---|---|
| 1 | `DoseSchedule` library module (Constant/Bolus/MultiDose/Infusion/FromPk) + `from_cell_with_ros_opts` (skips RSL3 one-shot knockdown for the dosed path) |
| 2 | Wire into sim-tme-3d step loop behind `is_constant()` gate |
| 3 | `--dose-sweep` mode → `dose_comparison.json` + `tumor_pk` **FromPk bridge** |
| 4 | `--snapshot=multidose` preset + **SDT envelope-neutralization** + renderer dose markers |
| 5–7 | Review follow-ups: architecture-doc contracts, Constant-path golden regression test, clamp/alloc/assert cleanup + Infusion/FromPk end-to-end tests |

## How drug becomes time-varying

`DoseSchedule::factor_at(step) -> f64` is a per-step availability multiplier (Constant ⇒ exactly 1.0). Applied per modality:
- **RSL3**: drives per-step covalent GPX4 inactivation (`gpx4 -= RSL3_INACTIVATION_RATE · availability · gpx4`, the validated `sim_cell_with_pk` model) instead of the one-shot init knockdown. pH ion-trapping composes as a per-cell spatial availability multiplier.
- **SDT/PDT**: scales the per-step exogenous-ROS bolus. **Envelope-neutralization fix**: `sim_cell_step`'s intrinsic single-bolus decay (extracted to `biochem::exo_decay_factor`) is divided out on the dosed path, so the schedule is the *sole* availability envelope — otherwise ROS from a late dose would be wrongly crushed by the from-t=0 decay.

## Two headline results

**`--dose-sweep`** (RSL3 across protocols, shared grid + RNG seed):

| protocol | kill % | ferro | immune |
|---|---|---|---|
| constant | 0.39 | 314 | 10 |
| multidose | 0.03 | 27 | 0 |
| infusion | 0.02 | 20 | 0 |
| frompk | 0.02 | 16 | 0 |
| bolus | 0.01 | 5 | 0 |

The steady-state `constant` model **overestimates RSL3 kill by 10-60×** vs every realistic time-varying protocol — a direct quantification of the "drug present forever" idealization. (Magnitudes are uncalibrated v1; the cross-protocol ordering is the signal.)

**`--snapshot=multidose`** (SDT, 4 doses at steps 10/55/100/145): after the envelope fix, all four doses produce clean death waves (7928 / 27823 / 13040 / 7230 deaths, 69.6% total kill). The renderer marks each dose frame with a red border + `💉 DOSE`.

## Bit-identical guarantee

When every condition uses `DoseSchedule::Constant` (the entire default 24-condition matrix), the run is **byte-identical** to pre-#239: `summary.json` SHA = `1cf8866312…` (verified at every commit). The dose machinery is gated behind `is_constant()`; `--dose-sweep` writes a separate file and never touches `summary.json`. The `exo_decay_factor` extraction is an arithmetically-identical refactor of 3 call sites.

## Verification

- **189** ferroptosis-core (+10 DoseSchedule, +1 exo_decay_factor) + **20** sim-tme-3d (+4 dosed-path) tests pass.
- `cargo fmt --all --check` exits 0.
- `summary.json` byte-identical to baseline at every commit.
- `--dose-sweep` and `--snapshot=multidose` both run end-to-end; multidose GIF verified (180 frames, 4 death waves confirmed by per-step death-count analysis).

## Self-review

Ran an adversarial review workflow (4 dimension reviewers → verification of every medium+ finding). Both medium findings were **refuted** on inspection (the Bolus `half_life` guard is unreachable with current inputs + idiomatic; the PK normalization fails-loud rather than masking). No critical/high findings; the bit-identical and RSL3-dosed dimensions found only confirmations.

## Known limitation (follow-up)

No CI-level golden-SHA regression test for the byte-identity claim (same gap #237 noted). The full 60³×180 production run is too slow for CI; determinism + kill-accounting are guarded by existing fast tests. A checked-in baseline snapshot test is worth a follow-up.

## Test plan

- [ ] CI: `Rust Tests / test` + `fmt` green
- [ ] CI: CodeQL / Analyze green
- [x] #238 merged; this rebased onto `main` (base is now `main`, conflicts resolved)

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)
