### PR TITLE
[corpus]: fix duplicate processing in corpus duplicates

### DIFF
--- a/analysis/corpus-duplicate-audit.md
+++ b/analysis/corpus-duplicate-audit.md
@@ -37,10 +37,17 @@ Records sharing a near-identical title (a guard, not a remover — both records 
 
 ## Other same-title collisions (review individually)
 
+**Corrigendum: Establishment of tumor treating fields combined with mild hyperthermia as nov**
+
 | PMID | Journal | Year | OA status | Kind |
 |---|---|---|---|---|
 | 38487722 | Frontiers in oncology | 2024 | gold | published |
 | 35433483 | Frontiers in oncology | 2022 | gold | published |
+
+**Regarding: 'High-intensity-focused ultrasound in the treatment of primary prostate cancer:**
+
+| PMID | Journal | Year | OA status | Kind |
+|---|---|---|---|---|
 | 19997112 | British journal of cancer | 2009 | hybrid | published |
 | 19997110 | British journal of cancer | 2009 | hybrid | published |
 

--- a/scripts/detect_corpus_duplicates.py
+++ b/scripts/detect_corpus_duplicates.py
@@ -73,11 +73,14 @@ def main():
         lines += [fmt_row(r) for r in g]
         lines.append("")
     if other:
-        lines += ["## Other same-title collisions (review individually)", "",
-                  "| PMID | Journal | Year | OA status | Kind |", "|---|---|---|---|---|"]
+        lines += ["## Other same-title collisions (review individually)", ""]
         for g in sorted(other, key=lambda g: norm_title(g[0].get("title"))):
+            lines.append(f"**{(g[0].get('title') or '')[:90]}**")
+            lines.append("")
+            lines.append("| PMID | Journal | Year | OA status | Kind |")
+            lines.append("|---|---|---|---|---|")
             lines += [fmt_row(r) for r in g]
-        lines.append("")
+            lines.append("")
 
     REPORT.write_text("\n".join(lines) + "\n", encoding="utf-8")
     print(f"{len(preprint_twins)} preprint/published twin groups, {len(other)} other "

--- a/tests/test_detect_corpus_duplicates.py
+++ b/tests/test_detect_corpus_duplicates.py
@@ -1,0 +1,96 @@
+"""Guard the duplicate-corpus audit script (#535).
+
+These tests keep the detector lightweight: verify the title normalizer and the
+load-bearing report split between preprint/published twins and other same-title
+collisions.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SPEC = importlib.util.spec_from_file_location(
+    "detect_corpus_duplicates", REPO / "scripts" / "detect_corpus_duplicates.py"
+)
+dcd = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(dcd)
+
+
+def test_norm_title_lowercases_and_strips_non_alnum():
+    assert dcd.norm_title(" Ferroptosis: In Cancer?! ") == "ferroptosisincancer"
+    assert dcd.norm_title("") == ""
+    assert dcd.norm_title(None) == ""
+
+
+def test_main_writes_preprint_twin_and_other_collision_sections(tmp_path, monkeypatch, capsys):
+    index_path = tmp_path / "INDEX.jsonl"
+    report_path = tmp_path / "corpus-duplicate-audit.md"
+
+    records = [
+        {
+            "pmid": "1001",
+            "title": "Long shared ferroptosis title in pancreatic cancer",
+            "journal": "bioRxiv",
+            "year": 2024,
+            "oa_status": "green",
+        },
+        {
+            "pmid": "1002",
+            "title": "Long shared ferroptosis title in pancreatic cancer",
+            "journal": "Cancer Discovery",
+            "year": 2025,
+            "oa_status": "gold",
+        },
+        {
+            "pmid": "2001",
+            "title": "Independent same title collision in glioblastoma models",
+            "journal": "Journal A",
+            "year": 2021,
+            "oa_status": "bronze",
+        },
+        {
+            "pmid": "2002",
+            "title": "Independent same title collision in glioblastoma models",
+            "journal": "Journal B",
+            "year": 2022,
+            "oa_status": "hybrid",
+        },
+        {
+            "pmid": "3001",
+            "title": "short title",
+            "journal": "medRxiv",
+            "year": 2023,
+            "oa_status": "green",
+        },
+        {
+            "pmid": "3002",
+            "title": "short title",
+            "journal": "Nature",
+            "year": 2024,
+            "oa_status": "gold",
+        },
+    ]
+    index_path.write_text(
+        "\n".join(json.dumps(record) for record in records) + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(dcd, "INDEX", index_path)
+    monkeypatch.setattr(dcd, "REPORT", report_path)
+    monkeypatch.setattr(dcd, "REPO_ROOT", tmp_path)
+
+    dcd.main()
+
+    out = capsys.readouterr().out
+    report = report_path.read_text(encoding="utf-8")
+
+    assert "1 preprint/published twin groups, 1 other same-title groups." in out
+    assert "## Preprint/published twins" in report
+    assert "## Other same-title collisions (review individually)" in report
+    assert "| 1001 | bioRxiv | 2024 | green | preprint |" in report
+    assert "| 1002 | Cancer Discovery | 2025 | gold | published |" in report
+    assert "| 2001 | Journal A | 2021 | bronze | published |" in report
+    assert "| 2002 | Journal B | 2022 | hybrid | published |" in report
+    assert "short title" not in report
+


### PR DESCRIPTION
<!--
Thanks for contributing. This template is a guide, not a gate. Delete the parts
that do not apply. A small, clear PR with a couple of these boxes ticked is very
welcome.
-->

## What this changes

A short description of the change and why.

This pr should help viewers identify the differences between duplicate corpus texts. This mimics the twins branch.
This pr also adds a small test script to ensure detect corpus duplicate's new logic passes expectations.
Closes #573

## Checklist

- [X] Tests pass locally (`python3 -m pytest tests/ -q` and, for Rust changes,
      `cd simulations && cargo test --workspace`).


## Notes for reviewers

Anything that needs context: a design tradeoff, a deferred follow-up, or a part
you are unsure about. Honest uncertainty is welcome here.
