### PR TITLE
ci(release): name released PDF manuscript.{date}.pdf + de-bias release/Zenodo title

### DIFF
--- a/.github/workflows/release-pdf.yml
+++ b/.github/workflows/release-pdf.yml
@@ -59,22 +59,26 @@ jobs:
       - name: Generate release tag
         id: tag
         run: |
+          DATE="$(date -u +%Y-%m-%d)"
           TAG="v$(date -u +%Y.%m.%d)-$(echo ${GITHUB_SHA} | cut -c1-7)"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+          echo "date=${DATE}" >> "$GITHUB_OUTPUT"
+
+      - name: Name the released PDF manuscript.{date}.pdf
+        run: cp article/drafts/v1.pdf "article/drafts/manuscript.${{ steps.tag.outputs.date }}.pdf"
 
       - name: Create Release
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
-          name: "Article PDF — ${{ steps.tag.outputs.date }}"
+          name: "Manuscript PDF — ${{ steps.tag.outputs.date }}"
           body: |
-            Compiled PDF of *Beyond Pharmacologic Ferroptosis Inducers: Physical ROS Modalities for Drug-Tolerant Persister Cells*.
+            Compiled PDF of *Cancer Therapy Mechanisms and Evidence: A Cross-Literature Synthesis* — an evidence-led consolidation of the cancer-therapy literature (4,830 full-text articles across 19 mechanisms and 22 cancer types) paired with multi-scale simulations that test specific mechanistic claims.
 
-            Built from commit ${{ github.sha }}.
+            Released as `manuscript.${{ steps.tag.outputs.date }}.pdf`, built from commit ${{ github.sha }}.
 
             **Changes in this release:**
             ${{ github.event.head_commit.message }}
-          files: article/drafts/v1.pdf
+          files: article/drafts/manuscript.${{ steps.tag.outputs.date }}.pdf
           draft: false
           prerelease: false

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,7 +1,7 @@
 {
-  "title": "Cancer Research: Cross-Literature Analysis and Ferroptosis Simulation",
+  "title": "Cancer Therapy Mechanisms and Evidence: A Cross-Literature Synthesis",
   "upload_type": "dataset",
-  "description": "Open-source cancer research combining cross-literature analysis of 4,830 research articles with Monte Carlo biochemical simulations of ferroptosis sensitivity. Content classes and rights: (1) Code — Python pipeline, Rust simulation engine, tests: MIT licensed. (2) Manuscript and analysis — authored by the depositor, released under the repo MIT license. (3) Corpus metadata — INDEX.jsonl contains bibliographic metadata (PMIDs, mechanisms, cancer types, evidence tiers); factual metadata is not copyrightable. (4) Corpus abstracts — 5,584 abstract-only records; abstracts are non-copyrightable factual summaries (Feist v. Rural, 1991). Excluded from this deposit: full-text corpus articles (61 of 4,830 have unconfirmed OA status), reference textbooks (Git LFS, CC BY 4.0 but 1.6 GB), and news articles (fair use, not a redistributable license). See PROVENANCE.yaml for full asset licensing details.",
+  "description": "Open-source cancer research consolidating the cancer-therapy literature into a single evidence-led synthesis: a cross-literature analysis of 4,830 full-text research articles across 19 therapeutic mechanisms and 22 cancer types (immunotherapy dominant), paired with multi-scale computational simulations used to validate or disprove specific mechanistic claims (ferroptosis biochemistry, immune coupling, stromal shielding, drug penetration, and tumor-microenvironment effects). Ferroptosis, photodynamic and sonodynamic therapy are among the mechanisms tested, not the focus. Content classes and rights: (1) Code — Python pipeline, Rust simulation engine, tests: MIT licensed. (2) Manuscript and analysis — authored by the depositor, released under the repo MIT license. (3) Corpus metadata — INDEX.jsonl contains bibliographic metadata (PMIDs, mechanisms, cancer types, evidence tiers); factual metadata is not copyrightable. (4) Corpus abstracts — 5,584 abstract-only records; abstracts are non-copyrightable factual summaries (Feist v. Rural, 1991). Excluded from this deposit: full-text corpus articles (61 of 4,830 have unconfirmed OA status), reference textbooks (Git LFS, CC BY 4.0 but 1.6 GB), and news articles (fair use, not a redistributable license). See PROVENANCE.yaml for full asset licensing details.",
   "creators": [
     {
       "name": "Lares, Ezequiel",
@@ -11,11 +11,13 @@
   "license_note": "Mixed-rights deposit. Select license at Zenodo upload time after reviewing: MIT for code (LICENSE), non-copyrightable for abstracts/metadata (Feist v. Rural), author-owned manuscript. See PROVENANCE.yaml.",
   "keywords": [
     "cancer research",
-    "ferroptosis",
-    "Monte Carlo simulation",
+    "cancer therapy",
     "cross-literature analysis",
-    "drug-tolerant persister cells",
+    "evidence synthesis",
+    "immunotherapy",
     "tumor microenvironment",
+    "computational simulation",
+    "ferroptosis",
     "sonodynamic therapy",
     "open science"
   ],


### PR DESCRIPTION
Closes #326.

## What & why
The release workflow uploaded the asset as `v1.pdf` and its release body still named a **stale, heavily PDT/SDT-biased title** ("Beyond Pharmacologic Ferroptosis Inducers: Physical ROS Modalities for Drug-Tolerant Persister Cells") that no longer matches the manuscript and is the first thing GitHub Releases / Zenodo surface.

## Changes
- **`release-pdf.yml`**: copies the compiled PDF to **`manuscript.{YYYY-MM-DD}.pdf`** (date from the existing release-tag step) and uploads that as the release asset; release renamed to "Manuscript PDF — {date}"; release body replaced with the neutral title **"Cancer Therapy Mechanisms and Evidence: A Cross-Literature Synthesis"** + a one-line consolidation summary. Working source `v1.pdf`/`v1.tex` left untouched (no churn across tests/docs — only the released artifact is renamed, per the issue).
- **`.zenodo.json`**: retitled to the neutral title; description reframed from "ferroptosis sensitivity" to an evidence-led consolidation across 19 mechanisms (immunotherapy dominant) in which ferroptosis/PDT/SDT are tested rather than the focus; keywords reordered (cancer therapy / cross-literature / evidence synthesis / immunotherapy lead).

## Verification
`.zenodo.json` validates as JSON; `release-pdf.yml` validates as YAML. The date-based naming uses the same `steps.tag.outputs.date` the tag already computes.

Part of the de-bias effort (#324 README/repo-docs, #325 manuscript) to make the repo read as a neutral consolidation rather than a PDT/SDT thesis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)