### PR TITLE
refactor(grid): rename misleading GridCell.lp_at_death -> lp_at_grace_end (#314)

### DIFF
--- a/simulations/ferroptosis-core/src/clonal.rs
+++ b/simulations/ferroptosis-core/src/clonal.rs
@@ -322,7 +322,7 @@ pub fn repopulate_dead_sites_3d(
                 state,
                 is_tumor: true,
                 extra_iron: 0.0,
-                lp_at_death: 0.0,
+                lp_at_grace_end: 0.0,
                 newly_dead: false,
             },
         ));

--- a/simulations/ferroptosis-core/src/grid.rs
+++ b/simulations/ferroptosis-core/src/grid.rs
@@ -42,8 +42,11 @@ pub struct GridCell {
     pub is_tumor: bool,
     /// Extra iron from neighbor deaths, accumulated between timesteps.
     pub extra_iron: f64,
-    /// LP at death (for DAMP calculation).
-    pub lp_at_death: f64,
+    /// LP captured at the end of the post-death grace period (for DAMP
+    /// calculation). The value is read `post_death_steps` after a cell dies,
+    /// not at the instant of death, so it is named for the grace-end (renamed
+    /// from the misleading `lp_at_death` in #314).
+    pub lp_at_grace_end: f64,
     /// Whether this cell just died this step (for diffusion).
     pub newly_dead: bool,
 }
@@ -146,7 +149,7 @@ impl TumorGrid {
                     state,
                     is_tumor,
                     extra_iron: 0.0,
-                    lp_at_death: 0.0,
+                    lp_at_grace_end: 0.0,
                     newly_dead: false,
                 });
             }
@@ -529,7 +532,7 @@ impl TumorGrid3D {
                         state,
                         is_tumor,
                         extra_iron: 0.0,
-                        lp_at_death: 0.0,
+                        lp_at_grace_end: 0.0,
                         newly_dead: false,
                     });
                 }
@@ -596,7 +599,7 @@ impl TumorGrid3D {
                 state,
                 is_tumor: true,
                 extra_iron: 0.0,
-                lp_at_death: 0.0,
+                lp_at_grace_end: 0.0,
                 newly_dead: false,
             });
         }

--- a/simulations/sim-spatial/src/main.rs
+++ b/simulations/sim-spatial/src/main.rs
@@ -113,7 +113,7 @@ fn run_spatial(
             gc.state = CellState::from_cell_with_ros(&gc.cell, tx, params, exo_ros_peak);
             gc.extra_iron = 0.0;
             gc.newly_dead = false;
-            gc.lp_at_death = 0.0;
+            gc.lp_at_grace_end = 0.0;
         }
     }
 
@@ -153,11 +153,11 @@ fn run_spatial(
 
                 if died {
                     gc.newly_dead = true;
-                    gc.lp_at_death = gc.state.lp;
+                    gc.lp_at_grace_end = gc.state.lp;
                 }
-                // Update lp_at_death during grace period
+                // Update lp_at_grace_end during grace period
                 if gc.state.dead {
-                    gc.lp_at_death = gc.state.lp;
+                    gc.lp_at_grace_end = gc.state.lp;
                 }
             }
         }

--- a/simulations/sim-tme-3d/src/main.rs
+++ b/simulations/sim-tme-3d/src/main.rs
@@ -788,11 +788,11 @@ fn run_one_condition_full(
                 };
                 gc.extra_iron = 0.0;
                 gc.newly_dead = false;
-                // Init to NaN so any code path that reads `lp_at_death`
+                // Init to NaN so any code path that reads `lp_at_grace_end`
                 // before writing it (grace-end write or end-of-sim
                 // catch-all) produces NaN downstream — calibration trips
                 // instead of silently using a stale value (#225 review).
-                gc.lp_at_death = f64::NAN;
+                gc.lp_at_grace_end = f64::NAN;
             }
         }
     }
@@ -1055,14 +1055,14 @@ fn run_one_condition_full(
                     if let Some(ds) = gc.state.death_step {
                         let grace_end = ds + params.post_death_steps;
                         if step == grace_end {
-                            // `lp_at_death` = "LP at end of post-death grace"
-                            // (misnamed; matches sim-tme; rename tracked in
-                            // #314, re-homed from the closed #195 checklist).
-                            gc.lp_at_death = gc.state.lp;
+                            // `lp_at_grace_end` captures LP at the end of the
+                            // post-death grace period (renamed from the
+                            // misleading `lp_at_death` in #314).
+                            gc.lp_at_grace_end = gc.state.lp;
                             // DAMP release gated on immune_on (else damp_field
                             // is never read/aggregated — PR #219 third-pass).
                             if condition.immune_on {
-                                *damp_slot += gc.lp_at_death * immune_cfg.damp_per_lp;
+                                *damp_slot += gc.lp_at_grace_end * immune_cfg.damp_per_lp;
                             }
                         }
                         if step >= grace_end {
@@ -1433,8 +1433,8 @@ fn run_one_condition_full(
             if let Some(ds) = gc.state.death_step {
                 let grace_end = ds + params.post_death_steps;
                 if grace_end >= run_cfg.n_steps {
-                    gc.lp_at_death = gc.state.lp;
-                    damp_field[idx] += gc.lp_at_death * immune_cfg.damp_per_lp;
+                    gc.lp_at_grace_end = gc.state.lp;
+                    damp_field[idx] += gc.lp_at_grace_end * immune_cfg.damp_per_lp;
                 }
             }
         }

--- a/simulations/sim-tme/src/main.rs
+++ b/simulations/sim-tme/src/main.rs
@@ -172,11 +172,11 @@ fn run_spatial(
             gc.state = CellState::from_cell_with_ros(&gc.cell, tx, params, exo_ros_peak);
             gc.extra_iron = 0.0;
             gc.newly_dead = false;
-            // Init to NaN so any code path that reads `lp_at_death` before
+            // Init to NaN so any code path that reads `lp_at_grace_end` before
             // writing it (the grace-end write or the end-of-sim catch-all)
             // produces NaN downstream — calibration will trip instead of
             // silently using a stale value (#225 review).
-            gc.lp_at_death = f64::NAN;
+            gc.lp_at_grace_end = f64::NAN;
         }
     }
 
@@ -213,11 +213,11 @@ fn run_spatial(
 
                 if died {
                     gc.newly_dead = true;
-                    gc.lp_at_death = gc.state.lp;
+                    gc.lp_at_grace_end = gc.state.lp;
                 }
-                // Update lp_at_death during grace period
+                // Update lp_at_grace_end during grace period
                 if gc.state.dead {
-                    gc.lp_at_death = gc.state.lp;
+                    gc.lp_at_grace_end = gc.state.lp;
                 }
             }
         }
@@ -277,11 +277,11 @@ fn run_spatial_cycling(
             gc.state = CellState::from_cell_with_ros(&gc.cell, tx, params, exo_ros_peak);
             gc.extra_iron = 0.0;
             gc.newly_dead = false;
-            // Init to NaN so any code path that reads `lp_at_death` before
+            // Init to NaN so any code path that reads `lp_at_grace_end` before
             // writing it (the grace-end write or the end-of-sim catch-all)
             // produces NaN downstream — calibration will trip instead of
             // silently using a stale value (#225 review).
-            gc.lp_at_death = f64::NAN;
+            gc.lp_at_grace_end = f64::NAN;
         }
     }
 
@@ -327,10 +327,10 @@ fn run_spatial_cycling(
 
                 if died {
                     gc.newly_dead = true;
-                    gc.lp_at_death = gc.state.lp;
+                    gc.lp_at_grace_end = gc.state.lp;
                 }
                 if gc.state.dead {
-                    gc.lp_at_death = gc.state.lp;
+                    gc.lp_at_grace_end = gc.state.lp;
                 }
             }
         }
@@ -441,11 +441,11 @@ fn run_spatial_with_immune(
             gc.state = CellState::from_cell_with_ros(&gc.cell, tx, params, exo_ros_peak);
             gc.extra_iron = 0.0;
             gc.newly_dead = false;
-            // Init to NaN so any code path that reads `lp_at_death` before
+            // Init to NaN so any code path that reads `lp_at_grace_end` before
             // writing it (the grace-end write or the end-of-sim catch-all)
             // produces NaN downstream — calibration will trip instead of
             // silently using a stale value (#225 review).
-            gc.lp_at_death = f64::NAN;
+            gc.lp_at_grace_end = f64::NAN;
         }
     }
 
@@ -490,8 +490,8 @@ fn run_spatial_with_immune(
                         let grace_end = ds + params.post_death_steps;
                         if step == grace_end {
                             // Grace period just ended: release DAMP with accumulated LP
-                            grid.cells[idx].lp_at_death = grid.cells[idx].state.lp;
-                            damp_field[idx] += grid.cells[idx].lp_at_death * immune.damp_per_lp;
+                            grid.cells[idx].lp_at_grace_end = grid.cells[idx].state.lp;
+                            damp_field[idx] += grid.cells[idx].lp_at_grace_end * immune.damp_per_lp;
                         }
                         if step >= grace_end {
                             continue; // fully dead
@@ -520,7 +520,7 @@ fn run_spatial_with_immune(
                     ferroptosis_kills += 1;
                     // DAMP release is deferred until the post-death grace
                     // period ends (emergent LP overshoot, issue #85). At
-                    // that point `lp_at_death` is set to the grace-end LP
+                    // that point `lp_at_grace_end` is set to the grace-end LP
                     // value just before being read for DAMP — see the
                     // grace-end block above. The moment-of-death write
                     // that used to live here was dead (always overwritten
@@ -621,8 +621,8 @@ fn run_spatial_with_immune(
                 let grace_end = ds + params.post_death_steps;
                 if grace_end >= N_STEPS {
                     // Grace period wasn't completed in the loop — release DAMP now
-                    grid.cells[idx].lp_at_death = grid.cells[idx].state.lp;
-                    damp_field[idx] += grid.cells[idx].lp_at_death * immune.damp_per_lp;
+                    grid.cells[idx].lp_at_grace_end = grid.cells[idx].state.lp;
+                    damp_field[idx] += grid.cells[idx].lp_at_grace_end * immune.damp_per_lp;
                 }
             }
         }


### PR DESCRIPTION
Closes #314. The `GridCell.lp_at_death` field actually holds LP captured at the **end of the post-death grace period** (`post_death_steps` after death), not at the instant of death.

## Change
- Word-bounded rename (`\blp_at_death\b` via perl) to `lp_at_grace_end` across **ferroptosis-core** (grid.rs, clonal.rs) + the 3 consuming binaries (**sim-tme**, **sim-tme-3d**, **sim-spatial**).
- **sim-icd's separate serialized `avg_lp_at_death` metric is deliberately untouched** — the `\b` word boundary protects it (the `_` before `lp` blocks the match), so sim-icd's JSON output is unchanged.
- Updated the field doc comment + the now-stale sim-tme-3d "misnamed/#314" comment; kept two intentional historical-name mentions so a grep of `lp_at_death` finds the rename.

## Verification
- Logic-neutral; the field is **internal** (never serialized to summary.json — verified no `lp_at_death` in any committed JSON). **Production matrix SHA `1cf88663…` unchanged**; golden kill-count tests pass.
- 280 ferroptosis-core + 57 sim-tme-3d tests pass; sim-tme/sim-spatial/sim-icd compile + test; `cargo fmt --all --check` clean.
- ferroptosis-python is unaffected (zero `lp_at_death` refs; the local PyO3 dylib-link quirk is environmental, CI builds it via maturin).

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)