### PR TITLE
Community infrastructure: issue/PR templates + CONTRIBUTORS.md (closes #445)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,48 @@
+---
+name: Bug report
+about: Something in the scripts, simulations, pipeline, or build is broken or behaving wrong
+title: "[bug] "
+labels: bug
+assignees: ''
+---
+
+Thanks for helping make the project more reliable. The more of this you can fill
+in, the faster it gets fixed, but a partial report is far better than none.
+
+## What is wrong
+
+A clear description of the bug and what you expected to happen instead.
+
+## Where
+
+Which part of the repo is affected? For example:
+
+- a script (`scripts/...`)
+- a simulation binary or the `ferroptosis-core` library (`simulations/...`)
+- the corpus pipeline or an analysis output (`analysis/...`)
+- the manuscript build (`article/...`)
+- CI or the build
+
+## How to reproduce
+
+Steps, commands, or inputs that trigger it. A minimal example is ideal:
+
+```text
+# command(s) you ran
+```
+
+## What you saw
+
+The actual output, error message, or wrong result. Paste the full traceback if
+there is one.
+
+## Environment
+
+- OS:
+- Python version (`python3 --version`) if relevant:
+- Rust version (`rustc --version`) if relevant:
+- Commit or branch you are on (`git rev-parse --short HEAD`):
+
+## Anything else
+
+Screenshots, related issues, or a guess at the cause if you have one.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+# Issue template chooser configuration.
+# Blank issues stay enabled so a contributor is never forced into a template for
+# something that does not fit one.
+blank_issues_enabled: true
+contact_links:
+  - name: Read the contributor guide first
+    url: https://github.com/ELares/cancer_research/blob/main/CONTRIBUTING.md
+    about: Setup, testing, and how to open a pull request.
+  - name: Ask a question or share an idea (Discussions)
+    url: https://github.com/ELares/cancer_research/discussions
+    about: For open-ended questions, ideas, and conversations that are not yet a concrete issue. Maintainers can enable Discussions in repo settings to activate this link.

--- a/.github/ISSUE_TEMPLATE/corpus_contribution.md
+++ b/.github/ISSUE_TEMPLATE/corpus_contribution.md
@@ -1,0 +1,41 @@
+---
+name: Corpus or literature contribution
+about: Suggest a paper, dataset, or correction to the literature corpus and tagging
+title: "[corpus] "
+labels: subject:taxonomy-and-search
+assignees: ''
+---
+
+You do not need to write any code to contribute here. Pointing us at a paper we
+are missing, a mis-tagged record, or a dataset that would calibrate a model layer
+is one of the most valuable things you can do. The corpus is a frozen snapshot for
+reproducibility, so most additions land in the living-review layer or a future
+re-freeze rather than changing the published numbers, and that is fine.
+
+## What kind of contribution is this
+
+- [ ] A paper the corpus is missing (especially a landmark that would change a
+      field-level claim)
+- [ ] A mis-tagged or mis-classified record (wrong mechanism, evidence tier,
+      cancer type, or tissue)
+- [ ] A dataset that would calibrate a model layer (see
+      `simulations/calibration/CALIBRATION_STATUS.md` for what is data-gated)
+- [ ] A taxonomy or search-query suggestion
+- [ ] Something else
+
+## Details
+
+For a paper: the PMID, DOI, title, and one line on why it matters (what claim it
+supports, contradicts, or fills a gap in).
+
+For a mis-tagging: the PMID and what the tag should be instead, with a reason.
+
+For a dataset: what it measures, where it lives (a public URL if possible), its
+license, and which prediction or model layer it would test.
+
+## Honesty note
+
+If this contradicts something the repo currently claims, say so plainly. The
+project optimizes for being right for patients, not for defending its current
+framing, so a contribution that refutes a claim is as welcome as one that supports
+it.

--- a/.github/ISSUE_TEMPLATE/manuscript_correction.md
+++ b/.github/ISSUE_TEMPLATE/manuscript_correction.md
@@ -1,0 +1,37 @@
+---
+name: Manuscript correction
+about: Report an error, unclear passage, or missing caveat in the manuscript
+title: "[manuscript] "
+labels: subject:manuscript
+assignees: ''
+---
+
+Corrections to the manuscript are genuinely appreciated, from a typo to a wrong
+citation to an overstated claim. The manuscript drafts live in
+`article/drafts/v1.md` (the source) and `article/drafts/v1.tex` (the generated
+LaTeX). Pointing at the source is most useful.
+
+## What kind of correction
+
+- [ ] Factual error (a number, a mechanism, a result stated wrong)
+- [ ] Citation problem (wrong, missing, or unverifiable reference)
+- [ ] Overstated or under-caveated claim (the evidence does not support the
+      strength of the statement)
+- [ ] Unclear or confusing passage
+- [ ] Typo or formatting
+
+## Where
+
+The section or a short quote of the passage (for example "Section 7.1" or the
+sentence beginning "..."). A `v1.md` line number is ideal if you have it.
+
+## What is wrong and the suggested fix
+
+Describe the problem and, if you can, what it should say instead. For a citation,
+include the correct PMID or DOI.
+
+## Why it matters
+
+One line on the impact, especially if a claim is stronger than the evidence
+supports. The project would rather state uncertainty honestly than read cleanly,
+so flagging an overclaim is exactly the kind of correction we want.

--- a/.github/ISSUE_TEMPLATE/roadmap_update.md
+++ b/.github/ISSUE_TEMPLATE/roadmap_update.md
@@ -1,0 +1,32 @@
+---
+name: Roadmap update (maintainer)
+about: A periodic progress summary and a call for where help is most useful
+title: "[roadmap] YYYY-MM update"
+labels: roadmap
+assignees: ''
+---
+
+A short, regular pulse on where the project is and where contributors can plug in.
+Intended for maintainer use, roughly monthly, but anyone is welcome to draft one.
+
+## Since last update
+
+The notable things that landed (merged PRs, new analysis, calibration progress,
+manuscript changes). Link the PRs and issues.
+
+## Calibration honesty check
+
+What moved on the calibration ledger (`simulations/calibration/CALIBRATION_STATUS.md`)?
+Did any prediction get confirmed, refuted, or stay prior-predictive? State failures
+as plainly as successes.
+
+## Next priorities
+
+The two or three things that matter most right now, and why.
+
+## Where help is most useful
+
+Concrete, scoped asks a new contributor could pick up. Call out the `help wanted`
+issues (especially the data-gated wet-lab ones, #442 and #448) and any
+non-code contributions (literature, datasets, manuscript review) that would move
+the work forward.

--- a/.github/ISSUE_TEMPLATE/simulation_extension.md
+++ b/.github/ISSUE_TEMPLATE/simulation_extension.md
@@ -1,0 +1,43 @@
+---
+name: Simulation extension proposal
+about: Propose a new biology layer, parameter, or analysis for the ferroptosis simulation
+title: "[sim] "
+labels: subject:simulation, enhancement
+assignees: ''
+---
+
+Proposals to extend the model are welcome. Before writing one, it helps to know
+the project's two standing rules for simulation layers, because following them
+makes a proposal much easier to accept:
+
+1. **Off by default, byte-identical.** A new layer must default to an inert state
+   that leaves the production matrix output bit-for-bit unchanged (a regression
+   test guards the SHA of `sim-tme-3d`'s `summary.json`). New mechanisms are
+   opt-in.
+2. **Direction over magnitude, honestly labeled.** Most layers are uncalibrated
+   mechanistic scaffolding. The claim is the direction of an effect, not a fitted
+   number, and the uncalibrated status is stated in
+   `simulations/calibration/CALIBRATION_STATUS.md` and the module doc.
+
+## The mechanism
+
+What biology do you want to add or refine, and what is the expected direction of
+its effect on ferroptosis (more sensitive, more resistant, or context-dependent)?
+
+## Evidence
+
+The key reference(s), ideally with PMIDs. If the direction is contested in the
+literature, say so, and say which way the evidence leans.
+
+## How it would fit
+
+- Which module or part of the engine would it touch
+  (`simulations/ferroptosis-core/src/...`)?
+- What would the off-by-default identity case be?
+- Is there a falsifiable prediction it would generate?
+
+## What would calibrate it
+
+The measurement or dataset that would move it from uncalibrated to anchored. If
+that data does not exist publicly, that is worth noting too (it may become a
+`help wanted` collaborator call).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+<!--
+Thanks for contributing. This template is a guide, not a gate. Delete the parts
+that do not apply. A small, clear PR with a couple of these boxes ticked is very
+welcome.
+-->
+
+## What this changes
+
+A short description of the change and why.
+
+Closes #<!-- issue number, if this fully resolves one. Use "refs #N" for partial work. -->
+
+## Checklist
+
+- [ ] Tests pass locally (`python3 -m pytest tests/ -q` and, for Rust changes,
+      `cd simulations && cargo test --workspace`).
+- [ ] For Rust changes, `cargo fmt --all --check` is clean.
+
+### If this touches the simulation
+
+- [ ] The change is **off by default** and the production matrix stays
+      **byte-identical** (the `sim-tme-3d` `summary.json` SHA regression test still
+      passes). New mechanisms are opt-in.
+- [ ] Uncalibrated parameters are labeled as such (in the module doc and
+      `simulations/calibration/CALIBRATION_STATUS.md`); the claim is a direction,
+      not a fitted magnitude.
+
+### If this touches claims, the manuscript, or the corpus
+
+- [ ] Strong claims are traceable to the corpus, an analysis output, or a verified
+      external source, and any taxonomy artifact or corpus gap is flagged rather
+      than buried.
+- [ ] Citations are real and verifiable (PMID or DOI), not asserted from memory.
+- [ ] The frozen corpus (`corpus/INDEX.jsonl`) and the manuscript's quantitative
+      numbers are unchanged unless that is the explicit point of the PR.
+
+## Notes for reviewers
+
+Anything that needs context: a design tradeoff, a deferred follow-up, or a part
+you are unsure about. Honest uncertainty is welcome here.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,51 @@
+# Contributors
+
+This project exists because cancer takes people from their families, and the work
+is bigger than any one person. Every contribution helps, whether it is code, a
+literature pointer, a dataset, a manuscript correction, or a sharp question that
+changes how we think about a result. This page recognizes the people who help.
+
+If you have contributed and are not listed, or your tier is out of date, please
+open a pull request adding yourself, or mention it on any issue and a maintainer
+will add you. The list is hand-curated for now; it may move to an automated
+recognition bot later.
+
+## How recognition works
+
+Contribution is counted broadly. A merged pull request, a substantive issue that
+leads to a change, a corpus or dataset contribution, a manuscript correction, and
+a genuinely helpful discussion thread all count.
+
+| Tier | What it recognizes |
+|------|--------------------|
+| **Bronze** | At least one merged contribution (a PR, an actioned issue, a corpus or data contribution, or a substantive discussion that led to a change). |
+| **Silver** | Five or more contributions, or one that was clearly significant on its own. |
+| **Gold** | Ten or more contributions, or sustained expert collaboration over time. |
+
+### A note on authorship
+
+Acknowledgment in the manuscript and any preprints is offered to contributors, and
+sustained, substantial scientific contribution can merit co-authorship under
+standard authorship criteria (the kind of intellectual contribution to design,
+analysis, or interpretation that journals recognize). This is handled case by case
+and in conversation, not automatically by tier. The tiers above are about
+recognition and gratitude, not a promise of authorship.
+
+## Maintainers
+
+- **Ezequiel Lares** ([@ELares](https://github.com/ELares)), author and
+  maintainer.
+
+## Gold
+
+_Sustained expert collaborators. Be the first._
+
+## Silver
+
+_Five or more contributions, or one clearly significant one. Be the first._
+
+## Bronze
+
+_At least one merged contribution. Be the first. See
+[CONTRIBUTING.md](CONTRIBUTING.md) to get started, and the issue templates for the
+kind of contribution you have in mind._


### PR DESCRIPTION
## What

Lowers the friction for contributions (especially non-code: literature, datasets, manuscript review) and adds contributor recognition, serving the mission's goal of welcoming the wider community (guiding principle #5).

## Added

- **`.github/ISSUE_TEMPLATE/`** — the 4 requested templates: `bug_report`, `corpus_contribution`, `simulation_extension`, `manuscript_correction`. The simulation/corpus/manuscript templates encode the project's **actual conventions** (off-by-default byte-identical sim layers, direction-over-magnitude with uncalibrated labeling, frozen corpus, verifiable PMIDs/DOIs, honest caveats), so a proposal that follows them is easy to accept.
- **`config.yml`** — keeps blank issues enabled, links the contributor guide and (once enabled) Discussions.
- **`roadmap_update.md`** — the optional periodic maintainer roadmap template, with a calibration-honesty check and a where-help-is-useful section pointing at the `help wanted` wet-lab issues.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — a guide-not-gate checklist mirroring the same standards.
- **`CONTRIBUTORS.md`** — the bronze/silver/gold contribution ladder. Recognition is framed as acknowledgment; **co-authorship is explicitly handled case-by-case under standard criteria, not promised automatically by tier**.

## Remaining maintainer/settings steps (cannot be done from a PR, flagged in the files)

- Enable **GitHub Discussions** in repo settings (one click; the config.yml link activates once it is on).
- Optionally install an **All Contributors bot** to automate the recognition list.

## Validation

- Docs/infra only. YAML frontmatter validated (all templates render as choosable); **284 Python tests still pass**.
- Focused review: **clean** — coverage complete, GitHub-valid, no over-promised authorship, conventions accurate, no em/en dashes, valid links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)