### PR TITLE
docs+CI housekeeping: refresh CLAUDE.md (#257) + crates.io flake env (#258)

### DIFF
--- a/.github/workflows/sim-tme-3d-regression.yml
+++ b/.github/workflows/sim-tme-3d-regression.yml
@@ -35,6 +35,14 @@ jobs:
     # Cold --release build + the heavy 60^3 x 180 run; cap it so a wedge
     # fails fast instead of squatting a runner toward the 6-hour default.
     timeout-minutes: 60
+    env:
+      # Resilience against transient crates.io download flakes on this
+      # unattended weekly job (the first dispatch hit `curl failed: [16]
+      # Error in the HTTP2 framing layer` and false-reds look like drift).
+      # More network retries; disabling HTTP/2 multiplexing is the
+      # documented mitigation for that specific framing error.
+      CARGO_NET_RETRY: '10'
+      CARGO_HTTP_MULTIPLEXING: 'false'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,31 +88,31 @@ The repo exists to compare therapeutic mechanisms, evidence depth, resistant-sta
 ## Key Files
 
 ```text
-README.md                                 repo-level framing and entry points
-article/drafts/v1.{md,tex,pdf}            manuscript drafts
-analysis/evidence-coverage-audit.md       evidence-tier coverage and guardrails
-analysis/taxonomy-rerun-notes.md          taxonomy/query caveats after reruns
-analysis/pathway-target-audit.md          pathway-target coverage
-analysis/landmark-corpus-gaps.md          known missing papers that distort claims
-corpus/INDEX.jsonl                        master index
-scripts/                                  Python pipeline
-simulations/                              Rust simulation work
-simulations/ferroptosis-python/           Python bindings (PyO3)
-simulations/ferroptosis-ffi/              C FFI bindings (PhysiCell integration)
-tags/                                     precomputed tag indexes
-article/book-outline.md                   frozen book outline and chapter contracts
-article/AUTHORING.md                      writing rules and heading conventions
-news/                                     news source scaffolding (issue #99)
-PROVENANCE.yaml                           content provenance and redistribution rights
-CONTRIBUTING.md                           contributor setup, testing, and PR guide
-CITATION.cff                              citation metadata (renders GitHub "Cite" button)
-requirements-lock.txt                     pinned Python dependency versions
-FIGURES.yaml                              figure-to-script traceability index (23 figures)
-.github/workflows/python-test.yml         Python CI (Linux PR/push, macOS weekly)
-.github/workflows/cargo-test.yml          Rust CI (cargo test + cargo fmt --check gate)
+README.md                                    repo-level framing and entry points
+article/drafts/v1.{md,tex,pdf}               manuscript drafts
+analysis/evidence-coverage-audit.md          evidence-tier coverage and guardrails
+analysis/taxonomy-rerun-notes.md             taxonomy/query caveats after reruns
+analysis/pathway-target-audit.md             pathway-target coverage
+analysis/landmark-corpus-gaps.md             known missing papers that distort claims
+corpus/INDEX.jsonl                           master index
+scripts/                                     Python pipeline
+simulations/                                 Rust simulation work
+simulations/ferroptosis-python/              Python bindings (PyO3)
+simulations/ferroptosis-ffi/                 C FFI bindings (PhysiCell integration)
+tags/                                        precomputed tag indexes
+article/book-outline.md                      frozen book outline and chapter contracts
+article/AUTHORING.md                         writing rules and heading conventions
+news/                                        news source scaffolding (issue #99)
+PROVENANCE.yaml                              content provenance and redistribution rights
+CONTRIBUTING.md                              contributor setup, testing, and PR guide
+CITATION.cff                                 citation metadata (renders GitHub "Cite" button)
+requirements-lock.txt                        pinned Python dependency versions
+FIGURES.yaml                                 figure-to-script traceability index (23 figures)
+.github/workflows/python-test.yml            Python CI (Linux PR/push, macOS weekly)
+.github/workflows/cargo-test.yml             Rust CI (cargo test + cargo fmt --check gate)
 .github/workflows/sim-tme-3d-regression.yml  sim-tme-3d production byte-identity regression (weekly + manual)
-.zenodo.json                              Zenodo deposit metadata template
-scripts/generate_release_manifest.py      SHA256 manifest + filtered archive builder
+.zenodo.json                                 Zenodo deposit metadata template
+scripts/generate_release_manifest.py         SHA256 manifest + filtered archive builder
 ```
 
 ## Search Conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,11 +33,11 @@ The repo exists to compare therapeutic mechanisms, evidence depth, resistant-sta
 - pathway-target and resistant-state analysis
 - diagnostic-to-therapy chain extraction (6 chains, 129 articles mapped)
 - tissue-of-origin analysis layer (5 tissue categories, 62% coverage)
-- simulation work: ferroptosis biochemistry, drug penetration, calibration, photosensitizer PK (drug-light-interval scaling, saturating distribution phase, relative singlet-O₂ yield, FromStr-based clap CLI integration in sim-spatial), 3D spheroid scaffolding (TumorGrid3D #185, signed radial depth + 3D energy-physics dispatcher #186, 3D radial O₂ gradient + zone-census #187, 3D radial pH gradient + iron/ion-trap helpers #190, 3D CAF-shielded boundary detection #189, 3D spatial immune coupling + DAMP diffusion #188) for the #185–#197 spheroid-validation series; sim-tme-3d TME capstone (#195); 2D-math lift + `immune_3d`→`immune_spatial` rename + JSON schema_version (#220/#224); 3D trajectory snapshots + animated axial-slice GIF renderer (#193/#238); time-varying multi-dose pharmacokinetics (`dose_schedule` module — Constant/Bolus/MultiDose/Infusion/FromPk — wired into sim-tme-3d via `--dose-sweep` + the `--snapshot=multidose` preset, with the orphaned `tumor_pk` ODE finally bridged in via `FromPk`, #239)
+- simulation work: ferroptosis biochemistry, drug penetration, calibration, photosensitizer PK (drug-light-interval scaling, saturating distribution phase, relative singlet-O₂ yield, FromStr-based clap CLI integration in sim-spatial), 3D spheroid scaffolding (TumorGrid3D #185, signed radial depth + 3D energy-physics dispatcher #186, 3D radial O₂ gradient + zone-census #187, 3D radial pH gradient + iron/ion-trap helpers #190, 3D CAF-shielded boundary detection #189, 3D spatial immune coupling + DAMP diffusion #188) for the #185–#197 spheroid-validation series; sim-tme-3d TME capstone (#195); 2D-math lift + `immune_3d`→`immune_spatial` rename + JSON schema_version (#220/#224); 3D trajectory snapshots + animated axial-slice GIF renderer (#193/#238); time-varying multi-dose pharmacokinetics (`dose_schedule` module — Constant/Bolus/MultiDose/Infusion/FromPk — wired into sim-tme-3d via `--dose-sweep` + the `--snapshot=multidose` preset, with the orphaned `tumor_pk` ODE finally bridged in via `FromPk`, #239); 3D performance and scalability work (`--bench` harness + within-condition rayon parallelism, byte-identical via position-independent per-cell RNG, 3.8x to 4.9x speedup on single large grids, dense 200³ measured at ~1.29 GB so sparse storage deferred to #254, #192); full-production byte-identity regression CI guarding sim-tme-3d's default-matrix `summary.json` SHA (#253)
 - ferroptosis-core library packaging for external use
 - news source authentication pipeline (fetch, extract claims, verify, score, index)
 - broader strategy review of alternative therapies and biological bottlenecks
-- operational maturity: Phase 2 complete — CI (#126), figure traceability (#127), archival release tooling (#131)
+- operational maturity: Phase 2 complete — CI (#126), figure traceability (#127), archival release tooling (#131); workspace `cargo fmt --check` gate added to Rust CI (#209/#236); off-PR sim-tme-3d production byte-identity regression workflow (#253)
 - manuscript integrity: Phase 3 complete — immune coupling confidence (#130), structural uncertainty qualifiers (#137), PRISMA corpus flow diagram (#135), retrieval bias subsection (#140)
 - sensitivity analyses: weight-sensitivity (#128), taxonomy-sensitivity (#133), PRCC global sensitivity (#134), and O2 cycling (#138) complete — pre-registered, run, results in manuscript
 - test expansion (#139) complete — 19 invariant/integration tests added (schema, weight monotonicity, tagging correctness)
@@ -62,6 +62,8 @@ The repo exists to compare therapeutic mechanisms, evidence depth, resistant-sta
 - pinned Python environment (requirements-lock.txt, 32 packages) and Rust toolchain (rust-toolchain.toml, 1.96.0)
 - contributor guide (CONTRIBUTING.md), citation metadata (CITATION.cff), and pytest in tracked dependencies
 - Python CI workflow (.github/workflows/python-test.yml): Linux on PR/push, macOS weekly
+- Rust CI workflow (.github/workflows/cargo-test.yml): `cargo test --workspace` + `cargo fmt --all --check` gate on PR/push (fmt pinned to the 1.96.0 toolchain, #209/#236)
+- sim-tme-3d production regression workflow (.github/workflows/sim-tme-3d-regression.yml): weekly + on-demand full 60³×180 run asserting `summary.json`'s SHA-256 against a checked-in hash on the pinned 1.96.0 toolchain (#253)
 - figure traceability index (FIGURES.yaml) mapping all 23 figures to generators, inputs, and types
 - archival release tooling (.zenodo.json metadata template, scripts/generate_release_manifest.py for SHA256 manifest + filtered archive)
 
@@ -107,6 +109,8 @@ CITATION.cff                              citation metadata (renders GitHub "Cit
 requirements-lock.txt                     pinned Python dependency versions
 FIGURES.yaml                              figure-to-script traceability index (23 figures)
 .github/workflows/python-test.yml         Python CI (Linux PR/push, macOS weekly)
+.github/workflows/cargo-test.yml          Rust CI (cargo test + cargo fmt --check gate)
+.github/workflows/sim-tme-3d-regression.yml  sim-tme-3d production byte-identity regression (weekly + manual)
 .zenodo.json                              Zenodo deposit metadata template
 scripts/generate_release_manifest.py      SHA256 manifest + filtered archive builder
 ```


### PR DESCRIPTION
Post-merge debt from #255 (#192) and #256 (#253), neither of which touched `CLAUDE.md`. Two small, tracked gaps surfaced during the post-#256 regroup, bundled into one low-risk PR (docs + CI only).

## #257 — CLAUDE.md staleness

Verified on `main`: `CLAUDE.md` had zero mentions of `#192`, `--bench`, within-condition rayon, `#253`, or `sim-tme-3d-regression`.

- **Simulation workstream** now records the #192 work (`--bench` harness, within-condition rayon, byte-identical, 3.8x–4.9x single-large-grid speedup, dense 200³ at ~1.29 GB → sparse deferred to #254) and the #253 byte-identity regression CI.
- **Operational maturity** bullet now includes the #209/#236 `cargo fmt --check` gate and the #253 workflow.
- **Current Repo State + Key Files** now list `cargo-test.yml` (Rust CI + fmt gate) and `sim-tme-3d-regression.yml`; previously only `python-test.yml` appeared.
- **Count sweep** (the AC's "fix any other drift" item): binaries **11**, ferroptosis-core modules **16**, Python tests **105** (93 collected in `tests/` incl. parametrization + 12 in `ferroptosis-python/test_bindings.py`) — all confirmed accurate, no change needed.

## #258 — weekly-job network resilience

The first `workflow_dispatch` of the #253 job failed on a transient crates.io download (`curl failed: [16] Error in the HTTP2 framing layer`) before any build/sim ran; the rerun was green. For an unattended weekly job that's a false-red that looks like drift.

- Added job-level `CARGO_NET_RETRY: '10'` + `CARGO_HTTP_MULTIPLEXING: 'false'` (the documented mitigation for that framing error).
- **Determinism contract unchanged**: toolchain pin, flagless `cargo run --release`, and `sha256sum -c` are untouched; env only affects cargo's network layer.

## Verification

- `CLAUDE.md` edits confirmed present; counts re-derived from the tree.
- Workflow YAML parses; `env` block asserted; existing hardening (timeout, on-failure artifact upload, cron stagger, concurrency) intact.

Closes #257
Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)