### PR TITLE
3D performance & scalability: benchmark harness + within-condition rayon (#192)

### DIFF
--- a/simulations/ferroptosis-core/src/grid.rs
+++ b/simulations/ferroptosis-core/src/grid.rs
@@ -359,9 +359,11 @@ pub fn death_heatmap(grid: &TumorGrid) -> Array2<u8> {
 /// bit-for-bit. The two types share `GridCell` and `GridCensus`; any
 /// common abstraction can land as a trait when patterns emerge.
 ///
-/// **Memory:** `GridCell` is ~150–170 B; 100³ ≈ 170 MB, 200³ ≈ 1.4 GB.
-/// Tests use ≤ 20³ (≈ 1.4 MB). Realistic 3D simulation grids land with
-/// the binary that constructs them (#194 `sim-spatial-3d`).
+/// **Memory (measured, #192):** `size_of::<GridCell>() = 144 B`. Peak
+/// process RSS for a sim-tme-3d run: 100³ ≈ 163 MB, 150³ ≈ 546 MB,
+/// 200³ ≈ 1.29 GB (dense — fits the 2 GB budget with headroom). Tests
+/// use ≤ 20³. See sim-tme-3d's `--bench` + the README "Performance &
+/// scalability" section.
 ///
 /// **Storage:** flat `Vec<GridCell>` indexed as
 /// `r * cols * layers + c * layers + l` — row-major (C-order) with
@@ -398,14 +400,15 @@ impl TumorGrid3D {
     /// sphere center when dimensions are even. Same convention as
     /// `TumorGrid::generate`.
     ///
-    /// **Memory:** `GridCell` is ~150–170 B; a `100³` grid is ~170 MB,
-    /// `200³` is ~1.4 GB. Callers should size against available RAM
-    /// before invoking; `debug_assert!` guards against accidental
-    /// allocations above ~1 G cells (≈ 170 GB, almost certainly a typo).
+    /// **Memory (measured, #192):** `size_of::<GridCell>() = 144 B`; a
+    /// `100³` grid run peaks ≈ 163 MB RSS, `200³` ≈ 1.29 GB (dense, under
+    /// the 2 GB budget). Callers should size against available RAM before
+    /// invoking; `debug_assert!` guards against accidental allocations
+    /// above ~1 G cells (≈ 144 GB, almost certainly a typo).
     pub fn generate(rows: usize, cols: usize, layers: usize, cell_size_um: f64, seed: u64) -> Self {
         // Memory guard — catches "rows = 1000" typos in tests and CI.
         // Active only in debug builds; release callers are expected to
-        // size against their own hardware. 10^9 cells × 170 B ≈ 170 GB
+        // size against their own hardware. 10^9 cells × 144 B ≈ 144 GB
         // is well past any realistic spheroid sim and almost certainly
         // an off-by-orders-of-magnitude error.
         //

--- a/simulations/sim-tme-3d/README.md
+++ b/simulations/sim-tme-3d/README.md
@@ -164,6 +164,33 @@ Three smoke tests:
 
 The library primitives (`physics`, `oxygen`, `ph`, `stromal`, `immune_spatial`) are exhaustively tested in `ferroptosis-core`'s 160+ unit tests. This binary tests orchestration, not the math.
 
+## Performance & scalability (`--bench`, #192)
+
+`--bench` runs one representative condition (combined-TME RSL3) at a configurable grid size and prints wall-clock + throughput. Grid/steps come from env so a sweep is scriptable:
+
+```bash
+cd simulations
+BENCH_GRID_DIM=200 BENCH_N_STEPS=180 cargo run --release -p sim-tme-3d -- --bench
+# peak RSS: wrap with `/usr/bin/time -l` (macOS) or `/usr/bin/time -v` (Linux)
+```
+
+**Measured** (rust 1.96.0, 10-core machine; `size_of::<GridCell>() = 144 B`):
+
+| Grid | Cells | Peak RSS | Serial 180-step | Parallel 180-step | Throughput |
+|---|---|---|---|---|---|
+| 50³  | 125 k  | 22 MB    | ~0.7 s   | ~0.4 s   | 3.3e7 cell·step/s |
+| 100³ | 1.0 M  | 163 MB   | ~24 s    | ~5.4 s   | 3.3e7 |
+| 150³ | 3.375 M | 546 MB  | ~82 s    | ~18 s    | 3.3e7 |
+| 200³ | 8.0 M  | **1.29 GB** | ~195 s (~3.2 min) | **42.7 s** (measured) | 3.4e7 |
+
+(Serial figures are from the pre-parallelization commit; parallel from the within-condition rayon path.) Both **performance targets are met** — 100³ < 2 min and 200³ < 15 min — with the within-condition rayon parallelism (#192) giving a **~4.5× speedup** on 10 cores on top.
+
+**Memory verdict (feeds #240 patient-scale):** dense **200³ fits the 2 GB budget at 1.29 GB** with ~35% headroom — no sparse grid needed at this scale. Sparse/adaptive only become compelling at 300³+ (≈ 6 GB) or when running many large conditions concurrently; deferred to a follow-up issue.
+
+**Recommended grid size:** 60³ for the 24-condition matrix (throughput); up to 150³ comfortably for single high-resolution runs; 200³ feasible at ~1.29 GB / ~43 s. Do **not** run 200³ across many concurrent conditions (24 × 1.29 GB would OOM) — throttle with `RAYON_NUM_THREADS` if needed.
+
+**Parallelism note:** the default matrix parallelizes across the 24 conditions (`par_iter`); the biochem + immune-kill loops parallelize *within* a condition (rayon, byte-identical via position-independent per-cell RNG). Iron + DAMP diffusion stay serial (cross-cell dependencies). A single large `--bench` run has no condition-level parallelism, so within-condition rayon is what makes it fast.
+
 ## Manuscript-keystone questions (issue #195)
 
 After running both `sim-tme` and `sim-tme-3d` and generating the comparison table. Each bullet states the pre-run **hypothesis** from issue #195 and the **observed** result from the canonical 60³ × 180-step run (full details in `simulations/calibration/3d_validation_report.md`).
@@ -186,9 +213,9 @@ After running both `sim-tme` and `sim-tme-3d` and generating the comparison tabl
 
 ## Follow-ups deferred to subsequent PRs
 
-- **Lift `PhConfig` / `StromalConfig` / `ImmuneConfig` to `ferroptosis-core::params`** — currently duplicated from sim-tme. Per the consolidated cleanup checklist on issue #195.
+- ~~**Lift `PhConfig` / `StromalConfig` / `ImmuneConfig` to `ferroptosis-core::params`**~~ — **done** in #220/#224 (lifted as `PhConfig` / `StromalConfig` / `SpatialImmuneConfig`).
 - **O₂ cycling** (square-wave λ alternation) — sim-tme has it, sim-tme-3d skipped for v1 scope.
 - **Anti-PD-1 sweep** — included in sim-tme; skipped here for v1.
-- **3D volumetric visualization** — see #193.
-- **Larger grids** (80³+) — gated on #194 perf work.
+- **3D volumetric visualization** — partially done (#193/#238 axial-slice GIF); full volume render still open under #193.
+- ~~**Larger grids**~~ — **demonstrated feasible** in #192: up to 200³ at ~1.29 GB / ~43 s (see Performance & scalability above). The general `sim-spatial-3d` binary (#194) is separate.
 - **Empirical pimonidazole validation** — see #196.

--- a/simulations/sim-tme-3d/README.md
+++ b/simulations/sim-tme-3d/README.md
@@ -174,16 +174,16 @@ BENCH_GRID_DIM=200 BENCH_N_STEPS=180 cargo run --release -p sim-tme-3d -- --benc
 # peak RSS: wrap with `/usr/bin/time -l` (macOS) or `/usr/bin/time -v` (Linux)
 ```
 
-**Measured** (rust 1.96.0, 10-core machine; `size_of::<GridCell>() = 144 B`):
+**All figures below are direct `--bench` wall-clock measurements at 180 steps** (no projections), rust 1.96.0, 10-core machine, `size_of::<GridCell>() = 144 B`. Serial figures are from the pre-parallelization commit (commit 1 of this PR); parallel figures from the within-condition rayon path (commit 2). Throughput columns are each path's own `cell_steps_per_s`. Peak RSS is process-wide, measured via `/usr/bin/time -l`.
 
-| Grid | Cells | Peak RSS | Serial 180-step | Parallel 180-step | Throughput |
-|---|---|---|---|---|---|
-| 50³  | 125 k  | 22 MB    | ~0.7 s   | ~0.4 s   | 3.3e7 cell·step/s |
-| 100³ | 1.0 M  | 163 MB   | ~24 s    | ~5.4 s   | 3.3e7 |
-| 150³ | 3.375 M | 546 MB  | ~82 s    | ~18 s    | 3.3e7 |
-| 200³ | 8.0 M  | **1.29 GB** | ~195 s (~3.2 min) | **42.7 s** (measured) | 3.4e7 |
+| Grid | Cells | Peak RSS | Serial 180-step | Parallel 180-step | Speedup | Parallel throughput |
+|---|---|---|---|---|---|---|
+| 50³  | 125 k   | 23 MB   | 3.7 s   | 1.0 s  | 3.8× | 2.3e7 cell·step/s |
+| 100³ | 1.0 M   | 164 MB  | 26.4 s  | 6.1 s  | 4.3× | 3.0e7 |
+| 150³ | 3.375 M | 546 MB  | 87.6 s  | 18.3 s | 4.8× | 3.3e7 |
+| 200³ | 8.0 M   | **1.29 GB** | 201.3 s (3.4 min) | **40.8 s** | 4.9× | 3.5e7 |
 
-(Serial figures are from the pre-parallelization commit; parallel from the within-condition rayon path.) Both **performance targets are met** — 100³ < 2 min and 200³ < 15 min — with the within-condition rayon parallelism (#192) giving a **~4.5× speedup** on 10 cores on top.
+Both **performance targets are met even serially** (100³ < 2 min, 200³ < 15 min); the within-condition rayon parallelism (#192) adds a **3.8×–4.9× speedup** on 10 cores (the ratio grows with grid size as the fixed per-step rayon-join overhead amortizes). Serial throughput is ~7e6 cell·step/s across sizes.
 
 **Memory verdict (feeds #240 patient-scale):** dense **200³ fits the 2 GB budget at 1.29 GB** with ~35% headroom — no sparse grid needed at this scale. Sparse/adaptive only become compelling at 300³+ (≈ 6 GB) or when running many large conditions concurrently; deferred to a follow-up issue.
 

--- a/simulations/sim-tme-3d/README.md
+++ b/simulations/sim-tme-3d/README.md
@@ -191,6 +191,8 @@ Both **performance targets are met even serially** (100³ < 2 min, 200³ < 15 mi
 
 **Parallelism note:** the default matrix parallelizes across the 24 conditions (`par_iter`); the biochem + immune-kill loops parallelize *within* a condition (rayon, byte-identical via position-independent per-cell RNG). Iron + DAMP diffusion stay serial (cross-cell dependencies). A single large `--bench` run has no condition-level parallelism, so within-condition rayon is what makes it fast.
 
+The within-condition rayon is **nested** inside the condition-level `par_iter` on the default 24-condition matrix. Measured before/after, the **matrix wall-clock is unchanged** (~15 s on 10 cores, serial-within-condition vs parallel-within-condition, within run-to-run noise): the 24 conditions already saturate the pool, so the inner `par_iter_mut` adds no measurable overhead and finds no idle workers to exploit until the tail. The speedup applies to **single large-grid runs** (the #240 patient-scale direction), not the everyday 60³ matrix — which is the intended target.
+
 ## Manuscript-keystone questions (issue #195)
 
 After running both `sim-tme` and `sim-tme-3d` and generating the comparison table. Each bullet states the pre-run **hypothesis** from issue #195 and the **observed** result from the canonical 60³ × 180-step run (full details in `simulations/calibration/3d_validation_report.md`).

--- a/simulations/sim-tme-3d/src/main.rs
+++ b/simulations/sim-tme-3d/src/main.rs
@@ -21,9 +21,12 @@
 //!
 //! sim-tme uses a 500×500 grid (tumor radius ≈ 4500 µm — large in-vivo
 //! tumor). sim-tme-3d uses a **60³ grid** (tumor radius ≈ 540 µm —
-//! upper end of in-vitro spheroids). Larger 3D grids are infeasible
-//! at this stage (a 500³ grid would need ~21 GB; even 100³ × 180 steps
-//! is hours per condition without #194's perf optimizations).
+//! upper end of in-vitro spheroids) as the default for the 24-condition
+//! matrix. Larger single-condition grids are now feasible after the #192
+//! perf work: measured 200³ × 180 = ~43 s at ~1.29 GB on 10 cores (see
+//! `--bench` + the "Performance & scalability" section of the README).
+//! Only 500³+ (≈ 18 GB dense) remains out of reach. The 60³ default is a
+//! deliberate matrix-throughput choice, not a ceiling.
 //!
 //! **The Python comparison script reports RATIOS** (e.g., RSL3 hypoxic
 //! kill / RSL3 normoxic kill) which are dimensionally meaningful at

--- a/simulations/sim-tme-3d/src/main.rs
+++ b/simulations/sim-tme-3d/src/main.rs
@@ -545,6 +545,13 @@ fn run_one_condition_with_config(
         // Reads of `base_exo` / `rsl3_drug_avail` / `adjacency_mask` are
         // shared-immutable by own index. Iron + DAMP diffusion stay serial
         // (cross-cell deps) and run after the rayon join (a per-step barrier).
+        //
+        // The `zip` below relies on `cells` and `damp_field` having equal
+        // length (both allocated `n_cells`); a shorter `damp_field` would
+        // silently TRUNCATE the loop and drop cells. They're allocated full
+        // size unconditionally above, but assert it so a future conditional
+        // allocation can't introduce a silent correctness bug (review #255).
+        debug_assert_eq!(grid.cells.len(), damp_field.len());
         let died_this_step: usize = grid
             .cells
             .par_iter_mut()
@@ -1305,13 +1312,23 @@ fn run_dose_sweep(output_dir: &Path) {
     eprintln!("Wrote {}", path.display());
 }
 
-/// Read a positive-integer env var, falling back to `default` if unset or
-/// unparseable. Used by `--bench` to override grid size / step count without
-/// touching the byte-identical-locked `GRID_DIM`/`N_STEPS` constants.
-fn bench_env(name: &str, default: usize) -> usize {
+/// Read a positive `usize` env var, falling back to `default` if unset or
+/// unparseable. Used by `--bench` to override grid size without touching the
+/// byte-identical-locked `GRID_DIM` constant.
+fn bench_env_usize(name: &str, default: usize) -> usize {
     std::env::var(name)
         .ok()
         .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(default)
+}
+
+/// Read a positive `u32` env var (parsed directly into `u32` — values above
+/// `u32::MAX` are rejected, not silently truncated). For `BENCH_N_STEPS`.
+fn bench_env_u32(name: &str, default: u32) -> u32 {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse::<u32>().ok())
         .filter(|&n| n > 0)
         .unwrap_or(default)
 }
@@ -1330,9 +1347,11 @@ fn bench_env(name: &str, default: usize) -> usize {
 /// within-condition cost — exactly the work the within-condition parallelism
 /// targets. Writes no output files; the default matrix path is untouched.
 fn run_bench() {
-    let grid_dim = bench_env("BENCH_GRID_DIM", GRID_DIM);
-    let n_steps = bench_env("BENCH_N_STEPS", N_STEPS as usize) as u32;
-    let n_cells = grid_dim.pow(3);
+    let grid_dim = bench_env_usize("BENCH_GRID_DIM", GRID_DIM);
+    let n_steps = bench_env_u32("BENCH_N_STEPS", N_STEPS);
+    // saturating_pow: a huge BENCH_GRID_DIM saturates rather than overflow-
+    // panicking in debug (the grid allocation would fail first anyway).
+    let n_cells = grid_dim.saturating_pow(3);
 
     eprintln!(
         "=== --bench: single combined-TME RSL3 condition, {grid_dim}³ = {n_cells} cells × {n_steps} steps ==="
@@ -1518,6 +1537,10 @@ mod tests {
     const GOLDEN_TOTAL_DEAD: usize = 2992;
     const GOLDEN_FERRO_KILLS: usize = 2990;
     const GOLDEN_IMMUNE_KILLS: usize = 2;
+    // Dosed-path golden (MultiDose SDT + immune + stromal + pH, 20³×80).
+    const GOLDEN_DOSED_TOTAL_DEAD: usize = 2660;
+    const GOLDEN_DOSED_FERRO_KILLS: usize = 2658;
+    const GOLDEN_DOSED_IMMUNE_KILLS: usize = 2;
 
     /// `--snapshot` (no `=NAME`) defaults to `combined`.
     #[test]
@@ -1881,6 +1904,55 @@ mod tests {
             r.immune_kills,
             Some(GOLDEN_IMMUNE_KILLS),
             "Constant-path immune_kills drifted"
+        );
+    }
+
+    /// **Golden guard for the DOSED parallel path** (review #255 substantive
+    /// point 2). `constant_path_golden_kill_counts` pins the Constant path;
+    /// this pins a MultiDose SDT + immune + stromal + pH condition, which
+    /// exercises the machinery the Constant golden does NOT: the per-step
+    /// SDT exo-envelope divide-out, the grace-end DAMP write, and the
+    /// immune-kill loop — all through the rayon-parallelized loops. Same
+    /// fixed-platform/toolchain caveat as the Constant golden (integer
+    /// counts; `powf`/Ziggurat aren't bit-identical across libm).
+    #[test]
+    fn dosed_path_golden_kill_counts() {
+        let cond = Condition {
+            name: "golden_multidose_SDT".to_string(),
+            treatment: Treatment::SDT,
+            treatment_name: "SDT".to_string(),
+            o2_lambda: Some(ZONE_REF_LAMBDA),
+            immune_on: true,
+            stromal_on: true,
+            ph_on: true,
+            dose_schedule: DoseSchedule::MultiDose {
+                dose_steps: vec![5, 30, 55],
+                peak: 1.0,
+                half_life_steps: 8.0,
+            },
+        };
+        let cfg = RunConfig {
+            grid_dim: 20,
+            n_steps: 80,
+        };
+        let r = run_one_condition_with_config(&cond, cfg, None);
+        assert_eq!(
+            r.total_tumor, GOLDEN_TOTAL_TUMOR,
+            "tumor-cell count drifted"
+        );
+        assert_eq!(
+            r.total_dead, GOLDEN_DOSED_TOTAL_DEAD,
+            "dosed-path total_dead drifted"
+        );
+        assert_eq!(
+            r.ferroptosis_kills,
+            Some(GOLDEN_DOSED_FERRO_KILLS),
+            "dosed-path ferroptosis_kills drifted"
+        );
+        assert_eq!(
+            r.immune_kills,
+            Some(GOLDEN_DOSED_IMMUNE_KILLS),
+            "dosed-path immune_kills drifted"
         );
     }
 

--- a/simulations/sim-tme-3d/src/main.rs
+++ b/simulations/sim-tme-3d/src/main.rs
@@ -23,7 +23,7 @@
 //! tumor). sim-tme-3d uses a **60³ grid** (tumor radius ≈ 540 µm —
 //! upper end of in-vitro spheroids) as the default for the 24-condition
 //! matrix. Larger single-condition grids are now feasible after the #192
-//! perf work: measured 200³ × 180 = ~43 s at ~1.29 GB on 10 cores (see
+//! perf work: measured 200³ × 180 ≈ 41 s at ~1.29 GB on 10 cores (see
 //! `--bench` + the "Performance & scalability" section of the README).
 //! Only 500³+ (≈ 18 GB dense) remains out of reach. The 60³ default is a
 //! deliberate matrix-throughput choice, not a ceiling.

--- a/simulations/sim-tme-3d/src/main.rs
+++ b/simulations/sim-tme-3d/src/main.rs
@@ -503,162 +503,141 @@ fn run_one_condition_with_config(
     let mut ferroptosis_kills = 0usize;
     let mut immune_kills = 0usize;
 
+    // Hoisted out of the per-cell hot loop (these invariants don't vary by
+    // cell or step): on the dosed path the relevant availability vec must be
+    // populated. Compiled out in release.
+    if dosed {
+        match condition.treatment {
+            Treatment::RSL3 => debug_assert!(
+                !rsl3_drug_avail.is_empty(),
+                "rsl3_drug_avail must be populated on the dosed RSL3 path"
+            ),
+            Treatment::SDT | Treatment::PDT => debug_assert!(
+                !base_exo.is_empty(),
+                "base_exo must be populated on the dosed SDT/PDT path"
+            ),
+            Treatment::Control => {}
+        }
+    }
+
     for step in 0..run_cfg.n_steps {
         // Drug availability for this step (#239). `1.0` on the Constant
         // default path (and the `dosed` guard below skips all modulation
         // there anyway, so it's never actually read for Constant).
         let dose_factor = if dosed { schedule.factor_at(step) } else { 1.0 };
 
-        // Ferroptosis biochem + stromal protection
-        for r in 0..grid.rows {
-            for c in 0..grid.cols {
-                for l in 0..grid.layers {
-                    let idx = grid.flat_index(r, c, l);
-                    if !grid.cells[idx].is_tumor {
-                        continue;
-                    }
-                    if grid.cells[idx].state.dead {
-                        if let Some(ds) = grid.cells[idx].state.death_step {
-                            let grace_end = ds + params.post_death_steps;
-                            if step == grace_end {
-                                // `lp_at_death` is misleadingly named — it's
-                                // actually "LP at the end of the post-death
-                                // grace period." Matches sim-tme's naming;
-                                // renaming would touch both binaries and is
-                                // deferred per the consolidated #195 cleanup
-                                // checklist.
-                                grid.cells[idx].lp_at_death = grid.cells[idx].state.lp;
-                                // DAMP release gated on `immune_on` —
-                                // without immune coupling, the damp_field
-                                // isn't read or aggregated, so writes here
-                                // would produce nonsense partial values
-                                // in serialized output (reviewer-flagged in
-                                // PR #219 third-pass).
-                                if condition.immune_on {
-                                    damp_field[idx] +=
-                                        grid.cells[idx].lp_at_death * immune_cfg.damp_per_lp;
-                                }
+        // Ferroptosis biochem + stromal protection.
+        //
+        // Parallelized over cells with rayon (#192). This is safe and
+        // BYTE-IDENTICAL to the old serial r/c/l triple loop because:
+        //   - `enumerate()` over the flat `cells` Vec yields the same `idx`
+        //     as `flat_index(r,c,l)` (row-major), so the per-cell RNG seed
+        //     `(cond_seed, idx, step)` is unchanged and position-independent;
+        //   - each cell reads/writes ONLY its own `GridCell` and its own
+        //     `damp_field[idx]` slot (paired via the zipped `par_iter_mut`);
+        //     `extra_iron` is read-then-zeroed per own cell (cross-cell iron
+        //     spread happens later in the serial `diffuse_iron` phase);
+        //   - `ferroptosis_kills` is an integer sum, associative+commutative,
+        //     so the reduction is order-independent.
+        // Reads of `base_exo` / `rsl3_drug_avail` / `adjacency_mask` are
+        // shared-immutable by own index. Iron + DAMP diffusion stay serial
+        // (cross-cell deps) and run after the rayon join (a per-step barrier).
+        let died_this_step: usize = grid
+            .cells
+            .par_iter_mut()
+            .zip(damp_field.par_iter_mut())
+            .enumerate()
+            .map(|(idx, (gc, damp_slot))| {
+                if !gc.is_tumor {
+                    return 0;
+                }
+                if gc.state.dead {
+                    if let Some(ds) = gc.state.death_step {
+                        let grace_end = ds + params.post_death_steps;
+                        if step == grace_end {
+                            // `lp_at_death` = "LP at end of post-death grace"
+                            // (misnamed; matches sim-tme — rename deferred to
+                            // the #195 cleanup checklist).
+                            gc.lp_at_death = gc.state.lp;
+                            // DAMP release gated on immune_on (else damp_field
+                            // is never read/aggregated — PR #219 third-pass).
+                            if condition.immune_on {
+                                *damp_slot += gc.lp_at_death * immune_cfg.damp_per_lp;
                             }
-                            if step >= grace_end {
-                                continue;
-                            }
-                        } else {
-                            continue;
                         }
-                    }
-
-                    let mut rng = StdRng::seed_from_u64(
-                        cond_seed
-                            .wrapping_add(500_000)
-                            .wrapping_add(idx as u64)
-                            .wrapping_add(step as u64 * 1_000_000),
-                    );
-
-                    let extra_iron = grid.cells[idx].extra_iron;
-                    grid.cells[idx].extra_iron = 0.0;
-
-                    // Time-varying drug modulation (#239). Skipped entirely on
-                    // the Constant default path (`dosed == false`), so output
-                    // is byte-identical there. Applied to LIVE cells only —
-                    // once a cell is dead, this block no longer runs, so its
-                    // STORED drug state (gpx4 for RSL3, exo_ros_peak for
-                    // SDT/PDT) is frozen at its death-step value.
-                    //
-                    // Nuance for SDT/PDT: freezing the stored *peak* is not the
-                    // same as freezing the *effective* exo. The post-death
-                    // branch in `biochem::sim_cell_step` keeps multiplying the
-                    // frozen peak by `exo_decay_factor(step)`, so a dead cell's
-                    // residual exo continues to shrink (~0.5^(k/15)) across its
-                    // ≤5-step grace window — the same intrinsic decay baseline
-                    // dead cells see. This perturbs only post-death `lp` (hence
-                    // `lp_at_death`/`damp_field`) in the SDT multidose snapshot;
-                    // it does NOT affect death determination, summary.json, or
-                    // the RSL3 path. (RSL3 truly freezes: gpx4 is untouched once
-                    // dead, matching `tumor_pk::sim_cell_with_pk`.)
-                    if dosed && !grid.cells[idx].state.dead {
-                        match condition.treatment {
-                            Treatment::RSL3 => {
-                                // Covalent GPX4 inactivation proportional to
-                                // drug availability = schedule × spatial pH
-                                // ion-trap factor. Mirrors sim_cell_with_pk:538.
-                                debug_assert!(
-                                    !rsl3_drug_avail.is_empty(),
-                                    "rsl3_drug_avail must be populated on the dosed RSL3 path"
-                                );
-                                let conc = (dose_factor * rsl3_drug_avail[idx]).clamp(0.0, 1.0);
-                                let st = &mut grid.cells[idx].state;
-                                st.gpx4 -= RSL3_INACTIVATION_RATE * conc * st.gpx4;
-                                st.gpx4 = st.gpx4.max(0.0);
-                            }
-                            Treatment::SDT | Treatment::PDT => {
-                                // Set the exogenous-ROS bolus so the schedule
-                                // is the SOLE availability envelope. We divide
-                                // out sim_cell_step's intrinsic single-bolus
-                                // decay (`exo_decay_factor`, 1.0 for step<30)
-                                // because it would otherwise double-count decay
-                                // for later doses — ROS generated at dose N
-                                // should decay from dose N, not from t=0 (#239).
-                                // Net effective exo in sim_cell_step is then
-                                // exactly `base * dose_factor(step)`.
-                                //
-                                // The `.max(1e-9)` only guards a 0/0; in
-                                // practice exo_decay_factor bottoms out near
-                                // ~1e-3 at step 179, so the stored exo_ros_peak
-                                // is amplified up to ~1000×. That's finite and
-                                // safe because `base * dose_factor` is itself
-                                // tiny that late in the run (the dose has
-                                // decayed), and sim_cell_step immediately
-                                // multiplies the envelope back in — the
-                                // amplified value never reaches any other
-                                // computation.
-                                debug_assert!(
-                                    !base_exo.is_empty(),
-                                    "base_exo must be populated on the dosed SDT/PDT path"
-                                );
-                                let decay = exo_decay_factor(step).max(1e-9);
-                                grid.cells[idx].state.exo_ros_peak =
-                                    base_exo[idx] * dose_factor / decay;
-                            }
-                            Treatment::Control => {}
+                        if step >= grace_end {
+                            return 0;
                         }
+                        // else: grace period — fall through to sim_cell_step
+                        // for post-death LP accumulation.
+                    } else {
+                        return 0;
                     }
+                }
 
-                    let gc = &mut grid.cells[idx];
-                    let died =
-                        sim_cell_step(&mut gc.state, &gc.cell, &params, step, extra_iron, &mut rng);
+                let mut rng = StdRng::seed_from_u64(
+                    cond_seed
+                        .wrapping_add(500_000)
+                        .wrapping_add(idx as u64)
+                        .wrapping_add(step as u64 * 1_000_000),
+                );
 
-                    if died {
-                        // `newly_dead` is consumed by `TumorGrid3D::diffuse_iron`
-                        // later this step to spread released iron to live
-                        // 26-Moore neighbors (grid.rs:586). Not vestigial —
-                        // load-bearing for iron-driven Fenton bystander effects.
-                        gc.newly_dead = true;
-                        ferroptosis_kills += 1;
-                        // `lp_at_death` is set later, at grace-end, just before
-                        // being read for the DAMP-field write. The moment-of-death
-                        // write that used to live here was dead (always overwritten
-                        // before read); removed in #220.
+                let extra_iron = gc.extra_iron;
+                gc.extra_iron = 0.0;
+
+                // Time-varying drug modulation (#239). Skipped on the Constant
+                // default path (`dosed == false`) → byte-identical there.
+                // Live cells only; a dead cell's stored drug state freezes at
+                // death (see the longer note removed from here — preserved in
+                // git history; the SDT post-death effective-exo nuance is
+                // documented on `biochem::exo_decay_factor`).
+                if dosed && !gc.state.dead {
+                    match condition.treatment {
+                        Treatment::RSL3 => {
+                            // Covalent GPX4 inactivation ∝ availability
+                            // (schedule × pH ion-trap). Mirrors sim_cell_with_pk.
+                            let conc = (dose_factor * rsl3_drug_avail[idx]).clamp(0.0, 1.0);
+                            gc.state.gpx4 -= RSL3_INACTIVATION_RATE * conc * gc.state.gpx4;
+                            gc.state.gpx4 = gc.state.gpx4.max(0.0);
+                        }
+                        Treatment::SDT | Treatment::PDT => {
+                            // Divide out sim_cell_step's intrinsic single-bolus
+                            // envelope so the schedule is the sole envelope
+                            // (#239). `.max(1e-9)` guards 0/0; the ~1000×
+                            // amplification at late steps is finite and never
+                            // escapes sim_cell_step's immediate re-multiply.
+                            let decay = exo_decay_factor(step).max(1e-9);
+                            gc.state.exo_ros_peak = base_exo[idx] * dose_factor / decay;
+                        }
+                        Treatment::Control => {}
                     }
+                }
 
-                    // Stromal CAF protection for alive cells — apply only when
-                    // stromal_on. The adjacency_mask is always computed (used
-                    // for kill-rate accounting later) but the boost helpers
-                    // gate on the toggle.
-                    if !died && !gc.state.dead {
-                        if let Some(cfg) = &stromal_cfg {
-                            if adjacency_mask[idx] {
-                                let gc = &mut grid.cells[idx];
-                                gc.state.gsh =
-                                    (gc.state.gsh + cfg.gsh_boost_per_step).min(cfg.gsh_boost_cap);
-                                gc.state.mufa_protection = (gc.state.mufa_protection
-                                    + cfg.mufa_boost_per_step)
-                                    .min(cfg.mufa_boost_cap);
-                            }
+                let died =
+                    sim_cell_step(&mut gc.state, &gc.cell, &params, step, extra_iron, &mut rng);
+                if died {
+                    // `newly_dead` is consumed by the later serial
+                    // `diffuse_iron` to spread released iron to live neighbors.
+                    gc.newly_dead = true;
+                }
+
+                // Stromal CAF protection for alive cells (stromal_on only).
+                if !died && !gc.state.dead {
+                    if let Some(cfg) = &stromal_cfg {
+                        if adjacency_mask[idx] {
+                            gc.state.gsh =
+                                (gc.state.gsh + cfg.gsh_boost_per_step).min(cfg.gsh_boost_cap);
+                            gc.state.mufa_protection = (gc.state.mufa_protection
+                                + cfg.mufa_boost_per_step)
+                                .min(cfg.mufa_boost_cap);
                         }
                     }
                 }
-            }
-        }
+
+                usize::from(died)
+            })
+            .sum();
+        ferroptosis_kills += died_this_step;
 
         // Iron diffusion via TumorGrid3D. Now uses the value from
         // `spatial_params.neighbor_iron_fraction` (single source of truth);
@@ -678,61 +657,52 @@ fn run_one_condition_with_config(
                 immune_cfg.damp_clearance_rate,
             );
 
-            // Immune kill (after delay)
+            // Immune kill (after delay). Parallelized over cells with rayon
+            // (#192) — byte-identical to the old serial triple loop: each cell
+            // reads its own `damp_field[idx]` (immutable here; DAMP diffusion
+            // already done) and writes only its own `state.dead`; the per-cell
+            // RNG seed `(cond_seed, idx, step)` is position-independent; and
+            // `immune_kills` is an order-independent integer sum.
             if step >= IMMUNE_START_STEP {
                 let effective_brake = immune_cfg.effective_brake();
-                for r in 0..grid.rows {
-                    for c in 0..grid.cols {
-                        for l in 0..grid.layers {
-                            let idx = grid.flat_index(r, c, l);
-                            if grid.cells[idx].state.dead || !grid.cells[idx].is_tumor {
-                                continue;
-                            }
-                            let local_damp = damp_field[idx];
-                            if local_damp < DAMP_KILL_THRESHOLD {
-                                continue;
-                            }
-                            let activation = dc_activation(local_damp, immune_cfg.dc_activation_kd);
-                            let kill_prob = immune_kill_probability(
-                                activation,
-                                immune_cfg.immune_kill_rate,
-                                effective_brake,
-                            );
-                            let mut rng = StdRng::seed_from_u64(
-                                cond_seed
-                                    .wrapping_add(900_000_000)
-                                    .wrapping_add(idx as u64)
-                                    .wrapping_add(step as u64 * 2_000_000),
-                            );
-                            if rng.gen::<f64>() < kill_prob {
-                                // Immune kills set `state.dead` but deliberately
-                                // do NOT set `death_step` or `newly_dead`.
-                                // **Modeling asymmetry**: ferroptosis-killed
-                                // cells with `Some(death_step)` fall through
-                                // to `sim_cell_step` for `post_death_steps`
-                                // more iterations (post-death LP overshoot
-                                // dynamics); immune-killed cells with
-                                // `None` death_step hit the `else { continue }`
-                                // branch and exit immediately. Three
-                                // intentional consequences:
-                                //   (1) immune-killed cells skip grace-period
-                                //       biochem — they're apoptotic, not
-                                //       ferroptotic (no LP buildup beyond
-                                //       moment of death);
-                                //   (2) no DAMP burst — T-cell perforin
-                                //       death doesn't release the DAMPs
-                                //       (calreticulin, HMGB1) that ferroptosis
-                                //       releases;
-                                //   (3) no iron release via `diffuse_iron`
-                                //       (no `newly_dead` flag).
-                                // This is a real modeling choice (consistent
-                                // with sim-tme/main.rs:749), not a side-effect.
-                                grid.cells[idx].state.dead = true;
-                                immune_kills += 1;
-                            }
+                let killed_this_step: usize = grid
+                    .cells
+                    .par_iter_mut()
+                    .enumerate()
+                    .map(|(idx, gc)| {
+                        if gc.state.dead || !gc.is_tumor {
+                            return 0;
                         }
-                    }
-                }
+                        let local_damp = damp_field[idx];
+                        if local_damp < DAMP_KILL_THRESHOLD {
+                            return 0;
+                        }
+                        let activation = dc_activation(local_damp, immune_cfg.dc_activation_kd);
+                        let kill_prob = immune_kill_probability(
+                            activation,
+                            immune_cfg.immune_kill_rate,
+                            effective_brake,
+                        );
+                        let mut rng = StdRng::seed_from_u64(
+                            cond_seed
+                                .wrapping_add(900_000_000)
+                                .wrapping_add(idx as u64)
+                                .wrapping_add(step as u64 * 2_000_000),
+                        );
+                        if rng.gen::<f64>() < kill_prob {
+                            // Immune kills set `state.dead` but deliberately
+                            // NOT `death_step`/`newly_dead`: immune-killed cells
+                            // are apoptotic (no post-death LP grace, no DAMP
+                            // burst, no iron release) — a modeling choice
+                            // consistent with sim-tme, not a side-effect.
+                            gc.state.dead = true;
+                            1
+                        } else {
+                            0
+                        }
+                    })
+                    .sum();
+                immune_kills += killed_this_step;
             }
         }
 

--- a/simulations/sim-tme-3d/src/main.rs
+++ b/simulations/sim-tme-3d/src/main.rs
@@ -47,6 +47,7 @@
 
 use std::fs;
 use std::path::Path;
+use std::time::Instant;
 
 mod npy;
 mod snapshot;
@@ -1331,6 +1332,74 @@ fn run_dose_sweep(output_dir: &Path) {
     eprintln!("Wrote {}", path.display());
 }
 
+/// Read a positive-integer env var, falling back to `default` if unset or
+/// unparseable. Used by `--bench` to override grid size / step count without
+/// touching the byte-identical-locked `GRID_DIM`/`N_STEPS` constants.
+fn bench_env(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(default)
+}
+
+/// `--bench`: run ONE representative condition (the combined-TME RSL3 cell —
+/// immune + stromal + pH, the heaviest per-cell path) at a configurable grid
+/// size and print wall-clock timing. The performance/scalability harness for
+/// issue #192.
+///
+/// Grid size and step count come from env (`BENCH_GRID_DIM`, `BENCH_N_STEPS`;
+/// defaults 60/180) so a sweep is scriptable, e.g.
+/// `BENCH_GRID_DIM=200 BENCH_N_STEPS=180 cargo run --release -p sim-tme-3d -- --bench`.
+/// Capture peak RSS externally: `/usr/bin/time -v <that command>`.
+///
+/// Runs a SINGLE condition with no condition-level rayon, so it measures the
+/// within-condition cost — exactly the work the within-condition parallelism
+/// targets. Writes no output files; the default matrix path is untouched.
+fn run_bench() {
+    let grid_dim = bench_env("BENCH_GRID_DIM", GRID_DIM);
+    let n_steps = bench_env("BENCH_N_STEPS", N_STEPS as usize) as u32;
+    let n_cells = grid_dim.pow(3);
+
+    eprintln!(
+        "=== --bench: single combined-TME RSL3 condition, {grid_dim}³ = {n_cells} cells × {n_steps} steps ==="
+    );
+    eprintln!(
+        "(override via BENCH_GRID_DIM / BENCH_N_STEPS; wrap with `/usr/bin/time -v` for peak RSS)"
+    );
+
+    let condition = Condition {
+        name: "bench_combined_RSL3".to_string(),
+        treatment: Treatment::RSL3,
+        treatment_name: "RSL3".to_string(),
+        o2_lambda: Some(ZONE_REF_LAMBDA),
+        immune_on: true,
+        stromal_on: true,
+        ph_on: true,
+        dose_schedule: DoseSchedule::Constant,
+    };
+    let cfg = RunConfig { grid_dim, n_steps };
+
+    let t0 = Instant::now();
+    let r = run_one_condition_with_config(&condition, cfg, None);
+    let elapsed = t0.elapsed();
+
+    let secs = elapsed.as_secs_f64();
+    let cell_steps = (n_cells as f64) * (n_steps as f64);
+    eprintln!(
+        "  done in {secs:.2}s — total_kill={:.2}% (ferro={}, immune={})",
+        r.overall_kill_rate * 100.0,
+        r.ferroptosis_kills.unwrap_or(0),
+        r.immune_kills.unwrap_or(0),
+    );
+    // Machine-readable line for sweep collection (grep 'BENCH_RESULT').
+    eprintln!(
+        "BENCH_RESULT grid_dim={grid_dim} n_cells={n_cells} n_steps={n_steps} \
+         wall_s={secs:.3} cell_steps_per_s={:.3e}",
+        cell_steps / secs.max(1e-9)
+    );
+}
+
 fn main() {
     // Guard against silent drift between this binary's metadata const and
     // the library's runtime value: if a future PR tunes
@@ -1394,6 +1463,17 @@ fn main() {
     // summary.json (which stays byte-identical to the 24-condition matrix).
     if std::env::args().any(|a| a == "--dose-sweep") {
         run_dose_sweep(output_dir);
+        return;
+    }
+
+    // `--bench` runs ONE representative condition at a configurable grid size
+    // (env BENCH_GRID_DIM / BENCH_N_STEPS, defaults 60/180) and prints
+    // wall-clock timing — the performance/scalability harness for #192. It
+    // measures the WITHIN-condition cost (no condition-level rayon), which is
+    // exactly what the within-condition parallelism targets. Does NOT write
+    // summary.json; the default matrix path below is untouched (byte-identical).
+    if std::env::args().any(|a| a == "--bench") {
+        run_bench();
         return;
     }
 


### PR DESCRIPTION
## Summary

Implements issue #192 (3D performance & scalability): a benchmark harness, within-condition rayon parallelism, and a measured memory / grid-size recommendation. Sparse/adaptive grids were scoped out (dense already fits the budget — filed as #254).

## Four commits

| # | What |
|---|---|
| 1 | `--bench` CLI harness — runs one representative condition at a configurable grid size (`BENCH_GRID_DIM`/`BENCH_N_STEPS` env), prints wall-clock + a machine-readable `BENCH_RESULT` line. No prior benchmark infra existed. |
| 2 | **Within-condition rayon** — parallelize the biochem + immune-kill per-cell loops (`par_iter_mut`), byte-identical. |
| 3 | Benchmark results + memory/grid-size doc; corrected stale memory comments. |
| 4 | Review fix: re-ran the full 180-step sweep so the doc table is all-measured (no projections). |

## Results (measured, rust 1.96.0, 10 cores; `size_of::<GridCell>() = 144 B`)

| Grid | Cells | Peak RSS | Serial 180-step | Parallel 180-step | Speedup |
|---|---|---|---|---|---|
| 50³  | 125 k   | 23 MB   | 3.7 s   | 1.0 s  | 3.8× |
| 100³ | 1.0 M   | 164 MB  | 26.4 s  | 6.1 s  | 4.3× |
| 150³ | 3.375 M | 546 MB  | 87.6 s  | 18.3 s | 4.8× |
| 200³ | 8.0 M   | **1.29 GB** | 201.3 s | **40.8 s** | 4.9× |

- **Both perf targets met**: 100³ < 2 min, 200³ < 15 min — even serially. Within-condition rayon adds a **3.8×–4.9×** speedup (grows with grid as the per-step join overhead amortizes).
- **Memory verdict (feeds #240 patient-scale)**: dense **200³ fits the 2 GB budget at 1.29 GB** with ~35% headroom — no sparse grid needed at this scale. Sparse/adaptive deferred to #254 (only compelling at 300³+).

## Why the parallelization is byte-identical

The biochem + immune-kill loops were serial `for r/c/l` triple loops; they're now `grid.cells.par_iter_mut()` (biochem zips `damp_field.par_iter_mut()`). This is provably output-preserving:
- `enumerate()` over the flat `cells` Vec yields the same `idx` as the old `flat_index(r,c,l)` (row-major), so the per-cell RNG seed `(cond_seed, idx, step)` is unchanged — and it's a pure function of index+step, NOT iteration order.
- Each cell reads/writes only its own `GridCell` + its own `damp_field[idx]` slot. No cross-cell reads.
- Kill counters became integer `.sum()` reductions (associative+commutative → order-independent).
- Iron diffusion + DAMP diffusion (cross-cell dependencies) stay **serial**, run after the rayon join. The default 24-condition matrix's condition-level `par_iter` composes with this via rayon's shared pool.

## Acceptance criteria (#192)
- [x] Benchmarks for 50³/100³/150³/200³
- [x] Memory usage documented per grid size
- [x] Rayon parallelism applied where beneficial (within-condition biochem + immune)
- [x] Recommended grid size documented (sim-tme-3d README "Performance & scalability")

## Verification
- **summary.json SHA `1cf8866312…` byte-identical** at every commit (the correctness gate for the parallelization).
- 23 sim-tme-3d tests pass (incl. `rayon_run_is_deterministic`, `constant_path_golden_kill_counts`) + 189 ferroptosis-core tests; `--dose-sweep` numbers unchanged; `cargo fmt --all --check` clean — all under rust 1.96.0 (CI's pinned toolchain).
- Adversarial review (4 dimension reviewers + verification): no concurrency or byte-identity bugs found; the one real finding (table mixed measured + projected numbers) is fixed in commit 4 by re-measuring the full sweep.

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)