### PR TITLE
docs: link CONTRIBUTORS.md / PREREGISTRATION.md / templates from README + CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,12 +37,16 @@ All tests must pass before submitting a PR.
 - **Rust**: Follow existing patterns. Use `cargo fmt` and `cargo clippy` before committing.
 - **Manuscript** (`article/drafts/v1.md`): Follow the conventions in `article/AUTHORING.md` — heading levels, citation formats, narrative inflation guardrails.
 
+## Opening an Issue
+
+Issue templates live in `.github/ISSUE_TEMPLATE/`: bug report, corpus or literature contribution, simulation extension proposal, and manuscript correction. They encode the project's conventions (for example, that new simulation layers stay off by default and byte-identical), so following the matching template makes a proposal easier to act on. Blank issues are still allowed for anything that does not fit a template.
+
 ## Submitting Changes
 
 1. **Fork and branch** from `main`
 2. **Make focused changes** — one issue per PR where possible
 3. **Run tests** (both Python and Rust)
-4. **Describe your changes** in the PR body — what changed, why, and what was tested
+4. **Describe your changes** in the PR body. The pull-request template (`.github/PULL_REQUEST_TEMPLATE.md`) has a checklist covering tests, the off-by-default byte-identical rule for simulation changes, and verifiable citations for claims
 5. **Link to the relevant issue** if one exists
 
 ## Dependency Management

--- a/README.md
+++ b/README.md
@@ -119,9 +119,12 @@ We'd rather publish a longer, clearer document that a graduate student can follo
 This project is most useful when it's questioned, expanded, and corrected. You don't need to be a cancer researcher—curiosity and a willingness to look at the evidence are enough.
 
 - Read [CONTRIBUTING.md](CONTRIBUTING.md) for setup, testing, and PR guidelines
-- Open an issue with a question, a counter-example, or a missing paper
+- Open an issue with a question, a counter-example, or a missing paper. Issue templates (bug, corpus/literature contribution, simulation extension, manuscript correction) are in [.github/ISSUE_TEMPLATE/](.github/ISSUE_TEMPLATE/)
 - Submit a pull request that improves the code, the corpus, or the manuscript
+- See [CONTRIBUTORS.md](CONTRIBUTORS.md) for how contributions are recognized
 - Fork the repo and go in a completely new direction—MIT license means you're free to do that
+
+The model's falsifiable predictions and the experiments that would confirm or refute them are registered in [PREREGISTRATION.md](PREREGISTRATION.md), so the predictions are locked in before the calibration work that tests them.
 
 We're not trying to steer everyone toward one answer. The goal is to build a shared space where good ideas can emerge.
 


### PR DESCRIPTION
## What

A docs-review sweep after the #440-#447 arc confirmed the core docs are **current** on main (ferroptosis-core 0.55.0, 29 modules, 11 binaries, 298 Python tests, the 10-chain / 240-article diagnostic-therapy layer all consistent), with **two real gaps**: the contributor-facing docs added in #440 (PREREGISTRATION.md) and #445 (CONTRIBUTORS.md + `.github` templates) were not linked from the entry-point docs.

## Changes

- **README "Contribute" section** now links the issue templates (`.github/ISSUE_TEMPLATE/`), `CONTRIBUTORS.md`, and `PREREGISTRATION.md`.
- **CONTRIBUTING.md** gains an "Opening an Issue" note pointing at the templates, and the submit-changes steps now reference the PR template's checklist.

## Not changed (verified current, false positives from the sweep)

- The CLAUDE.md figure counts (24 in-manuscript figures / 28 total tracked in FIGURES.yaml) are **both correct** and refer to different things, so left as-is.
- Module/binary/test/chain counts on main were already consistent (the sweep's "stale" hits were from an un-pulled local checkout, not origin/main).

## Validation

Docs-only; the `doc-test-count` and `manuscript-inventory` drift guards still pass. No em/en dashes in added prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)