### PR TITLE
CI: full-production byte-identity regression for sim-tme-3d (#253)

### DIFF
--- a/.github/workflows/sim-tme-3d-regression.yml
+++ b/.github/workflows/sim-tme-3d-regression.yml
@@ -1,0 +1,54 @@
+name: sim-tme-3d Production Regression
+
+# Full-scale byte-identity regression for sim-tme-3d's default 24-condition
+# matrix summary.json (#253). This is the production-scale companion to the
+# fast `constant_path_golden_kill_counts` unit test (which guards per-PR
+# drift at a small 20^3 x 80 config in `cargo test`).
+#
+# Deliberately OFF the per-PR path: the full 60^3 x 180 release run + build
+# is too heavy to gate every PR, and the unit-level golden already covers
+# per-PR drift. This runs on a weekly schedule and on demand.
+#
+# A scale-dependent refactor could pass the small-config golden yet still
+# perturb the full production output; this job catches exactly that.
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 9 * * 1' # Weekly Monday 9am UTC
+
+permissions:
+  contents: read
+
+jobs:
+  production-byte-identity:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install pinned Rust toolchain
+        # MUST match simulations/rust-toolchain.toml (currently 1.96.0).
+        # The expected SHA is toolchain-specific (powf / Ziggurat are not
+        # bit-identical across libm); @stable would silently drift it.
+        # Bumping the workspace pin requires bumping this version too.
+        uses: dtolnay/rust-toolchain@1.96.0
+
+      - name: Cache Cargo registry and build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: simulations
+
+      - name: Run production sim-tme-3d (default 24-condition matrix)
+        working-directory: simulations
+        run: cargo run --release -p sim-tme-3d
+
+      - name: Show actual summary.json SHA-256 (for the log / drift triage)
+        working-directory: simulations
+        run: sha256sum output/tme-3d/summary.json
+
+      - name: Assert byte-identity against checked-in expected hash
+        working-directory: simulations
+        # Fails loudly on any drift. On an INTENTIONAL change, regenerate
+        # the hash per the instructions in expected_summary.sha256.
+        run: sha256sum -c sim-tme-3d/expected_summary.sha256

--- a/.github/workflows/sim-tme-3d-regression.yml
+++ b/.github/workflows/sim-tme-3d-regression.yml
@@ -15,14 +15,26 @@ name: sim-tme-3d Production Regression
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 9 * * 1' # Weekly Monday 9am UTC
+    # Weekly Monday 09:17 UTC. Staggered off minute 0 to avoid GitHub's
+    # documented top-of-hour high-load window, where scheduled runs can be
+    # delayed or silently dropped (matters at weekly cadence).
+    - cron: '17 9 * * 1'
 
 permissions:
   contents: read
 
+# Serialize an ad-hoc workflow_dispatch against the cron run (each run is
+# read-only and regenerates its own output, so queue rather than cancel).
+concurrency:
+  group: sim-tme-3d-regression
+  cancel-in-progress: false
+
 jobs:
   production-byte-identity:
     runs-on: ubuntu-latest
+    # Cold --release build + the heavy 60^3 x 180 run; cap it so a wedge
+    # fails fast instead of squatting a runner toward the 6-hour default.
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -52,3 +64,13 @@ jobs:
         # Fails loudly on any drift. On an INTENTIONAL change, regenerate
         # the hash per the instructions in expected_summary.sha256.
         run: sha256sum -c sim-tme-3d/expected_summary.sha256
+
+      - name: Upload divergent summary.json on drift
+        # Only when the assert above failed: a bare SHA is weak triage, so
+        # keep the actual file that drifted for diffing against a known-good.
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sim-tme-3d-summary-drift
+          path: simulations/output/tme-3d/summary.json
+          if-no-files-found: warn

--- a/simulations/sim-tme-3d/README.md
+++ b/simulations/sim-tme-3d/README.md
@@ -164,6 +164,15 @@ Three smoke tests:
 
 The library primitives (`physics`, `oxygen`, `ph`, `stromal`, `immune_spatial`) are exhaustively tested in `ferroptosis-core`'s 160+ unit tests. This binary tests orchestration, not the math.
 
+### Production byte-identity regression (#253)
+
+Two layers guard the load-bearing invariant that the #239 multi-dose work relies on (default matrix = all `DoseSchedule::Constant` = byte-identical `summary.json`):
+
+1. **Per-PR (fast):** `constant_path_golden_kill_counts` pins integer kill counts at a small 20³ × 80 config, so a structural regression fails in ordinary `cargo test`.
+2. **Off-PR (full scale):** the `.github/workflows/sim-tme-3d-regression.yml` job runs the real 60³ × 180 matrix and asserts `output/tme-3d/summary.json`'s SHA-256 against the checked-in `expected_summary.sha256`. It runs weekly and on `workflow_dispatch` (not per-PR: the release run + build is too heavy to gate every PR, and a scale-dependent change could pass the small golden yet perturb the full output).
+
+The expected hash is **toolchain-specific** (pinned 1.96.0; confirmed identical on 1.92.0). When an *intentional* output change lands, regenerate it per the instructions inside `expected_summary.sha256`.
+
 ## Performance & scalability (`--bench`, #192)
 
 `--bench` runs one representative condition (combined-TME RSL3) at a configurable grid size and prints wall-clock + throughput. Grid/steps come from env so a sweep is scriptable:
@@ -218,6 +227,6 @@ After running both `sim-tme` and `sim-tme-3d` and generating the comparison tabl
 - ~~**Lift `PhConfig` / `StromalConfig` / `ImmuneConfig` to `ferroptosis-core::params`**~~ — **done** in #220/#224 (lifted as `PhConfig` / `StromalConfig` / `SpatialImmuneConfig`).
 - **O₂ cycling** (square-wave λ alternation) — sim-tme has it, sim-tme-3d skipped for v1 scope.
 - **Anti-PD-1 sweep** — included in sim-tme; skipped here for v1.
-- **3D volumetric visualization** — partially done (#193/#238 axial-slice GIF); full volume render still open under #193.
-- ~~**Larger grids**~~ — **demonstrated feasible** in #192: up to 200³ at ~1.29 GB / ~43 s (see Performance & scalability above). The general `sim-spatial-3d` binary (#194) is separate.
+- **3D volumetric visualization** — delivered in #193/#238 (axial-slice GIF/MP4 renderer + `.npy` volumetric trajectory arrays + 2D-vs-3D comparison table). #193 closed as substantially delivered; a ParaView-grade VTK/HDF5 export remains optional polish if a manuscript figure ever needs it.
+- ~~**Larger grids**~~ — **demonstrated feasible** in #192: up to 200³ at ~1.29 GB / ~43 s (see Performance & scalability above). A standalone `sim-spatial-3d` binary (#194) was closed as superseded: `--snapshot=bare` already provides the unprotected depth-physics baseline.
 - **Empirical pimonidazole validation** — see #196.

--- a/simulations/sim-tme-3d/expected_summary.sha256
+++ b/simulations/sim-tme-3d/expected_summary.sha256
@@ -1,0 +1,26 @@
+# Expected SHA-256 of sim-tme-3d's default 24-condition matrix summary.json.
+#
+# This pins the byte-identity invariant that the #239 multi-dose PK work
+# leans on: when every condition uses DoseSchedule::Constant (the entire
+# default matrix), summary.json must be byte-for-byte identical to its
+# pre-#239 output. The fast `constant_path_golden_kill_counts` unit test
+# guards per-PR drift at a small 20^3 x 80 config; this file guards the
+# FULL 60^3 x 180 production output via the (off-PR) sim-tme-3d-regression
+# workflow.
+#
+# TOOLCHAIN-SPECIFIC: this hash is only stable on the pinned channel in
+# simulations/rust-toolchain.toml (currently 1.96.0). powf / Ziggurat are
+# not bit-identical across libm versions. Confirmed identical on 1.92.0
+# and 1.96.0, so it is stable in practice for the pinned channel.
+#
+# Regenerate ONLY when an INTENTIONAL output change lands (and say why in
+# the PR):
+#   cd simulations
+#   rustup run 1.96.0 cargo run --release -p sim-tme-3d
+#   sha256sum output/tme-3d/summary.json   # paste the hash below
+#
+# Verify (what CI does), from the simulations/ directory:
+#   sha256sum -c sim-tme-3d/expected_summary.sha256
+#
+# (Lines beginning with '#' are ignored by `sha256sum -c`.)
+1cf8866312c100bfb453718dfd68e0b492d2e199485e75e8f622657cd390ff71  output/tme-3d/summary.json


### PR DESCRIPTION
## What

Adds a production-scale, off-PR CI guard for `sim-tme-3d`'s byte-identity invariant, plus housekeeping on two now-closed issue references.

The #239 multi-dose PK work leans on a load-bearing invariant: when every condition uses `DoseSchedule::Constant` (the entire default 24-condition matrix), `summary.json` is byte-for-byte identical to its pre-#239 output. Until now that was guarded per-PR only by `constant_path_golden_kill_counts` (a small 20³ × 80 config) plus a manual local SHA check. A scale-dependent refactor could pass the small golden yet perturb the full 60³ × 180 output unnoticed.

## Changes

- **`.github/workflows/sim-tme-3d-regression.yml`** — new job on `workflow_dispatch` + weekly `schedule` (Mon 9am UTC), deliberately **off the per-PR path** (the release run + build is too heavy to gate every PR). Pins `dtolnay/rust-toolchain@1.96.0` (the hash is toolchain-specific; `@stable` would silently drift it, per the #236 lesson). Runs the default matrix, prints the actual SHA for triage, then asserts via `sha256sum -c`.
- **`simulations/sim-tme-3d/expected_summary.sha256`** — checked-in expected hash (`1cf8866312…`) with regeneration steps + toolchain caveat inline (`sha256sum -c` ignores `#` comment lines).
- **`simulations/sim-tme-3d/README.md`** — new "Production byte-identity regression (#253)" subsection documenting the two-layer guard; refreshed the two "Follow-ups deferred" bullets that cited #193/#194 as open (both now closed: #193 delivered by #238, #194 superseded by `--snapshot=bare`).

## Verification (local, pinned 1.96.0)

- Production run reproduces the documented SHA: `1cf8866312c100bfb453718dfd68e0b492d2e199485e75e8f622657cd390ff71`.
- `sha256sum -c sim-tme-3d/expected_summary.sha256` → `OK` (exit 0) on current output.
- Negative control: a 1-byte perturbation → `FAILED` (exit 1), so it fails loudly on drift.
- YAML well-formed (`workflow_dispatch` + `schedule` triggers); `cargo fmt --all --check` clean (no Rust changed).

## Acceptance criteria

- [x] A non-per-PR CI job runs the production sim-tme-3d and checks `summary.json` SHA-256 against a checked-in expected value
- [x] Toolchain pinned; expected hash + regeneration steps documented
- [x] Fails loudly on drift; passes on current main

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)